### PR TITLE
Refine legacy sound format detection and docs

### DIFF
--- a/Test/BlingoEngine.IO.Legacy.Tests/Helpers/TestContextHarness.cs
+++ b/Test/BlingoEngine.IO.Legacy.Tests/Helpers/TestContextHarness.cs
@@ -1,6 +1,7 @@
 using BlingoEngine.IO.Legacy.Cast;
 using BlingoEngine.IO.Legacy.Core;
 using BlingoEngine.IO.Legacy.Files;
+using BlingoEngine.IO.Legacy.Sounds;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -8,7 +9,7 @@ using System.IO;
 namespace BlingoEngine.IO.Legacy.Tests.Helpers;
 
 internal sealed class TestContextHarness : IDisposable
-    {
+{
 
     public static IReadOnlyList<BlLegacyCastLibrary> LoadCastLibraries(string relativePath)
     {
@@ -18,31 +19,38 @@ internal sealed class TestContextHarness : IDisposable
         return libraries;
     }
 
-    private TestContextHarness(ReaderContext context)
-        {
-            Context = context;
-        }
-
-        public ReaderContext Context { get; }
-
-        public static TestContextHarness Open(string relativePath)
-        {
-            var fullPath = TestFolder.AssetPath(relativePath);
-            var stream = File.OpenRead(fullPath);
-            var context = new ReaderContext(stream, Path.GetFileName(fullPath), leaveOpen: false);
-            return new TestContextHarness(context);
-        }
-
-        public void ReadResources()
-        {
-            Context.ReadDirFilesContainer();
-        }
-
-        public void Dispose()
-        {
-            Context.Dispose();
-        }
+    public static IReadOnlyList<BlLegacySound> LoadSounds(string relativePath)
+    {
+        using var harness = Open(relativePath);
+        harness.ReadResources();
+        return harness.Context.ReadSounds();
     }
 
-   
+    private TestContextHarness(ReaderContext context)
+    {
+        Context = context;
+    }
+
+    public ReaderContext Context { get; }
+
+    public static TestContextHarness Open(string relativePath)
+    {
+        var fullPath = TestFolder.AssetPath(relativePath);
+        var stream = File.OpenRead(fullPath);
+        var context = new ReaderContext(stream, Path.GetFileName(fullPath), leaveOpen: false);
+        return new TestContextHarness(context);
+    }
+
+    public void ReadResources()
+    {
+        Context.ReadDirFilesContainer();
+    }
+
+    public void Dispose()
+    {
+        Context.Dispose();
+    }
+}
+
+
 

--- a/Test/BlingoEngine.IO.Legacy.Tests/Sounds/BlLegacySoundReaderTests.cs
+++ b/Test/BlingoEngine.IO.Legacy.Tests/Sounds/BlLegacySoundReaderTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Linq;
+
+using BlingoEngine.IO.Legacy.Sounds;
+using BlingoEngine.IO.Legacy.Tests.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace BlingoEngine.IO.Legacy.Tests.Sounds;
+
+public class BlLegacySoundReaderTests
+{
+    [Fact]
+    public void ReadDirFileWithThreeSounds_LoadsMp3Payloads()
+    {
+        var sounds = TestContextHarness.LoadSounds("Sounds/DirFileWith_3_Sounds.dir");
+
+        sounds.Should().HaveCount(3);
+        sounds.Select(sound => sound.ResourceId)
+            .Should()
+            .BeEquivalentTo(new[] { 13, 19, 25 });
+        sounds.Select(sound => sound.Bytes.Length)
+            .Should()
+            .BeEquivalentTo(new[] { 56350, 53474, 6554 });
+        sounds.Select(sound => sound.Format)
+            .Should()
+            .AllBeEquivalentTo(BlLegacySoundFormatKind.Mp3);
+
+        ReadOnlySpan<byte> id3 = stackalloc byte[] { (byte)'I', (byte)'D', (byte)'3' };
+
+        foreach (var sound in sounds)
+        {
+            sound.Bytes.Length.Should().BeGreaterThan(2);
+            var span = sound.Bytes.AsSpan();
+            var hasId3 = span.Length >= id3.Length && span[..id3.Length].SequenceEqual(id3);
+            var hasFrameSync = span[0] == 0xFF && (span[1] & 0xE0) == 0xE0;
+            (hasId3 || hasFrameSync).Should().BeTrue();
+        }
+    }
+
+    [Theory]
+    [InlineData("Sounds/DirFileWith_3_Sounds_D10.dcr")]
+    [InlineData("Sounds/DirFileWith_3_Sounds_D85.dcr")]
+    [InlineData("Sounds/DirFileWith_3_Sounds_compressed_D10.dcr")]
+    public void ReadProjectorVariants_LoadsSoundPayloads(string relativePath)
+    {
+        var sounds = TestContextHarness.LoadSounds(relativePath);
+
+        sounds.Should().HaveCount(3);
+        sounds.Select(sound => sound.Format)
+            .Should()
+            .AllBeEquivalentTo(BlLegacySoundFormatKind.Mp3);
+        sounds.Select(sound => sound.Bytes.Length)
+            .Should()
+            .OnlyContain(length => length > 0);
+    }
+}

--- a/docs/BlazorDemo.md
+++ b/docs/BlazorDemo.md
@@ -1,2 +1,4 @@
+[← Back to Docs Home](README.md)
+
 # Blazor Demo
 

--- a/docs/CastLibCsvImport.md
+++ b/docs/CastLibCsvImport.md
@@ -1,3 +1,5 @@
+[← Back to Docs Home](README.md)
+
 # Importing Cast Libraries from CSV
 
 BlingoEngine can populate a cast library by reading a simple **CSV** file. This allows you to organise media assets and script members in a spreadsheet and load them at runtime.

--- a/docs/FilmLoop.md
+++ b/docs/FilmLoop.md
@@ -1,3 +1,5 @@
+[← Back to Docs Home](README.md)
+
 # Film Loops
 
 Film loops are reusable animations composed of sprites or sounds that play in a loop independent of the score timeline. They are roughly equivalent to movie clips in other engines and act like mini‑movies that can be dropped onto the stage or nested inside other film loops.

--- a/docs/Fonts.md
+++ b/docs/Fonts.md
@@ -1,3 +1,5 @@
+[← Back to Docs Home](README.md)
+
 # Fonts in BlingoEngine
 
 BlingoEngine relies on the `IAbstFontManager` abstraction from the underlying AbstUI library to provide a uniform font API across SDL2, Godot, Unity, and Blazor backends. The manager registers font files, loads platform-specific assets, and exposes helpers for measuring text. Font styles use the flag-based `AbstFontStyle` enum so bold and italic styles can be combined.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1,3 +1,5 @@
+[← Back to Docs Home](README.md)
+
 # Getting Started
 
 This short guide explains the layout of the repository and how to run the test suite locally.

--- a/docs/GodotSetup.md
+++ b/docs/GodotSetup.md
@@ -1,3 +1,5 @@
+[← Back to Docs Home](README.md)
+
 # Setting Up the Godot Runtime
 
 The Godot adapter embeds BlingoEngine into a Godot scene through a framework

--- a/docs/LegacySoundLoading.md
+++ b/docs/LegacySoundLoading.md
@@ -1,0 +1,41 @@
+[← Back to Docs Home](README.md)
+
+# Legacy Sound Loading Notes
+
+The legacy IO layer now exposes a `BlLegacySoundReader` that resolves `ediM` entries from a
+movie's resource table and classifies the decoded bytes into familiar audio container formats.
+This mirrors how the original Director runtime bundled edited audio data: the actual sound stream
+is saved inside the `ediM` entry while the surrounding `snd ` container only holds metadata or
+index records. Once the reader inflates the payload (handling Afterburner compression when needed),
+it inspects the file signature to label each sound with a `BlLegacySoundFormatKind`.
+
+## Format classification
+
+`BlLegacySoundFormat.Detect` performs a lightweight header inspection so higher layers can decide
+how to replay or transcode the bytes. The classifier recognises:
+
+- ID3 tags and MP3 frame sync words for MPEG Layer III streams.
+- Big-endian RIFF variants (RIFF/FFIR/RIFX) for waveform data.
+- FORM chunks that expand into AIFF or AIFC subtypes.
+- Ogg, FLAC, AU, CAF, and MIDI signatures via their magic numbers.
+- MPEG-4 audio when an `ftyp` box appears at the beginning of the buffer.
+
+If no signature is found the loader reports the payload as `Unknown` so callers can fall back to
+external probing tools.
+
+## Historical notes from ScummVM research
+
+Older Director releases stored audio differently, and understanding that history helps align our
+reader with real-world movies:
+
+- **Director 2–3:** sound members implicitly pointed at classic Macintosh `SND ` resources. The ID
+  was derived from the cast member number, and playback relied on the platform decoder.
+- **Director 4–5:** child resource entries were introduced, still targeting `snd ` or `SND ` tags but
+  now explicitly listed inside the cast library.
+- **Director 6:** Macromedia migrated to bundled MOA assets with `sndH`, `sndS`, and `ediM` pieces.
+  A helper assembled these segments and interpreted compression or looping metadata before exposing
+  audio to the mixer.
+
+The ScummVM Director engine documents these transitions in detail and served as a reference when
+verifying how Afterburner archives surface their sound payloads, especially for early projector
+files that mix classic and MOA-era assets without consistent tagging.

--- a/docs/Progress.md
+++ b/docs/Progress.md
@@ -1,3 +1,5 @@
+[← Back to Docs Home](README.md)
+
 # Lingo Feature Conversion Progress
 
 This document tracks the current implementation status of Lingo language elements in **BlingoEngine**. The percentages are based on the comparison between the Director MX 2004 scripting manual and the interfaces implemented in the repository.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ This folder collects guides, references, and research notes for BlingoEngine.
 - [FilmLoop.md](FilmLoop.md) – Film loop usage, internals, and nesting animations inside animations.
 - [Fonts.md](Fonts.md) – Managing fonts across SDL2, Godot, Unity, and Blazor backends.
 - [GettingStarted.md](GettingStarted.md) – Repository layout and how to run tests locally.
+- [LegacySoundLoading.md](LegacySoundLoading.md) – Notes about `ediM` payloads, format detection, and historical Director sound handling.
 - [GodotSetup.md](GodotSetup.md) – Embedding BlingoEngine into a Godot project.
 - [Progress.md](Progress.md) – Current implementation status of Lingo language features.
 - [SDLSetup.md](SDLSetup.md) – Notes for using the SDL2 front‑end runtime.

--- a/docs/SDLSetup.md
+++ b/docs/SDLSetup.md
@@ -1,3 +1,5 @@
+[← Back to Docs Home](README.md)
+
 # Setting Up the SDL2 Runtime
 
 Use the SDL2 front‑end when you want a lightweight desktop window without a

--- a/docs/Todos.md
+++ b/docs/Todos.md
@@ -1,3 +1,5 @@
+[← Back to Docs Home](README.md)
+
 # TODO list
 Bugs, missing features, todo's and so on. A fast notes document.
 

--- a/src/BlingoEngine.IO.Legacy/Sounds/BlLegacySound.cs
+++ b/src/BlingoEngine.IO.Legacy/Sounds/BlLegacySound.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace BlingoEngine.IO.Legacy.Sounds;
+
+/// <summary>
+/// Represents the decoded payload of a legacy Director sound resource. The loader classifies the
+/// raw bytes into a lightweight <see cref="BlLegacySoundFormatKind"/> so higher layers can decide how
+/// to persist or transcode the data.
+/// </summary>
+internal sealed class BlLegacySound
+{
+    /// <summary>
+    /// Gets the resource identifier associated with the sound entry in the resource table.
+    /// </summary>
+    public int ResourceId { get; }
+
+    /// <summary>
+    /// Gets the best-effort classification of the sound payload.
+    /// </summary>
+    public BlLegacySoundFormatKind Format { get; }
+
+    /// <summary>
+    /// Gets the raw bytes stored inside the <c>ediM</c> chunk.
+    /// </summary>
+    public byte[] Bytes { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BlLegacySound"/> class.
+    /// </summary>
+    public BlLegacySound(int resourceId, BlLegacySoundFormatKind format, byte[] bytes)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        ResourceId = resourceId;
+        Format = format;
+        Bytes = bytes;
+    }
+}

--- a/src/BlingoEngine.IO.Legacy/Sounds/BlLegacySoundFormat.cs
+++ b/src/BlingoEngine.IO.Legacy/Sounds/BlLegacySoundFormat.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Buffers.Binary;
+
+namespace BlingoEngine.IO.Legacy.Sounds;
+
+/// <summary>
+/// Enumerates container formats detected in legacy Director sound resources. The reader only
+/// inspects the leading bytes of the payload, so the classification is lightweight and tolerant
+/// of uncommon codecs that may appear in the wild.
+/// </summary>
+internal enum BlLegacySoundFormatKind
+{
+    /// <summary>
+    /// The payload could not be classified using the known file headers.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// MPEG Layer III stream identified by an ID3 tag or an MP3 frame sync word.
+    /// </summary>
+    Mp3,
+
+    /// <summary>
+    /// Waveform audio stored in RIFF/FFIR/RIFX containers.
+    /// </summary>
+    Wave,
+
+    /// <summary>
+    /// AIFF container detected via the FORM/AIFF header.
+    /// </summary>
+    Aiff,
+
+    /// <summary>
+    /// AIFF-C container detected via the FORM/AIFC header.
+    /// </summary>
+    Aifc,
+
+    /// <summary>
+    /// MIDI sequence starting with the standard MThd signature.
+    /// </summary>
+    Midi,
+
+    /// <summary>
+    /// Apple Core Audio Format (CAF) stream.
+    /// </summary>
+    Caf,
+
+    /// <summary>
+    /// Ogg container (typically Vorbis) detected via the OggS marker.
+    /// </summary>
+    Ogg,
+
+    /// <summary>
+    /// Free Lossless Audio Codec stream detected via the fLaC marker.
+    /// </summary>
+    Flac,
+
+    /// <summary>
+    /// Sun/NeXT AU container identified by the .snd signature.
+    /// </summary>
+    Au,
+
+    /// <summary>
+    /// MPEG-4 container detected by the ftyp box near the start of the payload.
+    /// </summary>
+    Mp4
+}
+
+/// <summary>
+/// Provides helpers for classifying legacy sound payloads based on their file signatures.
+/// </summary>
+internal static class BlLegacySoundFormat
+{
+    public static BlLegacySoundFormatKind Detect(ReadOnlySpan<byte> data)
+    {
+        if (data.Length >= 3 && data[0] == (byte)'I' && data[1] == (byte)'D' && data[2] == (byte)'3')
+            return BlLegacySoundFormatKind.Mp3;
+
+        if (data.Length >= 4)
+        {
+            var header = BinaryPrimitives.ReadUInt32BigEndian(data);
+            switch (header)
+            {
+                case 0x52494646: // RIFF
+                case 0x46464952: // FFIR
+                case 0x52494658: // RIFX
+                    return BlLegacySoundFormatKind.Wave;
+                case 0x464F524D: // FORM
+                    if (data.Length >= 12)
+                    {
+                        var subType = BinaryPrimitives.ReadUInt32BigEndian(data.Slice(8, 4));
+                        if (subType == 0x41494646) // AIFF
+                            return BlLegacySoundFormatKind.Aiff;
+                        if (subType == 0x41494643) // AIFC
+                            return BlLegacySoundFormatKind.Aifc;
+                    }
+                    return BlLegacySoundFormatKind.Aiff;
+                case 0x4F676753: // OggS
+                    return BlLegacySoundFormatKind.Ogg;
+                case 0x664C6143: // fLaC
+                    return BlLegacySoundFormatKind.Flac;
+                case 0x2E736E64: // .snd
+                    return BlLegacySoundFormatKind.Au;
+                case 0x4D546864: // MThd
+                    return BlLegacySoundFormatKind.Midi;
+                case 0x63616666: // caff
+                case 0x43414646: // CAFF
+                    return BlLegacySoundFormatKind.Caf;
+            }
+        }
+
+        if (data.Length >= 8)
+        {
+            var box = BinaryPrimitives.ReadUInt32BigEndian(data.Slice(4, 4));
+            if (box == 0x66747970) // ftyp
+                return BlLegacySoundFormatKind.Mp4;
+        }
+
+        if (data.Length >= 2 && data[0] == 0xFF && (data[1] & 0xE0) == 0xE0)
+            return BlLegacySoundFormatKind.Mp3;
+
+        return BlLegacySoundFormatKind.Unknown;
+    }
+}

--- a/src/BlingoEngine.IO.Legacy/Sounds/BlLegacySoundReader.cs
+++ b/src/BlingoEngine.IO.Legacy/Sounds/BlLegacySoundReader.cs
@@ -16,7 +16,26 @@ namespace BlingoEngine.IO.Legacy.Sounds;
 /// </summary>
 internal sealed class BlLegacySoundReader
 {
-    private static readonly BlTag SoundDataTag = BlTag.Register("ediM");
+    private static readonly BlTag EditorTag = BlTag.Register("ediM");
+    private static readonly BlTag SoundDirectoryTag = BlTag.Register("snd ");
+    private static readonly BlTag SoundSampleTag = BlTag.Register("sndS");
+    private static readonly BlTag MacSoundTag = BlTag.Register("SND ");
+
+    private static readonly BlTag[] ChildPriority =
+    {
+        EditorTag,
+        SoundSampleTag,
+        MacSoundTag,
+        SoundDirectoryTag
+    };
+
+    private static readonly HashSet<BlTag> StandaloneTags = new()
+    {
+        EditorTag,
+        SoundSampleTag,
+        MacSoundTag,
+        SoundDirectoryTag
+    };
 
     private readonly ReaderContext _context;
 
@@ -37,14 +56,31 @@ internal sealed class BlLegacySoundReader
         if (_context.AfterburnerState is not null)
             afterburnerLoader = new BlAfterburnerPayloadLoader(_context, _context.AfterburnerState);
 
+        var processed = new HashSet<int>();
+        var entriesById = _context.Resources.EntriesById;
+
+        foreach (var pair in _context.Resources.ChildrenByParent)
+        {
+            if (!TryLoadChildSound(pair.Value, entriesById, classicLoader, afterburnerLoader, processed, out var sound))
+                continue;
+
+            sounds.Add(sound);
+        }
+
         foreach (var entry in _context.Resources.Entries)
         {
-            if (entry.Tag != SoundDataTag)
+            if (!StandaloneTags.Contains(entry.Tag))
+                continue;
+
+            if (!processed.Add(entry.Id))
                 continue;
 
             var payload = LoadPayload(entry, classicLoader, afterburnerLoader);
             if (payload.Length == 0)
+            {
+                processed.Remove(entry.Id);
                 continue;
+            }
 
             var format = BlLegacySoundFormat.Detect(payload);
             sounds.Add(new BlLegacySound(entry.Id, format, payload));
@@ -58,6 +94,43 @@ internal sealed class BlLegacySoundReader
         return entry.StorageKind == BlResourceStorageKind.AfterburnerSegment
             ? afterburnerLoader is null ? Array.Empty<byte>() : entry.LoadAfterburner(afterburnerLoader)
             : entry.ReadClassicPayload(classicLoader);
+    }
+
+    private static bool TryLoadChildSound(
+        IReadOnlyList<BlResourceKeyLink> links,
+        IReadOnlyDictionary<int, BlLegacyResourceEntry> entriesById,
+        BlClassicPayloadLoader classicLoader,
+        BlAfterburnerPayloadLoader? afterburnerLoader,
+        HashSet<int> processed,
+        out BlLegacySound sound)
+    {
+        foreach (var tag in ChildPriority)
+        {
+            for (var i = 0; i < links.Count; i++)
+            {
+                var link = links[i];
+                if (link.Tag != tag)
+                    continue;
+
+                if (!entriesById.TryGetValue(link.ChildId, out var child))
+                    continue;
+
+                if (processed.Contains(child.Id))
+                    continue;
+
+                var payload = LoadPayload(child, classicLoader, afterburnerLoader);
+                if (payload.Length == 0)
+                    continue;
+
+                var format = BlLegacySoundFormat.Detect(payload);
+                processed.Add(child.Id);
+                sound = new BlLegacySound(child.Id, format, payload);
+                return true;
+            }
+        }
+
+        sound = null!;
+        return false;
     }
 }
 

--- a/src/BlingoEngine.IO.Legacy/Sounds/BlLegacySoundReader.cs
+++ b/src/BlingoEngine.IO.Legacy/Sounds/BlLegacySoundReader.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+
+using BlingoEngine.IO.Legacy.Afterburner;
+using BlingoEngine.IO.Legacy.Classic;
+using BlingoEngine.IO.Legacy.Core;
+using BlingoEngine.IO.Legacy.Data;
+
+namespace BlingoEngine.IO.Legacy.Sounds;
+
+/// <summary>
+/// Reads sound payloads from the resource table, returning the decoded bytes alongside a
+/// best-effort format classification. Director stores the actual audio stream in <c>ediM</c>
+/// chunks, so the reader simply resolves those entries, inflates them when necessary, and runs a
+/// header inspection on the resulting buffer.
+/// </summary>
+internal sealed class BlLegacySoundReader
+{
+    private static readonly BlTag SoundDataTag = BlTag.Register("ediM");
+
+    private readonly ReaderContext _context;
+
+    public BlLegacySoundReader(ReaderContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _context = context;
+    }
+
+    public IReadOnlyList<BlLegacySound> Read()
+    {
+        var sounds = new List<BlLegacySound>();
+        if (_context.Resources.Entries.Count == 0)
+            return sounds;
+
+        var classicLoader = new BlClassicPayloadLoader(_context);
+        BlAfterburnerPayloadLoader? afterburnerLoader = null;
+        if (_context.AfterburnerState is not null)
+            afterburnerLoader = new BlAfterburnerPayloadLoader(_context, _context.AfterburnerState);
+
+        foreach (var entry in _context.Resources.Entries)
+        {
+            if (entry.Tag != SoundDataTag)
+                continue;
+
+            var payload = LoadPayload(entry, classicLoader, afterburnerLoader);
+            if (payload.Length == 0)
+                continue;
+
+            var format = BlLegacySoundFormat.Detect(payload);
+            sounds.Add(new BlLegacySound(entry.Id, format, payload));
+        }
+
+        return sounds;
+    }
+
+    private static byte[] LoadPayload(BlLegacyResourceEntry entry, BlClassicPayloadLoader classicLoader, BlAfterburnerPayloadLoader? afterburnerLoader)
+    {
+        return entry.StorageKind == BlResourceStorageKind.AfterburnerSegment
+            ? afterburnerLoader is null ? Array.Empty<byte>() : entry.LoadAfterburner(afterburnerLoader)
+            : entry.ReadClassicPayload(classicLoader);
+    }
+}
+
+internal static class BlLegacySoundReaderExtensions
+{
+    public static IReadOnlyList<BlLegacySound> ReadSounds(this ReaderContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var reader = new BlLegacySoundReader(context);
+        return reader.Read();
+    }
+}


### PR DESCRIPTION
## Summary
- centralize sound format detection in a `BlLegacySoundFormat` helper and rename the enum to `BlLegacySoundFormatKind`
- update the legacy sound reader/tests to consume the helper and report the new enum from `BlLegacySound`
- add a LegacySoundLoading guide plus back-links from top-level docs and link it from the docs home page

## Testing
- dotnet test Test/BlingoEngine.IO.Legacy.Tests/BlingoEngine.IO.Legacy.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cbde9ae78883329f6e5e8f170cd6ed