### PR TITLE
Improve Godot version parsing in SetGodotVersion.ps1

### DIFF
--- a/scripts/SetGodotVersion.ps1
+++ b/scripts/SetGodotVersion.ps1
@@ -1,12 +1,89 @@
 param([string]$VersionTag)
+
+function Get-NormalizedVersionTag {
+    param([string]$Input)
+
+    if([string]::IsNullOrWhiteSpace($Input)){
+        return $null
+    }
+
+    $value = $Input.Trim()
+
+    if($value -match 'Godot_v([^_]+)_'){
+        $value = $Matches[1]
+    }
+
+    if($value -match '^v(.+)$'){
+        $value = $Matches[1]
+    }
+
+    return $value
+}
+
+function Get-NuGetVersionFromTag {
+    param([string]$Tag)
+
+    if([string]::IsNullOrWhiteSpace($Tag)){
+        throw "Godot version tag cannot be empty."
+    }
+
+    $parts = $Tag -split '-', 2
+    $basePart = $parts[0]
+    $preReleasePart = if($parts.Count -gt 1){ $parts[1] } else { $null }
+
+    $baseSegments = @($basePart -split '\.')
+    $normalizedBase = @()
+    foreach($segment in $baseSegments){
+        if($segment -eq ''){ continue }
+        $number = 0
+        if([int]::TryParse($segment, [ref]$number)){
+            $normalizedBase += $number.ToString()
+        }else{
+            $normalizedBase += $segment
+        }
+    }
+    while($normalizedBase.Count -lt 3){
+        $normalizedBase += '0'
+    }
+    if($normalizedBase.Count -gt 3){
+        $normalizedBase = $normalizedBase[0..2]
+    }
+    $baseVersion = [string]::Join('.', $normalizedBase)
+
+    $preReleaseVersion = $null
+    if($preReleasePart){
+        $segments = @()
+        foreach($segment in ($preReleasePart -split '\.')){
+            if($segment -eq ''){ continue }
+            $matches = [regex]::Matches($segment, '[A-Za-z]+|\d+')
+            foreach($match in $matches){
+                if($match.Value){
+                    $segments += $match.Value
+                }
+            }
+        }
+        if($segments.Count -gt 0){
+            $preReleaseVersion = [string]::Join('.', $segments)
+        }
+    }
+
+    if($preReleaseVersion){
+        return '{0}-{1}' -f $baseVersion, $preReleaseVersion
+    }
+
+    return $baseVersion
+}
+
 if(-not $VersionTag){
     $VersionTag = Read-Host 'Enter Godot version (e.g., 4.5-dev5)'
 }
-if($VersionTag -match '^(\d+\.\d+)-(.*)$'){
-    $NugetVersion = '{0}.0-{1}' -f $Matches[1], $Matches[2]
-}else{
-    $NugetVersion = $VersionTag
+
+$VersionTag = Get-NormalizedVersionTag $VersionTag
+if(-not $VersionTag){
+    throw 'Unable to determine Godot version from the provided input.'
 }
+
+$NugetVersion = Get-NuGetVersionFromTag $VersionTag
 # Update .csproj files
 $csprojs = Get-ChildItem -Recurse -Filter *.csproj | Where-Object { Select-String -Path $_.FullName -Pattern 'Godot.NET.Sdk' -Quiet }
 foreach($file in $csprojs){


### PR DESCRIPTION
## Summary
- normalize Godot version inputs by stripping file prefixes and leading `v`
- convert Godot version tags into NuGet compatible semantic versions, including pre-release segments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cacb5077348332bc7b64090a875092