### PR TITLE
Add legacy CAST reader

### DIFF
--- a/src/BlingoEngine.IO.Legacy/BlTag.cs
+++ b/src/BlingoEngine.IO.Legacy/BlTag.cs
@@ -159,6 +159,7 @@ public readonly struct BlTag : IEquatable<BlTag>, IEquatable<string>
         Abmp = Register("ABMP");
         Fgei = Register("FGEI");
         Cast = Register("CAST");
+        CasStar = Register("CAS*");
     }
 
     public static BlTag Register(string value)
@@ -188,4 +189,5 @@ public readonly struct BlTag : IEquatable<BlTag>, IEquatable<string>
     public static BlTag Abmp { get; }
     public static BlTag Fgei { get; }
     public static BlTag Cast { get; }
+    public static BlTag CasStar { get; }
 }

--- a/src/BlingoEngine.IO.Legacy/Cast/BlLegacyCastLibrary.cs
+++ b/src/BlingoEngine.IO.Legacy/Cast/BlLegacyCastLibrary.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+
+namespace BlingoEngine.IO.Legacy.Cast;
+
+/// <summary>
+/// Represents the table of cast-member resource identifiers stored inside a <c>CAS*</c> chunk.
+/// Each slot mirrors the four-byte entries Director wrote to reference individual <c>CASt</c>
+/// members that belong to the owning cast library.
+/// </summary>
+internal sealed class BlLegacyCastLibrary
+{
+    public BlLegacyCastLibrary(int resourceId, int? libraryId, int entryCount)
+    {
+        ResourceId = resourceId;
+        LibraryId = libraryId;
+        EntryCount = entryCount;
+    }
+
+    /// <summary>
+    /// Gets the resource identifier assigned to the <c>CAS*</c> table in the map.
+    /// </summary>
+    public int ResourceId { get; }
+
+    /// <summary>
+    /// Gets the parent resource identifier recorded in the <c>KEY*</c> table. When present this
+    /// value identifies the cast library that owns the <c>CAS*</c> table.
+    /// </summary>
+    public int? LibraryId { get; }
+
+    /// <summary>
+    /// Gets the number of four-byte slots stored in the <c>CAS*</c> payload (including empty slots).
+    /// </summary>
+    public int EntryCount { get; }
+
+    /// <summary>
+    /// Gets the list of populated cast-member slots. Empty slots are omitted but their original
+    /// index is preserved so consumers can reconstruct member numbering.
+    /// </summary>
+    public List<BlLegacyCastMemberSlot> Members { get; } = new();
+}
+
+/// <summary>
+/// Describes a single populated entry inside the <c>CAS*</c> table. The slot index represents the
+/// position within the table while the resource identifier points to the <c>CASt</c> chunk that
+/// contains the cast-member data.
+/// </summary>
+/// <param name="SlotIndex">Zero-based position of the entry within the table.</param>
+/// <param name="ResourceId">Identifier of the <c>CASt</c> resource referenced by the slot.</param>
+internal readonly record struct BlLegacyCastMemberSlot(int SlotIndex, int ResourceId);

--- a/src/BlingoEngine.IO.Legacy/Cast/BlLegacyCastReader.cs
+++ b/src/BlingoEngine.IO.Legacy/Cast/BlLegacyCastReader.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+
+using BlingoEngine.IO.Legacy.Afterburner;
+using BlingoEngine.IO.Legacy.Classic;
+using BlingoEngine.IO.Legacy.Data;
+
+namespace BlingoEngine.IO.Legacy.Cast;
+
+/// <summary>
+/// Reads <c>CAS*</c> resources and exposes the cast-member tables they contain. Each table stores a
+/// packed list of 32-bit identifiers that point to individual <c>CASt</c> resources. The loader keeps
+/// the slot index for every populated entry so higher layers can reconstruct cast numbering.
+/// </summary>
+internal sealed class BlLegacyCastReader
+{
+    private readonly ReaderContext _context;
+
+    public BlLegacyCastReader(ReaderContext context)
+    {
+        _context = context;
+    }
+
+    /// <summary>
+    /// Iterates over all registered <c>CAS*</c> resources, loading their payload bytes and decoding the
+    /// cast-member tables contained within. The reader respects both classic chunk storage and
+    /// Afterburner inline segments, inflating compressed data when necessary.
+    /// </summary>
+    public IReadOnlyList<BlLegacyCastLibrary> Read()
+    {
+        var libraries = new List<BlLegacyCastLibrary>();
+        if (_context.Resources.Entries.Count == 0)
+        {
+            return libraries;
+        }
+
+        var classicLoader = new BlClassicPayloadLoader(_context);
+        BlAfterburnerPayloadLoader? afterburnerLoader = null;
+        if (_context.AfterburnerState is not null)
+        {
+            afterburnerLoader = new BlAfterburnerPayloadLoader(_context, _context.AfterburnerState);
+        }
+
+        foreach (var entry in _context.Resources.Entries)
+        {
+            if (entry.Tag != BlTag.CasStar)
+            {
+                continue;
+            }
+
+            var payload = LoadPayload(entry, classicLoader, afterburnerLoader);
+            var library = ParseLibrary(entry, payload);
+            libraries.Add(library);
+        }
+
+        return libraries;
+    }
+
+    private static byte[] LoadPayload(BlLegacyResourceEntry entry, BlClassicPayloadLoader classicLoader, BlAfterburnerPayloadLoader? afterburnerLoader)
+    {
+        return entry.StorageKind == BlResourceStorageKind.AfterburnerSegment
+            ? afterburnerLoader is null ? Array.Empty<byte>() : entry.LoadAfterburner(afterburnerLoader)
+            : entry.ReadClassicPayload(classicLoader);
+    }
+
+    private BlLegacyCastLibrary ParseLibrary(BlLegacyResourceEntry entry, byte[] payload)
+    {
+        int? parentId = null;
+        if (_context.Resources.ParentByChild.TryGetValue(entry.Id, out var link))
+        {
+            parentId = link.ParentId;
+        }
+
+        var entryCount = payload.Length / 4;
+        var library = new BlLegacyCastLibrary(entry.Id, parentId, entryCount);
+        if (entryCount == 0)
+        {
+            return library;
+        }
+
+        var reader = _context.CreateMemoryReader(payload);
+        for (var slot = 0; slot < entryCount; slot++)
+        {
+            var castResourceId = unchecked((int)reader.ReadUInt32());
+            if (castResourceId == 0)
+            {
+                continue;
+            }
+
+            library.Members.Add(new BlLegacyCastMemberSlot(slot, castResourceId));
+        }
+
+        return library;
+    }
+}
+
+/// <summary>
+/// Extension helpers that expose the <see cref="BlLegacyCastReader"/> through the shared
+/// <see cref="ReaderContext"/> type used by the legacy pipeline.
+/// </summary>
+internal static class BlLegacyCastReaderExtensions
+{
+    public static IReadOnlyList<BlLegacyCastLibrary> ReadCastLibraries(this ReaderContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var reader = new BlLegacyCastReader(context);
+        return reader.Read();
+    }
+}


### PR DESCRIPTION
## Summary
- register the CAS* tag alongside existing FourCC definitions
- add cast table DTOs and a reader that parses CAS* resources from classic and Afterburner storage

## Testing
- dotnet build src/BlingoEngine.IO.Legacy/BlingoEngine.IO.Legacy.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cbb011337483329691840552fb3d54