### PR TITLE
Add font manager base class and runtime platform enum

### DIFF
--- a/Test/BlingoEngine.Tests/BlingoEngine.Tests.csproj
+++ b/Test/BlingoEngine.Tests/BlingoEngine.Tests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\BlingoEngine\BlingoEngine.csproj" />
     <ProjectReference Include="..\..\WillMoveToOwnRepo\AbstUI\Test\AbstUI.Tests.Common\AbstUI.Tests.Common.csproj" />
+    <ProjectReference Include="..\..\src\BlingoEngine.IO\BlingoEngine.IO.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/Test/BlingoEngine.Tests/FontMapperReaderTests.cs
+++ b/Test/BlingoEngine.Tests/FontMapperReaderTests.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using System.Linq;
+using AbstUI.Primitives;
+using BlingoEngine.IO;
+using FluentAssertions;
+
+namespace BlingoEngine.Tests;
+
+public class FontMapperReaderTests
+{
+    private static string GetProjectRoot()
+    {
+        var baseDir = AppContext.BaseDirectory;
+        var root = Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "..", ".."));
+        return root;
+    }
+
+    [Fact]
+    public void ReadFromFile_ParsesFontAndKeyMappings()
+    {
+        var root = GetProjectRoot();
+        var path = Path.Combine(root, "WillMoveToOwnRepo", "ProjectorRays", "src", "ProjectorRays.DotNet", "fontmaps", "fontmap_D6.txt");
+        File.Exists(path).Should().BeTrue($"Expected font map file at {path}");
+
+        var document = FontMapperReader.ReadFromFile(path);
+
+        document.FontMappings.Should().NotBeEmpty();
+        document.InputKeyMappings.Should().NotBeEmpty();
+
+        var macTimes = document.FontMappings.FirstOrDefault(m =>
+            m.SourcePlatform == ARuntimePlatform.Mac && m.SourceFontName == "Times" && m.TargetPlatform == ARuntimePlatform.Win);
+        macTimes.Should().NotBeNull();
+        macTimes!.TargetFontName.Should().Be("Times New Roman");
+        macTimes.MapCharacters.Should().BeTrue();
+        macTimes.SizeMappings.Should().ContainKey(14);
+        macTimes.SizeMappings[14].Should().Be(12);
+
+        var macSymbol = document.FontMappings.FirstOrDefault(m =>
+            m.SourcePlatform == ARuntimePlatform.Mac && m.SourceFontName == "Symbol");
+        macSymbol.Should().NotBeNull();
+        macSymbol!.MapCharacters.Should().BeFalse();
+
+        var macToWin = document.InputKeyMappings.FirstOrDefault(m =>
+            m.SourcePlatform == ARuntimePlatform.Mac && m.TargetPlatform == ARuntimePlatform.Win);
+        macToWin.Should().NotBeNull();
+        macToWin!.Keys.Should().ContainKey(128);
+        macToWin.Keys[128].Should().Be(196);
+    }
+
+    [Theory]
+    [InlineData(600, "fontmap_D6.txt")]
+    [InlineData(750, "fontmap_D7.txt")]
+    [InlineData(850, "fontmap_D8_5.txt")]
+    [InlineData(900, "fontmap_D9.txt")]
+    [InlineData(1000, "fontmap_D10.txt")]
+    [InlineData(1100, "fontmap_D11.txt")]
+    [InlineData(1150, "fontmap_D11_5.txt")]
+    public void GetFontMapFileName_ResolvesExpectedFile(int version, string expected)
+    {
+        FontMapperReader.GetFontMapFileName(version).Should().Be(expected);
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests.Common/TestFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests.Common/TestFontManager.cs
@@ -2,7 +2,7 @@ using AbstUI.Styles;
 
 namespace AbstUI.Tests.Common;
 
-public class TestFontManager : IAbstFontManager
+public class TestFontManager : AbstFontManagerBase
 {
     private readonly int _topIndent;
     private readonly Dictionary<string, int> _topIndents;
@@ -15,14 +15,14 @@ public class TestFontManager : IAbstFontManager
         _extraHeights = extraHeights ?? new();
     }
 
-    public IAbstFontManager AddFont(string name, string pathAndName, AbstFontStyle style = AbstFontStyle.Regular) => this;
-    public void LoadAll() { }
-    public T? Get<T>(string name, AbstFontStyle style = AbstFontStyle.Regular) where T : class => null;
-    public T GetDefaultFont<T>() where T : class => null!;
-    public void SetDefaultFont<T>(T font) where T : class { }
-    public IEnumerable<string> GetAllNames() => Array.Empty<string>();
-    public float MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular) => text.Length * fontSize;
-    public FontInfo GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
+    public override IAbstFontManager AddFont(string name, string pathAndName, AbstFontStyle style = AbstFontStyle.Regular) => this;
+    public override void LoadAll() { }
+    public override T? Get<T>(string name, AbstFontStyle style = AbstFontStyle.Regular) where T : class => null;
+    public override T GetDefaultFont<T>() where T : class => null!;
+    public override void SetDefaultFont<T>(T font) where T : class { }
+    public override IEnumerable<string> GetAllNames() => Array.Empty<string>();
+    public override float MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular) => text.Length * fontSize;
+    public override FontInfo GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
     {
         int ascent = _topIndents.TryGetValue(fontName, out var ti) ? ti : _topIndent;
         int extra = _extraHeights.TryGetValue(fontName, out var h) ? h : 0;

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Styles/AbstBlazorFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.Blazor/Styles/AbstBlazorFontManager.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace AbstUI.Blazor.Styles;
 
-public class AbstBlazorFontManager : IAbstFontManager
+public class AbstBlazorFontManager : AbstFontManagerBase
 {
     private readonly List<(string Name, AbstFontStyle Style, string File)> _fontsToLoad = new();
     private readonly Dictionary<(string Name, AbstFontStyle Style), string> _loadedFonts = new();
@@ -13,13 +13,13 @@ public class AbstBlazorFontManager : IAbstFontManager
 
     public event Action? FontsChanged;
 
-    public IAbstFontManager AddFont(string name, string pathAndName, AbstFontStyle style = AbstFontStyle.Regular)
+    public override IAbstFontManager AddFont(string name, string pathAndName, AbstFontStyle style = AbstFontStyle.Regular)
     {
         _fontsToLoad.Add((name, style, pathAndName));
         return this;
     }
 
-    public void LoadAll()
+    public override void LoadAll()
     {
         foreach (var font in _fontsToLoad)
             _loadedFonts[(font.Name, font.Style)] = font.File;
@@ -27,7 +27,7 @@ public class AbstBlazorFontManager : IAbstFontManager
         FontsChanged?.Invoke();
     }
 
-    public T? Get<T>(string name, AbstFontStyle style = AbstFontStyle.Regular) where T : class
+    public override T? Get<T>(string name, AbstFontStyle style = AbstFontStyle.Regular) where T : class
     {
         if (string.IsNullOrEmpty(name))
             return _defaultFont as T;
@@ -38,23 +38,24 @@ public class AbstBlazorFontManager : IAbstFontManager
         return _defaultFont as T;
     }
 
-    public T GetDefaultFont<T>() where T : class
+    public override T GetDefaultFont<T>() where T : class
         => (_defaultFont as T)!;
 
-    public void SetDefaultFont<T>(T font) where T : class
+    public override void SetDefaultFont<T>(T font) where T : class
         => _defaultFont = font?.ToString() ?? string.Empty;
 
-    public IEnumerable<string> GetAllNames() => _loadedFonts.Keys.Select(k => k.Name).Distinct();
+    public override IEnumerable<string> GetAllNames() => _loadedFonts.Keys.Select(k => k.Name).Distinct();
 
-    public float MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
+    public override float MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
     {
         _ = Get<string>(fontName, style);
         return text.Length * fontSize * 0.6f;
     }
 
-    public FontInfo GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
+    public override FontInfo GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
     {
         _ = Get<string>(fontName, style);
         return new(fontSize, fontSize);
     }
+
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Styles/AbstGodotFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LGodot/Styles/AbstGodotFontManager.cs
@@ -6,7 +6,7 @@ using Godot;
 
 namespace AbstUI.LGodot.Styles
 {
-    public class AbstGodotFontManager : IAbstFontManager
+    public class AbstGodotFontManager : AbstFontManagerBase
     {
         public static bool IsRunningInTest { get; set; }
         private readonly Dictionary<(string FontName, int Size), Dictionary<long, Image>> _atlasCache = new();
@@ -21,7 +21,7 @@ namespace AbstUI.LGodot.Styles
 
         }
 
-        public IAbstFontManager AddFont(string name, string pathAndName, AbstFontStyle style = AbstFontStyle.Regular)
+        public override IAbstFontManager AddFont(string name, string pathAndName, AbstFontStyle style = AbstFontStyle.Regular)
         {
             if (_fontsToLoad.Contains((name, style, pathAndName)))
                 _fontsToLoad.Remove((name, style, pathAndName));
@@ -35,7 +35,7 @@ namespace AbstUI.LGodot.Styles
             }
             return this;
         }
-        public void LoadAll()
+        public override void LoadAll()
         {
             foreach (var fontTriple in _fontsToLoad)
             {
@@ -55,7 +55,7 @@ namespace AbstUI.LGodot.Styles
             }
             _fontsToLoad.Clear();
         }
-        public T? Get<T>(string name, AbstFontStyle style = AbstFontStyle.Regular) where T : class
+        public override T? Get<T>(string name, AbstFontStyle style = AbstFontStyle.Regular) where T : class
         {
             if (string.IsNullOrEmpty(name))
                 return _defaultStyle as T;
@@ -83,12 +83,12 @@ namespace AbstUI.LGodot.Styles
             return (FontFile)_defaultStyle;
         }
 
-        public T GetDefaultFont<T>() where T : class => (_defaultStyle as T)!;
-        public void SetDefaultFont<T>(T font) where T : class => _defaultStyle = (font as Font)!;
+        public override T GetDefaultFont<T>() where T : class => (_defaultStyle as T)!;
+        public override void SetDefaultFont<T>(T font) where T : class => _defaultStyle = (font as Font)!;
 
-        public IEnumerable<string> GetAllNames() => _loadedFonts.Keys.Select(k => k.Name).Distinct();
+        public override IEnumerable<string> GetAllNames() => _loadedFonts.Keys.Select(k => k.Name).Distinct();
 
-        public float MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
+        public override float MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
         {
             var font = string.IsNullOrEmpty(fontName)
                 ? _defaultStyle
@@ -97,7 +97,7 @@ namespace AbstUI.LGodot.Styles
             return font.GetStringSize(text, HorizontalAlignment.Left, -1, fontSize).X;
         }
 
-        public FontInfo GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
+        public override FontInfo GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
         {
             var font = string.IsNullOrEmpty(fontName)
                 ? _defaultStyle
@@ -117,6 +117,7 @@ namespace AbstUI.LGodot.Styles
             }
             return atlasCache;
         }
+
     }
 }
 

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Styles/UnityFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Styles/UnityFontManager.cs
@@ -8,18 +8,18 @@ namespace AbstUI.LUnity.Styles;
 /// <summary>
 /// Basic font manager that loads Unity <see cref="Font"/> assets and exposes them to the engine.
 /// </summary>
