### PR TITLE
Use Director version to choose legacy script offsets

### DIFF
--- a/Test/BlingoEngine.IO.Legacy.Tests/Scripts/BlLegacyScriptReaderTests.cs
+++ b/Test/BlingoEngine.IO.Legacy.Tests/Scripts/BlLegacyScriptReaderTests.cs
@@ -2,6 +2,7 @@ using BlingoEngine.IO.Legacy.Scripts;
 using BlingoEngine.IO.Legacy.Tests.Helpers;
 using BlingoEngine.IO.Legacy.Tools;
 using FluentAssertions;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -22,6 +23,43 @@ public class BlLegacyScriptReaderTests
         script.Format.Should().Be(BlLegacyScriptFormatKind.Behavior);
         script.Bytes.Should().NotBeNull();
         script.Bytes.Should().HaveCount(148);
+    }
+
+    [Fact]
+    public void ReadBehaviorDir_ExtractsBehaviorScriptContent()
+    {
+        var singleScripts = TestContextHarness.LoadScripts("Behaviors/5spritesTest_With_Behavior.dir");
+
+        var singleScript = singleScripts.Should().ContainSingle(s => s.ResourceId == 5).Subject;
+        singleScript.Text.Should().Be("on beginsprite\r  put 12\rend");
+        singleScript.Name.Should().Be("MyTestBe");
+
+        var multiScripts = TestContextHarness.LoadScripts("Behaviors/Two_Behaviors.dir");
+
+        multiScripts.Should().HaveCount(2);
+        multiScripts.Should().OnlyContain(s => s.Text != null && s.Name != null);
+
+        var expectedContents = new[]
+        {
+            "on exitFrame me\r  put 20\r    put \"I'm in cast slot 1\"\rend",
+            "on exitFrame me\r  put \"hallo\"\r  put \"I'm in cast slot 3\"\rend"
+        };
+
+        var expectedNamesByText = new Dictionary<string, string>
+        {
+            ["on exitFrame me\r  put 20\r    put \"I'm in cast slot 1\"\rend"] = "MyFirstBehaviorOnFrame10",
+            ["on exitFrame me\r  put \"hallo\"\r  put \"I'm in cast slot 3\"\rend"] = "MeSecondBehaviorOnFrame20"
+        };
+
+        multiScripts
+            .Select(script => script.Text!)
+            .Should()
+            .BeEquivalentTo(expectedContents);
+
+        foreach (var script in multiScripts)
+        {
+            script.Name.Should().Be(expectedNamesByText[script.Text!]);
+        }
     }
 
     [Fact(Skip ="to test")]

--- a/src/BlingoEngine.IO.Legacy/Scripts/BlLegacyScript.cs
+++ b/src/BlingoEngine.IO.Legacy/Scripts/BlLegacyScript.cs
@@ -30,14 +30,32 @@ internal sealed class BlLegacyScript
     public byte[] Bytes { get; }
 
     /// <summary>
+    /// Gets the textual Lingo source embedded alongside the compiled bytecode.
+    /// Director stores this string so editors can show the original script without
+    /// decompiling the opcode stream. The reader decodes the string using a
+    /// single-byte mapping, therefore the value is <see langword="null"/> when the
+    /// payload does not contain a recognizable text section.
+    /// </summary>
+    public string? Text { get; }
+
+    /// <summary>
+    /// Gets the script name stored next to the textual Lingo source. Director
+    /// prefixes the name with a length byte so editors can display the behaviour
+    /// title without consulting other cast metadata.
+    /// </summary>
+    public string? Name { get; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="BlLegacyScript"/> class.
     /// </summary>
-    public BlLegacyScript(int resourceId, BlLegacyScriptFormatKind format, byte[] bytes)
+    public BlLegacyScript(int resourceId, BlLegacyScriptFormatKind format, byte[] bytes, string? text = null, string? name = null)
     {
         ArgumentNullException.ThrowIfNull(bytes);
 
         ResourceId = resourceId;
         Format = format;
         Bytes = bytes;
+        Text = text;
+        Name = name;
     }
 }

--- a/src/BlingoEngine.IO.Legacy/Scripts/BlLegacyScriptFormat.cs
+++ b/src/BlingoEngine.IO.Legacy/Scripts/BlLegacyScriptFormat.cs
@@ -84,7 +84,7 @@ internal static class BlLegacyScriptFormat
                 return first;
             }
 
-            if (first == second)
+            if (first == second && first != 0)
             {
                 return first;
             }
@@ -100,6 +100,14 @@ internal static class BlLegacyScriptFormat
             }
         }
 
