### PR TITLE
Include AbstUI SDL test project in SDL2 copy step

### DIFF
--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -32,6 +32,7 @@ PROJECTS=(
   "Demo/TetriGrounds/BlingoEngine.Demo.TetriGrounds.SDL2"
   "Test/BlingoEngine.SDL2.GfxVisualTest"
   "WillMoveToOwnRepo/AbstUI/Test/AbstUI.GfxVisualTest.SDL2"
+  "WillMoveToOwnRepo/AbstUI/Test/AbstUI.SDLTest"
   "src/Director/BlingoEngine.Director.Runner.SDL2"
   "Samples/SetupWays/BlingoEngineMinimalSDL"
   "Samples/SetupWays/BlingoEngineWithDirectorInDebugSDL"

--- a/setup-windows.bat
+++ b/setup-windows.bat
@@ -22,7 +22,7 @@ if /i "%ARCH%"=="AMD64" (
     set "LIB_DIR="
 )
 
-set PROJECTS="Demo\TetriGrounds\BlingoEngine.Demo.TetriGrounds.SDL2" "Test\BlingoEngine.SDL2.GfxVisualTest" "WillMoveToOwnRepo\AbstUI\Test\AbstUI.GfxVisualTest.SDL2" "src\Director\BlingoEngine.Director.Runner.SDL2" "Samples\SetupWays\BlingoEngineMinimalSDL" "Samples\SetupWays\BlingoEngineWithDirectorInDebugSDL"
+set PROJECTS="Demo\TetriGrounds\BlingoEngine.Demo.TetriGrounds.SDL2" "Test\BlingoEngine.SDL2.GfxVisualTest" "WillMoveToOwnRepo\AbstUI\Test\AbstUI.GfxVisualTest.SDL2" "WillMoveToOwnRepo\AbstUI\Test\AbstUI.SDLTest" "src\Director\BlingoEngine.Director.Runner.SDL2" "Samples\SetupWays\BlingoEngineMinimalSDL" "Samples\SetupWays\BlingoEngineWithDirectorInDebugSDL"
 set "MEDIA_SRC=%ROOT%Demo\TetriGrounds\BlingoEngine.Demo.TetriGrounds.Godot\Media"
 set "MEDIA_DEST=%ROOT%Demo\TetriGrounds\BlingoEngine.Demo.TetriGrounds.Blazor\Media"
 set "SAMPLE_ASSET_ICONS_REL=Samples\SetupWays\BlingoEngineWithDirectorInDebugSDL\Media\Icons"


### PR DESCRIPTION
## Summary
- ensure setup scripts copy SDL2 binaries for the AbstUI.SDLTest project so its tests can run

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cac1361f548332aea5729ee25ef8d1