-internal class UnityFontManager : IAbstFontManager
+internal class UnityFontManager : AbstFontManagerBase
 {
     private readonly List<(string Name, AbstFontStyle Style, string FileName)> _fontsToLoad = new();
     private readonly Dictionary<(string Name, AbstFontStyle Style), Font> _loadedFonts = new();
 
-    public IAbstFontManager AddFont(string name, string pathAndName, AbstFontStyle style = AbstFontStyle.Regular)
+    public override IAbstFontManager AddFont(string name, string pathAndName, AbstFontStyle style = AbstFontStyle.Regular)
     {
         _fontsToLoad.Add((name, style, pathAndName));
         return this;
     }
 
-    public void LoadAll()
+    public override void LoadAll()
     {
         foreach (var font in _fontsToLoad)
         {
@@ -31,7 +31,7 @@ internal class UnityFontManager : IAbstFontManager
         _fontsToLoad.Clear();
     }
 
-    public T? Get<T>(string name, AbstFontStyle style = AbstFontStyle.Regular) where T : class
+    public override T? Get<T>(string name, AbstFontStyle style = AbstFontStyle.Regular) where T : class
     {
         if (string.IsNullOrEmpty(name))
             return _defaultFont as T;
@@ -55,13 +55,13 @@ internal class UnityFontManager : IAbstFontManager
 
     private Font _defaultFont = UnityEngine.Resources.GetBuiltinResource<Font>("Tahoma.ttf");
 
-    public T GetDefaultFont<T>() where T : class => (_defaultFont as T)!;
+    public override T GetDefaultFont<T>() where T : class => (_defaultFont as T)!;
 
-    public void SetDefaultFont<T>(T font) where T : class => _defaultFont = (font as Font)!;
+    public override void SetDefaultFont<T>(T font) where T : class => _defaultFont = (font as Font)!;
 
-    public IEnumerable<string> GetAllNames() => _loadedFonts.Keys.Select(k => k.Name).Distinct();
+    public override IEnumerable<string> GetAllNames() => _loadedFonts.Keys.Select(k => k.Name).Distinct();
 
-    public float MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
+    public override float MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
     {
         var font = string.IsNullOrEmpty(fontName) ? _defaultFont :
             (_loadedFonts.TryGetValue((fontName, style), out var f) ? f :
@@ -79,7 +79,7 @@ internal class UnityFontManager : IAbstFontManager
         return width;
     }
 
-    public FontInfo GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
+    public override FontInfo GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
     {
         var font = string.IsNullOrEmpty(fontName) ? _defaultFont :
             (_loadedFonts.TryGetValue((fontName, style), out var f) ? f :
@@ -93,4 +93,5 @@ internal class UnityFontManager : IAbstFontManager
         int top = Mathf.CeilToInt(info.maxY);
         return new FontInfo(height, top);
     }
+
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Styles/SdlFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Styles/SdlFontManager.cs
@@ -15,12 +15,12 @@ public interface IAbstSdlFont
 {
     ISdlFontLoadedByUser? Get(object fontUser, int fontSize);
 }
-public class SdlFontManager : IAbstFontManager
+public class SdlFontManager : AbstFontManagerBase
 {
     public const string DefaultFontName = "default";
     private readonly List<(string Name, AbstFontStyle Style, string FileName)> _fontsToLoad = new();
     private readonly Dictionary<(string Name, AbstFontStyle Style), AbstSdlFont> _loadedFonts = new();
-    public IAbstFontManager AddFont(string name, string pathAndName, AbstFontStyle style = AbstFontStyle.Regular)
+    public override IAbstFontManager AddFont(string name, string pathAndName, AbstFontStyle style = AbstFontStyle.Regular)
     {
         if (_fontsToLoad.Contains((name, style, pathAndName)))
             _fontsToLoad.Remove((name, style, pathAndName));
@@ -34,7 +34,7 @@ public class SdlFontManager : IAbstFontManager
         }
         return this;
     }
-    public void LoadAll()
+    public override void LoadAll()
     {
         if (_loadedFonts.Count == 0)
         {
@@ -63,7 +63,7 @@ public class SdlFontManager : IAbstFontManager
     }
 
    
-    public T? Get<T>(string name, AbstFontStyle style = AbstFontStyle.Regular) where T : class
+    public override T? Get<T>(string name, AbstFontStyle style = AbstFontStyle.Regular) where T : class
     {
         if (string.IsNullOrEmpty(name)) return null;
         var nameLower = name.ToLower();
@@ -85,19 +85,19 @@ public class SdlFontManager : IAbstFontManager
         return _loadedFonts[(DefaultFontName, style)].Get(fontUser, fontSize);
     }
 
-    public T GetDefaultFont<T>() where T : class
+    public override T GetDefaultFont<T>() where T : class
         => _loadedFonts.TryGetValue((DefaultFontName, AbstFontStyle.Regular), out var f) ? (f as T)! : throw new KeyNotFoundException("Default font not found");
 
-    public void SetDefaultFont<T>(T font) where T : class
+    public override void SetDefaultFont<T>(T font) where T : class
     {
         if (font is not IAbstSdlFont sdlFont)
             throw new ArgumentException("Font must be of type IAbstSdlFont", nameof(font));
         _loadedFonts[(DefaultFontName, AbstFontStyle.Regular)] = (AbstSdlFont)sdlFont;
     }
 
-    public IEnumerable<string> GetAllNames() => _loadedFonts.Keys.Select(k => k.Name).Distinct();
+    public override IEnumerable<string> GetAllNames() => _loadedFonts.Keys.Select(k => k.Name).Distinct();
 
-    public float MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
+    public override float MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
     {
         var user = new object();
         var font = GetTyped(user, string.IsNullOrEmpty(fontName) ? null : fontName, fontSize, style);
@@ -106,7 +106,7 @@ public class SdlFontManager : IAbstFontManager
         return w;
     }
 
-    public FontInfo GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
+    public override FontInfo GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular)
     {
         var user = new object();
         var font = GetTyped(user, string.IsNullOrEmpty(fontName) ? null : fontName, fontSize, style);
@@ -123,7 +123,6 @@ public class SdlFontManager : IAbstFontManager
     }
 
     public object? GetFont(int size) => null;
-
 
     private class AbstSdlFont : IAbstSdlFont
     {

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Primitives/ARuntimePlatform.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Primitives/ARuntimePlatform.cs
@@ -1,0 +1,13 @@
+namespace AbstUI.Primitives;
+
+/// <summary>
+/// Identifies the target runtime platform for AbstUI assets.
+/// </summary>
+public enum ARuntimePlatform
+{
+    /// <summary>Apple Macintosh runtime.</summary>
+    Mac,
+
+    /// <summary>Microsoft Windows runtime.</summary>
+    Win,
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/AbstFontManagerBase.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/AbstFontManagerBase.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Base implementation of <see cref="IAbstFontManager"/> that manages font and input key mappings.
+/// </summary>
+public abstract class AbstFontManagerBase : IAbstFontManager
+{
+    private readonly List<AbstFontMap> _fontMappings = new();
+    private readonly List<AbstInputKeyMap> _inputKeyMappings = new();
+
+    public abstract IAbstFontManager AddFont(string name, string pathAndName, AbstFontStyle style = AbstFontStyle.Regular);
+
+    public abstract void LoadAll();
+
+    public abstract T? Get<T>(string name, AbstFontStyle style = AbstFontStyle.Regular) where T : class;
+
+    public abstract T GetDefaultFont<T>() where T : class;
+
+    public abstract void SetDefaultFont<T>(T font) where T : class;
+
+    public abstract IEnumerable<string> GetAllNames();
+
+    public abstract float MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular);
+
+    public abstract FontInfo GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular);
+
+    public virtual void LoadFontMap(IEnumerable<AbstFontMap> fontMappings, IEnumerable<AbstInputKeyMap> inputKeyMappings)
+    {
+        _fontMappings.Clear();
+        _inputKeyMappings.Clear();
+
+        if (fontMappings != null)
+        {
+            foreach (var mapping in fontMappings)
+                _fontMappings.Add(mapping);
+        }
+
+        if (inputKeyMappings != null)
+        {
+            foreach (var mapping in inputKeyMappings)
+                _inputKeyMappings.Add(mapping);
+        }
+    }
+
+    public IReadOnlyList<AbstFontMap> FontMappings => _fontMappings;
+
+    public IReadOnlyList<AbstInputKeyMap> InputKeyMappings => _inputKeyMappings;
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/AbstFontMap.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/AbstFontMap.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using AbstUI.Primitives;
+
+namespace AbstUI.Styles;
+
+/// <summary>
+/// Represents a mapping between two platform font names as defined by Director font map files.
+/// </summary>
+public sealed record class AbstFontMap
+{
+    public AbstFontMap(
+        ARuntimePlatform sourcePlatform,
+        string sourceFontName,
+        ARuntimePlatform targetPlatform,
+        string targetFontName,
+        bool mapCharacters,
+        IReadOnlyDictionary<int, int>? sizeMappings = null)
+    {
+        SourcePlatform = sourcePlatform;
+        SourceFontName = sourceFontName;
+        TargetPlatform = targetPlatform;
+        TargetFontName = targetFontName;
+        MapCharacters = mapCharacters;
+        SizeMappings = sizeMappings != null
+            ? new Dictionary<int, int>(sizeMappings)
+            : new Dictionary<int, int>();
+    }
+
+    /// <summary>Origin platform (e.g., "Mac" or "Win").</summary>
+    public ARuntimePlatform SourcePlatform { get; }
+
+    /// <summary>Font name declared for the origin platform.</summary>
+    public string SourceFontName { get; }
+
+    /// <summary>Destination platform (e.g., "Win" or "Mac").</summary>
+    public ARuntimePlatform TargetPlatform { get; }
+
+    /// <summary>Font name used on the destination platform.</summary>
+    public string TargetFontName { get; }
+
+    /// <summary>Whether characters should be remapped when this font is applied.</summary>
+    public bool MapCharacters { get; }
+
+    /// <summary>
+    /// Optional point-size remappings (e.g., 14 => 12) that apply to this font pairing.
+    /// </summary>
+    public IReadOnlyDictionary<int, int> SizeMappings { get; }
+}
+
+/// <summary>
+/// Represents a character-code translation between two platforms.
+/// </summary>
+public sealed record class AbstInputKeyMap
+{
+    public AbstInputKeyMap(
+        ARuntimePlatform sourcePlatform,
+        ARuntimePlatform targetPlatform,
+        IReadOnlyDictionary<int, int>? keys = null)
+    {
+        SourcePlatform = sourcePlatform;
+        TargetPlatform = targetPlatform;
+        Keys = keys != null
+            ? new Dictionary<int, int>(keys)
+            : new Dictionary<int, int>();
+    }
+
+    /// <summary>Origin platform (e.g., "Mac" or "Win").</summary>
+    public ARuntimePlatform SourcePlatform { get; }
+
+    /// <summary>Destination platform (e.g., "Win" or "Mac").</summary>
+    public ARuntimePlatform TargetPlatform { get; }
+
+    /// <summary>Character-code mappings keyed by the origin code.</summary>
+    public IReadOnlyDictionary<int, int> Keys { get; }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/IAbstFontManager.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Styles/IAbstFontManager.cs
@@ -1,4 +1,6 @@
-﻿namespace AbstUI.Styles
+using System.Collections.Generic;
+
+namespace AbstUI.Styles
 {
     public interface IAbstFontManager
     {
@@ -11,6 +13,17 @@
 
         float MeasureTextWidth(string text, string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular);
         FontInfo GetFontInfo(string fontName, int fontSize, AbstFontStyle style = AbstFontStyle.Regular);
+
+        /// <summary>
+        /// Replaces the current set of font and character mappings with the provided data.
+        /// </summary>
+        void LoadFontMap(IEnumerable<AbstFontMap> fontMappings, IEnumerable<AbstInputKeyMap> inputKeyMappings);
+
+        /// <summary>Font mappings parsed from Director font map definitions.</summary>
+        IReadOnlyList<AbstFontMap> FontMappings { get; }
+
+        /// <summary>Character translation tables parsed from Director font map definitions.</summary>
+        IReadOnlyList<AbstInputKeyMap> InputKeyMappings { get; }
     }
 
     public readonly record struct FontInfo(int FontHeight, int TopIndentation);

--- a/src/BlingoEngine.IO/FontMapperReader.cs
+++ b/src/BlingoEngine.IO/FontMapperReader.cs
@@ -1,0 +1,319 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Collections.Generic;
+using AbstUI.Primitives;
+using AbstUI.Styles;
+
+namespace BlingoEngine.IO;
+
+/// <summary>
+/// Reads Director font map definitions and exposes the parsed mappings for consumers.
+/// </summary>
+public static class FontMapperReader
+{
+    public static FontMapDocument ReadFromFile(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("Path cannot be null or empty", nameof(path));
+        using var stream = File.OpenRead(path);
+        return Read(stream);
+    }
+
+    public static FontMapDocument Read(Stream stream)
+    {
+        if (stream == null)
+            throw new ArgumentNullException(nameof(stream));
+        using var reader = new StreamReader(stream, detectEncodingFromByteOrderMarks: true);
+        return Read(reader);
+    }
+
+    public static FontMapDocument Read(TextReader reader)
+    {
+        if (reader == null)
+            throw new ArgumentNullException(nameof(reader));
+
+        var fontMappings = new List<AbstFontMap>();
+        var keyMappings = new Dictionary<(ARuntimePlatform Source, ARuntimePlatform Target), Dictionary<int, int>>();
+        bool inFontMappings = false;
+        bool inCharacterMappings = false;
+
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            var trimmed = line.Trim();
+            if (trimmed.StartsWith(";", StringComparison.Ordinal))
+            {
+                var header = trimmed[1..].Trim();
+                if (header.Equals("FONT MAPPINGS", StringComparison.OrdinalIgnoreCase))
+                {
+                    inFontMappings = true;
+                    inCharacterMappings = false;
+                }
+                else if (header.Equals("CHARACTER MAPPINGS", StringComparison.OrdinalIgnoreCase))
+                {
+                    inFontMappings = false;
+                    inCharacterMappings = true;
+                }
+                continue;
+            }
+
+            if (inFontMappings)
+            {
+                if (TryParseFontMapping(trimmed, out var mapping))
+                    fontMappings.Add(mapping);
+                continue;
+            }
+
+            if (inCharacterMappings)
+            {
+                TryParseCharacterMapping(trimmed, keyMappings);
+            }
+        }
+
+        var inputMaps = new List<AbstInputKeyMap>(keyMappings.Count);
+        foreach (var kvp in keyMappings)
+        {
+            inputMaps.Add(new AbstInputKeyMap(kvp.Key.Source, kvp.Key.Target, kvp.Value));
+        }
+
+        return new FontMapDocument(fontMappings, inputMaps);
+    }
+
+    public static FontMapDocument ReadFromDirectory(string directory, int version)
+    {
+        if (directory == null)
+            throw new ArgumentNullException(nameof(directory));
+        var fileName = GetFontMapFileName(version);
+        var path = Path.Combine(directory, fileName);
+        if (!File.Exists(path))
+            return FontMapDocument.Empty;
+        return ReadFromFile(path);
+    }
+
+    public static FontMapDocument ReadFromApplicationDirectory(int version)
+    {
+        var baseDir = Path.Combine(AppContext.BaseDirectory, "fontmaps");
+        return ReadFromDirectory(baseDir, version);
+    }
+
+    public static string GetFontMapFileName(int version) => version switch
+    {
+        >= 1150 => "fontmap_D11_5.txt",
+        >= 1100 => "fontmap_D11.txt",
+        >= 1000 => "fontmap_D10.txt",
+        >= 900 => "fontmap_D9.txt",
+        >= 850 => "fontmap_D8_5.txt",
+        >= 800 => "fontmap_D8.txt",
+        >= 700 => "fontmap_D7.txt",
+        _ => "fontmap_D6.txt",
+    };
+
+    private static bool TryParseFontMapping(string line, out AbstFontMap map)
+    {
+        map = null!;
+        int arrowIndex = line.IndexOf("=>", StringComparison.Ordinal);
+        if (arrowIndex < 0)
+            return false;
+
+        var left = line[..arrowIndex];
+        var right = line[(arrowIndex + 2)..];
+
+        if (!TryParseEndpoint(left, out var sourcePlatform, out var sourceFont, out _))
+            return false;
+        if (!TryParseEndpoint(right, out var targetPlatform, out var targetFont, out var remainder))
+            return false;
+
+        bool mapCharacters = true;
+        var sizeMappings = new Dictionary<int, int>();
+        var rest = remainder.TrimStart();
+        while (!string.IsNullOrWhiteSpace(rest))
+        {
+            rest = rest.TrimStart();
+            if (rest.Length == 0)
+                break;
+
+            if (rest.StartsWith("Map", StringComparison.OrdinalIgnoreCase))
+            {
+                rest = rest[3..].TrimStart();
+                if (rest.StartsWith("None", StringComparison.OrdinalIgnoreCase))
+                {
+                    mapCharacters = false;
+                    rest = rest.Length > 4 ? rest[4..] : string.Empty;
+                }
+                continue;
+            }
+
+            int splitIndex = 0;
+            while (splitIndex < rest.Length && !char.IsWhiteSpace(rest[splitIndex]))
+                splitIndex++;
+            var token = splitIndex > 0 ? rest[..splitIndex] : rest;
+            rest = splitIndex < rest.Length ? rest[splitIndex..] : string.Empty;
+            token = token.Trim();
+            if (token.Length == 0)
+                continue;
+            var arrow = token.IndexOf("=>", StringComparison.Ordinal);
+            if (arrow < 0)
+                continue;
+            var fromPart = token[..arrow].Trim();
+            var toPart = token[(arrow + 2)..].Trim();
+            if (int.TryParse(fromPart, NumberStyles.Integer, CultureInfo.InvariantCulture, out var fromSize)
+                && int.TryParse(toPart, NumberStyles.Integer, CultureInfo.InvariantCulture, out var toSize))
+            {
+                sizeMappings[fromSize] = toSize;
+            }
+        }
+
+        map = new AbstFontMap(sourcePlatform, sourceFont, targetPlatform, targetFont, mapCharacters, sizeMappings);
+        return true;
+    }
+
+    private static void TryParseCharacterMapping(
+        string line,
+        Dictionary<(ARuntimePlatform Source, ARuntimePlatform Target), Dictionary<int, int>> accumulator)
+    {
+        int arrowIndex = line.IndexOf("=>", StringComparison.Ordinal);
+        if (arrowIndex < 0)
+            return;
+
+        var left = line[..arrowIndex];
+        var right = line[(arrowIndex + 2)..];
+        if (!TryParsePlatformName(left, out var sourcePlatform))
+            return;
+        if (!TryParsePlatformAndRemainder(right, out var targetPlatform, out var remainder))
+            return;
+        remainder = remainder.Trim();
+        if (remainder.Length == 0)
+            return;
+
+        if (!accumulator.TryGetValue((sourcePlatform, targetPlatform), out var map))
+        {
+            map = new Dictionary<int, int>();
+            accumulator[(sourcePlatform, targetPlatform)] = map;
+        }
+
+        var tokens = remainder.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        foreach (var token in tokens)
+        {
+            var arrow = token.IndexOf("=>", StringComparison.Ordinal);
+            if (arrow < 0)
+                continue;
+            var fromPart = token[..arrow].Trim();
+            var toPart = token[(arrow + 2)..].Trim();
+            if (int.TryParse(fromPart, NumberStyles.Integer, CultureInfo.InvariantCulture, out var from)
+                && int.TryParse(toPart, NumberStyles.Integer, CultureInfo.InvariantCulture, out var to))
+            {
+                map[from] = to;
+            }
+        }
+    }
+
+    private static bool TryParseEndpoint(string text, out ARuntimePlatform platform, out string fontName, out string remainder)
+    {
+        platform = default;
+        fontName = string.Empty;
+        remainder = string.Empty;
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        text = text.Trim();
+        int colonIndex = text.IndexOf(':');
+        if (colonIndex < 0)
+            return false;
+
+        var platformToken = text[..colonIndex].Trim();
+        if (!TryGetPlatform(platformToken, out platform))
+            return false;
+
+        var afterColon = text[(colonIndex + 1)..].TrimStart();
+        if (afterColon.Length == 0)
+        {
+            fontName = string.Empty;
+            remainder = string.Empty;
+            return true;
+        }
+
+        if (afterColon[0] == '\"')
+        {
+            int endQuote = 1;
+            while (endQuote < afterColon.Length && afterColon[endQuote] != '\"')
+                endQuote++;
+            if (endQuote >= afterColon.Length)
+                return false;
+            fontName = afterColon.Substring(1, endQuote - 1);
+            remainder = afterColon[(endQuote + 1)..];
+            return true;
+        }
+
+        int index = 0;
+        while (index < afterColon.Length && !char.IsWhiteSpace(afterColon[index]))
+        {
+            if (afterColon[index] == '=' && index + 1 < afterColon.Length && afterColon[index + 1] == '>')
+                break;
+            index++;
+        }
+        fontName = afterColon[..index].TrimEnd();
+        remainder = afterColon[index..];
+        return true;
+    }
+
+    private static bool TryParsePlatformName(string text, out ARuntimePlatform platform)
+    {
+        platform = default;
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        text = text.Trim();
+        int colonIndex = text.IndexOf(':');
+        var token = colonIndex < 0 ? text : text[..colonIndex].Trim();
+        return TryGetPlatform(token, out platform);
+    }
+
+    private static bool TryParsePlatformAndRemainder(string text, out ARuntimePlatform platform, out string remainder)
+    {
+        platform = default;
+        remainder = string.Empty;
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        text = text.Trim();
+        int colonIndex = text.IndexOf(':');
+        if (colonIndex < 0)
+            return TryGetPlatform(text, out platform);
+
+        var token = text[..colonIndex].Trim();
+        if (!TryGetPlatform(token, out platform))
+            return false;
+        remainder = text[(colonIndex + 1)..];
+        return true;
+    }
+
+    private static bool TryGetPlatform(string value, out ARuntimePlatform platform)
+    {
+        platform = default;
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        switch (value.Trim().ToLowerInvariant())
+        {
+            case "mac":
+            case "macintosh":
+                platform = ARuntimePlatform.Mac;
+                return true;
+            case "win":
+            case "windows":
+                platform = ARuntimePlatform.Win;
+                return true;
+            default:
+                return false;
+        }
+    }
+}
+
+public sealed record class FontMapDocument(IReadOnlyList<AbstFontMap> FontMappings, IReadOnlyList<AbstInputKeyMap> InputKeyMappings)
+{
+    public static FontMapDocument Empty { get; } = new(Array.Empty<AbstFontMap>(), Array.Empty<AbstInputKeyMap>());
+}


### PR DESCRIPTION
## Summary
- introduce an AbstFontManagerBase that centralizes font and input key map handling
- add an ARuntimePlatform enum and update AbstFontMap/InputKeyMap along with font managers to use the shared base class
- adjust FontMapperReader to emit enum-based platforms and update associated unit tests

## Testing
- dotnet test Test/BlingoEngine.Tests/BlingoEngine.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cb9ed0e0788332ad92c47079480408