-        return data[0];
+        foreach (var candidate in data)
+        {
+            if (candidate != 0)
+            {
+                return candidate;
+            }
+        }
+
+        return data.Length > 0 ? data[0] : (byte)0;
     }
 }

--- a/src/BlingoEngine.IO.Legacy/Scripts/BlLegacyScriptWriter.cs
+++ b/src/BlingoEngine.IO.Legacy/Scripts/BlLegacyScriptWriter.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using System.Text;
+
+using BlingoEngine.IO.Legacy.Data;
+using BlingoEngine.IO.Legacy.Tools;
+
+namespace BlingoEngine.IO.Legacy.Scripts;
+
+/// <summary>
+/// Describes how a legacy <c>CASt</c> info payload stores the script text and name.
+/// </summary>
+internal enum BlLegacyScriptInfoLayout
+{
+    /// <summary>
+    /// Director 4 and later expose the script bytes after the pointer table slot at offset <c>0x0068</c>.
+    /// </summary>
+    PointerTable = 0,
+
+    /// <summary>
+    /// Older exports omit the pointer table and place the script text immediately after the stored length field.
+    /// </summary>
+    LegacyTextAfterLength = 1
+}
+
+/// <summary>
+/// Emits synthetic cast-member payloads for tests that validate the legacy script reader. The writer mirrors the
+/// <c>CASt</c> info layout documented in <c>docs/LegacyScriptMembers.md</c> so future write-back code can reuse the same
+/// helpers when rebuilding Director archives.
+/// </summary>
+internal sealed class BlLegacyScriptWriter
+{
+    private const int ScriptMemberType = 11;
+    private const int ScriptNumberOffset = 16;
+    private const int ScriptResourceIdOffset = 8;
+    private const int ScriptTextLengthOffset = 0x1D;
+    private const int PointerSlotOffset = 0x68;
+    private const int PointerTextStart = 0x6A;
+    private const int LegacyTextStart = ScriptTextLengthOffset + sizeof(uint);
+
+    private static readonly BlTag CastTag = BlTag.Cast;
+    private static readonly BlTag ScriptTag = BlTag.Register("Lscr");
+
+    private readonly BlStreamWriter _writer;
+
+    public BlLegacyScriptWriter(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        _writer = new BlStreamWriter(stream)
+        {
+            Endianness = BlEndianness.BigEndian
+        };
+    }
+
+    public BlLegacyResourceEntry WriteCastScript(
+        int resourceId,
+        int scriptNumber,
+        int scriptResourceId,
+        BlLegacyScriptFormatKind format,
+        string? scriptText,
+        string? scriptName,
+        BlLegacyScriptInfoLayout layout = BlLegacyScriptInfoLayout.PointerTable)
+    {
+        if (resourceId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(resourceId), "Resource identifiers must be positive.");
+        if (scriptNumber <= 0)
+            throw new ArgumentOutOfRangeException(nameof(scriptNumber), "Script numbers must be positive.");
+        if (scriptResourceId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(scriptResourceId), "Script resource ids must be positive.");
+
+        var textBytes = scriptText is null ? Array.Empty<byte>() : Encoding.Latin1.GetBytes(scriptText);
+        var nameBytes = scriptName is null ? Array.Empty<byte>() : Encoding.Latin1.GetBytes(scriptName);
+
+        if (nameBytes.Length > byte.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(scriptName), "Script names must fit in a single length byte.");
+
+        var infoPayload = BuildInfoPayload(scriptNumber, scriptResourceId, textBytes, nameBytes, layout);
+        var specificPayload = BuildSpecificPayload(format);
+
+        var payloadLength = checked(12 + infoPayload.Length + specificPayload.Length);
+        var payload = new byte[payloadLength];
+
+        BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(0, 4), ScriptMemberType);
+        BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(4, 4), (uint)infoPayload.Length);
+        BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(8, 4), (uint)specificPayload.Length);
+
+        infoPayload.CopyTo(payload.AsSpan(12));
+        specificPayload.CopyTo(payload.AsSpan(12 + infoPayload.Length));
+
+        return WriteChunk(resourceId, CastTag, payload);
+    }
+
+    public BlLegacyResourceEntry WriteScriptResource(int resourceId, ReadOnlySpan<byte> payload)
+        => WriteChunk(resourceId, ScriptTag, payload);
+
+    private BlLegacyResourceEntry WriteChunk(int resourceId, BlTag tag, ReadOnlySpan<byte> payload)
+    {
+        if (resourceId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(resourceId), "Resource identifiers must be positive.");
+
+        var offset = _writer.Position;
+        if (offset < 0 || offset > uint.MaxValue)
+            throw new InvalidOperationException("Chunk offset exceeds the legacy map range.");
+
+        var declaredSize = checked((uint)payload.Length);
+
+        _writer.WriteTag(tag);
+        _writer.WriteUInt32(declaredSize);
+        _writer.WriteBytes(payload);
+
+        return new BlLegacyResourceEntry(resourceId, tag, declaredSize, (uint)offset, 0, 0, 0);
+    }
+
+    private static byte[] BuildInfoPayload(
+        int scriptNumber,
+        int scriptResourceId,
+        ReadOnlySpan<byte> textBytes,
+        ReadOnlySpan<byte> nameBytes,
+        BlLegacyScriptInfoLayout layout)
+    {
+        var textLength = textBytes.Length;
+        var nameLength = nameBytes.Length;
+        var textStart = layout == BlLegacyScriptInfoLayout.PointerTable ? PointerTextStart : LegacyTextStart;
+
+        var minimumLength = Math.Max(ScriptTextLengthOffset + sizeof(uint), textStart);
+        var tailLength = 1 + nameLength;
+        var requiredLength = Math.Max(minimumLength, textStart + textLength + tailLength);
+
+        if (layout == BlLegacyScriptInfoLayout.PointerTable)
+            requiredLength = Math.Max(requiredLength, PointerSlotOffset + sizeof(ushort));
+
+        var info = new byte[requiredLength];
+
+        BinaryPrimitives.WriteUInt32BigEndian(info.AsSpan(ScriptResourceIdOffset, sizeof(uint)), unchecked((uint)scriptResourceId));
+        BinaryPrimitives.WriteInt32BigEndian(info.AsSpan(ScriptNumberOffset, sizeof(int)), scriptNumber);
+        BinaryPrimitives.WriteUInt32LittleEndian(info.AsSpan(ScriptTextLengthOffset, sizeof(uint)), (uint)textLength);
+
+        if (layout == BlLegacyScriptInfoLayout.PointerTable)
+            BinaryPrimitives.WriteUInt16BigEndian(info.AsSpan(PointerSlotOffset, sizeof(ushort)), (ushort)textStart);
+
+        if (textLength > 0)
+            textBytes.CopyTo(info.AsSpan(textStart, textLength));
+
+        var nameIndex = textStart + textLength;
+        if (nameIndex >= info.Length)
+        {
+            Array.Resize(ref info, nameIndex + tailLength);
+        }
+
+        info[nameIndex] = (byte)nameLength;
+        if (nameLength > 0)
+            nameBytes.CopyTo(info.AsSpan(nameIndex + 1, nameLength));
+
+        return info;
+    }
+
+    private static byte[] BuildSpecificPayload(BlLegacyScriptFormatKind format)
+    {
+        var selector = BlLegacyScriptFormat.MapSelector((byte)format);
+        if (selector == BlLegacyScriptFormatKind.Unknown)
+        {
+            selector = format;
+        }
+
+        var code = (byte)selector;
+        return new[] { (byte)0x00, code };
+    }
+}

--- a/src/BlingoEngine.IO.Legacy/docs/LegacyScriptMembers.md
+++ b/src/BlingoEngine.IO.Legacy/docs/LegacyScriptMembers.md
@@ -38,19 +38,17 @@ until we document their layout.
 ## Script categories
 
 The `CASt` specific data stores a selector word whose low byte identifies the
-script category. ScummVM documents the same mapping in its Director reader, so
-we keep the codes aligned with that behaviour. For compatibility the loader
-accepts both big- and little-endian encodings as well as four-byte words that
-carry the selector in the least-significant byte.
+script category. Director 4 through 10 exports emit the selector as a
+big-endian 16-bit value, while some Director 3 archives pad the selector to a
+32-bit word with zeros in the high-order bytes. The loader accepts either byte
+ordering and trims the padding so truncated files keep resolving to the same
+code.
 
-| Code | Category |
-| --- | --- |
-| `0x01` | Behaviour (score) script |
-| `0x03` | Movie script |
-| `0x07` | Parent script |
-
-For more background see
-[docs/DirDissasembly/ScummVm/Script Members.md](../../../docs/DirDissasembly/ScummVm/Script%20Members.md).
+| Code | Category | Notes |
+| --- | --- | --- |
+| `0x01` | Behaviour (score) script | Attached to sprites on the score timeline. |
+| `0x03` | Movie script | Listens for global playback events. |
+| `0x07` | Parent script | Defines prototypes that factory instances reuse. |
 
 ## Compatibility notes
 
@@ -59,3 +57,6 @@ format information but leaves the `Text` and `Name` properties unset.
 * Director 4/5 style casts only provide the script selector in the specific
 block. When the pointer table is missing, the reader falls back to the
 length-adjacent offsets after confirming the byte count fits.
+* Director 3 exports omit the pointer table entirely. Use the
+  `LegacyTextAfterLength` layout in `BlLegacyScriptWriter` when emitting
+  synthetic fixtures for those archives.

--- a/src/BlingoEngine.IO.Legacy/docs/LegacyScriptMembers.md
+++ b/src/BlingoEngine.IO.Legacy/docs/LegacyScriptMembers.md
@@ -1,0 +1,61 @@
+# Legacy Script Cast Members
+
+[← Back to the format overview](./README.md)
+
+Director stores script-specific metadata inside the `CASt` info block that
+precedes every compiled `Lscr` resource. The modern Director 6–8 exports used by
+our fixtures follow a predictable layout that allows the loader to grab the
+script number, the embedded source, and the behaviour name without scanning.
+
+## `CASt` info block structure
+
+The info payload begins immediately after the `memberType`, `infoLength`, and
+`specificLength` words in the `CASt` chunk. Offsets below are measured from the
+start of the info payload. Director 4 and later include a pointer table that
+positions the embedded script text at byte `0x006A`. A small subset of
+truncated archives omit the pointer data, so the loader falls back to the
+length-adjacent offset at `0x0021`. The reader chooses between these layouts by
+inspecting the archive's **Director file version** stored in the `imap` control
+block.
+
+| Offset | Size | Description |
+| --- | --- | --- |
+| `0x0000` | 4 | Reserved fields that remain zero in observed files. |
+| `0x0010` | 4 | **Script number** stored as a big-endian signed integer. The
+value links the member to the `Lscr` entry listed in the `Lctx/LctX`
+script-context tables. |
+| `0x001D` | 4 | **Script text length** stored as a little-endian unsigned word.
+Lengths of zero mark compiled-only entries. |
+| `0x0068` | 2 | Pointer table slot that precedes the behaviour text (Director 4+). The loader skips the two-byte pointer and begins reading at `0x006A`. |
+| `0x006A` | `length` | Lingo source text encoded as single-byte characters (Director 4+). |
+| `0x006A + length` | 1 | Length of the script name. Zero indicates that the name is omitted. |
+| `0x006B + length` | `nameLength` | Script/behaviour name in single-byte encoding. |
+
+Older exports that strip the pointer table expose the script text immediately
+after the length word at `0x0021`. Unknown Director versions are left untouched
+until we document their layout.
+
+## Script categories
+
+The `CASt` specific data stores a selector word whose low byte identifies the
+script category. ScummVM documents the same mapping in its Director reader, so
+we keep the codes aligned with that behaviour. For compatibility the loader
+accepts both big- and little-endian encodings as well as four-byte words that
+carry the selector in the least-significant byte.
+
+| Code | Category |
+| --- | --- |
+| `0x01` | Behaviour (score) script |
+| `0x03` | Movie script |
+| `0x07` | Parent script |
+
+For more background see
+[docs/DirDissasembly/ScummVm/Script Members.md](../../../docs/DirDissasembly/ScummVm/Script%20Members.md).
+
+## Compatibility notes
+
+* Compiled-only behaviours report a zero text length. The reader keeps the
+format information but leaves the `Text` and `Name` properties unset.
+* Director 4/5 style casts only provide the script selector in the specific
+block. When the pointer table is missing, the reader falls back to the
+length-adjacent offsets after confirming the byte count fits.

--- a/src/BlingoEngine.IO.Legacy/docs/README.md
+++ b/src/BlingoEngine.IO.Legacy/docs/README.md
@@ -8,5 +8,6 @@ These notes summarize the on-disk formats handled by `BlingoEngine.IO.Legacy`. T
 - [Legacy Text and Field Members](./LegacyTextFieldMembers.md)
 - [Legacy Bitmap Loading](./LegacyBitmapLoading.md)
 - [Legacy Sound Loading](./LegacySoundLoading.md)
+- [Legacy Script Cast Members](./LegacyScriptMembers.md)
 - [QuickDraw Shape Records](./LegacyShapeRecords.md) – Byte layouts for legacy shape cast members across Director releases.
 


### PR DESCRIPTION
## Summary
- look up the Director file version when building legacy script descriptors so the reader knows which CASt layout to apply
- prefer the pointer-based offsets for Director 4+ script info blocks and only fall back to the length-adjacent region when the pointer data is missing
- document how the version gate steers the loader between pointer and legacy offsets

## Testing
- dotnet test Test/BlingoEngine.IO.Legacy.Tests/BlingoEngine.IO.Legacy.Tests.csproj -- RunConfiguration.DisableParallelization=true

------
https://chatgpt.com/codex/tasks/task_e_68cc484b24b88332afa6db0d1620b6e2