### PR TITLE
Add mp3 cast library builder and unify legacy version markers

### DIFF
--- a/Test/BlingoEngine.IO.Legacy.Tests/Files/BlLegacyFileWriterTests.cs
+++ b/Test/BlingoEngine.IO.Legacy.Tests/Files/BlLegacyFileWriterTests.cs
@@ -1,0 +1,158 @@
+using System.IO;
+
+using BlingoEngine.IO.Data.DTO;
+using BlingoEngine.IO.Legacy.Core;
+using BlingoEngine.IO.Legacy.Data;
+using BlingoEngine.IO.Legacy.Files;
+using BlingoEngine.IO.Legacy.Sounds;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace BlingoEngine.IO.Legacy.Tests.Files;
+
+public class BlLegacyFileWriterTests
+{
+    [Fact]
+    public void DirWriter_RoundTripsResources()
+    {
+        var container = new DirFilesContainerDTO();
+        container.Files.Add(new DirFileResourceDTO
+        {
+            FileName = "CASt_0000.bin",
+            Bytes = new byte[] { 0x01, 0x02, 0x03 }
+        });
+        container.Files.Add(new DirFileResourceDTO
+        {
+            FileName = "Lscr_0001.bin",
+            Bytes = new byte[] { 0x10, 0x11 }
+        });
+
+        var writer = new BlDirFileWriter();
+        using var stream = new MemoryStream();
+        writer.Write(stream, container);
+
+        stream.Position = 0;
+        using var context = new ReaderContext(stream, "movie.dir", leaveOpen: true);
+        var roundTrip = context.ReadDirFilesContainer();
+
+        context.DataBlock.Should().NotBeNull();
+        var block = context.DataBlock!;
+        block.PayloadStart.Should().Be(12);
+        block.Format.IsBigEndian.Should().BeFalse();
+        block.Format.Codec.Should().Be(BlRifxCodec.MV93);
+        block.Format.MapVersion.Should().Be(BlLegacyFormatConstants.ClassicMapVersion);
+        block.Format.ArchiveVersion.Should().Be(BlLegacyFormatConstants.Director101ArchiveVersion);
+
+        roundTrip.Files.Should().HaveCount(2);
+        roundTrip.Files[0].Bytes.Should().Equal(container.Files[0].Bytes);
+        roundTrip.Files[1].Bytes.Should().Equal(container.Files[1].Bytes);
+    }
+
+    [Fact]
+    public void CstWriter_WritesCastContainer()
+    {
+        var container = new DirFilesContainerDTO();
+        container.Files.Add(new DirFileResourceDTO
+        {
+            FileName = "CASt_0000.bin",
+            Bytes = new byte[] { 0x20, 0x21, 0x22 }
+        });
+
+        var writer = new BlCstFileWriter();
+        using var stream = new MemoryStream();
+        writer.Write(stream, container);
+
+        stream.Position = 0;
+        using var context = new ReaderContext(stream, "library.cst", leaveOpen: true);
+        var roundTrip = context.ReadDirFilesContainer();
+
+        context.DataBlock.Should().NotBeNull();
+        var format = context.DataBlock!.Format;
+        format.Codec.Should().Be(BlRifxCodec.MV93);
+        format.MapVersion.Should().Be(BlLegacyFormatConstants.ClassicMapVersion);
+        format.ArchiveVersion.Should().Be(BlLegacyFormatConstants.Director101ArchiveVersion);
+        roundTrip.Files.Should().ContainSingle();
+        roundTrip.Files[0].Bytes.Should().Equal(container.Files[0].Bytes);
+    }
+
+    [Fact]
+    public void CstWriter_WritesSoundCastLibrary()
+    {
+        var mp3Bytes = new byte[]
+        {
+            (byte)'I', (byte)'D', (byte)'3', 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            (byte)'T', (byte)'A', (byte)'G', 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0xFF, 0xFB, 0x50, 0x80
+        };
+
+        var container = BlLegacySoundLibraryBuilder.BuildSingleMemberMp3Library("mp3 member", mp3Bytes);
+
+        var writer = new BlCstFileWriter();
+        using var stream = new MemoryStream();
+        writer.Write(stream, container);
+
+        stream.Position = 0;
+        using var context = new ReaderContext(stream, "library.cst", leaveOpen: true);
+        context.ReadDirFilesContainer();
+
+        context.DataBlock.Should().NotBeNull();
+        var format = context.DataBlock!.Format;
+        format.Codec.Should().Be(BlRifxCodec.MV93);
+        format.MapVersion.Should().Be(BlLegacyFormatConstants.ClassicMapVersion);
+        format.ArchiveVersion.Should().Be(BlLegacyFormatConstants.Director101ArchiveVersion);
+
+        var sounds = context.ReadSounds();
+        sounds.Should().ContainSingle();
+        var sound = sounds[0];
+        sound.Format.Should().Be(BlLegacySoundFormatKind.Mp3);
+        sound.Bytes.Should().Equal(mp3Bytes);
+    }
+
+    [Fact]
+    public void DctWriter_WritesProtectedMovie()
+    {
+        var container = new DirFilesContainerDTO();
+        container.Files.Add(new DirFileResourceDTO
+        {
+            FileName = "CASt_0000.bin",
+            Bytes = new byte[] { 0x30, 0x31 }
+        });
+
+        var writer = new BlDctFileWriter();
+        using var stream = new MemoryStream();
+        writer.Write(stream, container);
+
+        stream.Position = 0;
+        using var context = new ReaderContext(stream, "movie.dct", leaveOpen: true);
+        context.ReadDirFilesContainer();
+
+        context.DataBlock.Should().NotBeNull();
+        context.DataBlock!.Format.Codec.Should().Be(BlRifxCodec.MC95);
+    }
+
+    [Fact]
+    public void LegacyWriter_SelectsWriterFromExtension()
+    {
+        var container = new DirFilesContainerDTO();
+        container.Files.Add(new DirFileResourceDTO
+        {
+            FileName = "CASt_0000.bin",
+            Bytes = new byte[] { 0x40 }
+        });
+
+        var writer = new BlLegacyWriter();
+        using var stream = new MemoryStream();
+        writer.Write(stream, "library.cst", container, leaveOpen: true);
+
+        stream.CanWrite.Should().BeTrue();
+
+        stream.Position = 0;
+        using var context = new ReaderContext(stream, "library.cst", leaveOpen: true);
+        context.ReadDirFilesContainer();
+
+        context.DataBlock.Should().NotBeNull();
+        context.DataBlock!.Format.Codec.Should().Be(BlRifxCodec.MV93);
+    }
+}

--- a/src/BlingoEngine.IO.Legacy/Core/BlLegacyWriter.cs
+++ b/src/BlingoEngine.IO.Legacy/Core/BlLegacyWriter.cs
@@ -1,0 +1,64 @@
+using System.IO;
+
+using BlingoEngine.IO.Data.DTO;
+using BlingoEngine.IO.Legacy.Files;
+
+namespace BlingoEngine.IO.Legacy.Core;
+
+/// <summary>
+/// Entry point for emitting Director-compatible archives from <see cref="DirFilesContainerDTO"/> instances.
+/// </summary>
+public sealed class BlLegacyWriter
+{
+    /// <summary>
+    /// Writes the supplied container to <paramref name="path"/>, creating or overwriting the target file.
+    /// </summary>
+    /// <param name="path">Destination path for the serialized movie.</param>
+    /// <param name="container">DTO container describing the resources to embed.</param>
+    public void Write(string path, DirFilesContainerDTO container)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        using var stream = File.Create(path);
+        Write(stream, path, container, leaveOpen: true);
+    }
+
+    /// <summary>
+    /// Writes the supplied container to an existing stream.
+    /// </summary>
+    /// <param name="stream">Destination stream that receives the movie bytes.</param>
+    /// <param name="fileName">Logical file name used to select the container writer.</param>
+    /// <param name="container">DTO container describing the resources to embed.</param>
+    /// <param name="leaveOpen">Whether the provided stream should remain open after the method returns.</param>
+    public void Write(Stream stream, string fileName, DirFilesContainerDTO container, bool leaveOpen = false)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(fileName);
+        ArgumentNullException.ThrowIfNull(container);
+
+        var writer = CreateFileWriter(fileName);
+        try
+        {
+            writer.Write(stream, container);
+        }
+        finally
+        {
+            if (!leaveOpen)
+            {
+                stream.Dispose();
+            }
+        }
+    }
+
+    private static BlLegacyFileWriterBase CreateFileWriter(string fileName)
+    {
+        string extension = Path.GetExtension(fileName).ToLowerInvariant();
+        return extension switch
+        {
+            ".cst" => new BlCstFileWriter(),
+            ".dct" => new BlDctFileWriter(),
+            ".dir" => new BlDirFileWriter(),
+            _ => new BlDirFileWriter()
+        };
+    }
+}

--- a/src/BlingoEngine.IO.Legacy/Data/BlDataFormat.cs
+++ b/src/BlingoEngine.IO.Legacy/Data/BlDataFormat.cs
@@ -7,7 +7,7 @@ namespace BlingoEngine.IO.Legacy.Data;
 /// The <c>RIFX/XFIR</c> signature consumes bytes 0x00-0x03 of the movie stream, the declared payload length
 /// occupies bytes 0x04-0x07, and the four-character codec marker sits at bytes 0x08-0x0B. Subsequent
 /// <c>imap</c> bytes expose a 32-bit archive version that maps to Director 4 (0x00000000), Director 5 (0x000004C1),
-/// Director 6 (0x000004C7), Director 8.5 (0x00000708), and Director 10 (0x00000742). These markers provide the
+/// Director 6 (0x000004C7), Director 8.5 (0x00000708), Director 10 (0x00000742), and Director 10.1 (0x00000744). These markers provide the
 /// version metadata necessary to choose the correct resource map interpretation without referencing external tools.
 /// </summary>
 public sealed class BlDataFormat
@@ -68,11 +68,12 @@ public sealed class BlDataFormat
 
     private static int MapDirectorVersion(uint rawVersion) => rawVersion switch
     {
-        0x00000000 => 4,
-        0x000004C1 => 5,
-        0x000004C7 => 6,
-        0x00000708 => 8,
-        0x00000742 => 10,
+        BlLegacyFormatConstants.Director4ArchiveVersion => 4,
+        BlLegacyFormatConstants.Director5ArchiveVersion => 5,
+        BlLegacyFormatConstants.Director6ArchiveVersion => 6,
+        BlLegacyFormatConstants.Director85ArchiveVersion => 8,
+        BlLegacyFormatConstants.Director10ArchiveVersion => 10,
+        BlLegacyFormatConstants.Director101ArchiveVersion => 10,
         _ => 0
     };
 }

--- a/src/BlingoEngine.IO.Legacy/Data/BlLegacyFormatConstants.cs
+++ b/src/BlingoEngine.IO.Legacy/Data/BlLegacyFormatConstants.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace BlingoEngine.IO.Legacy.Data;
+
+/// <summary>
+/// Consolidates version markers shared across the legacy Director readers and writers so the
+/// archive metadata remains consistent regardless of which side emits the container bytes.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public static class BlLegacyFormatConstants
+{
+    /// <summary>
+    /// Classic <c>imap</c> tables store a map version of <c>1</c> for Director 4 through Director 11
+    /// movies. The writers reuse the same value to align with the reader defaults.
+    /// </summary>
+    public const uint ClassicMapVersion = 1;
+
+    /// <summary>
+    /// Director 4 archive version marker observed in <c>imap</c> payloads.
+    /// </summary>
+    public const uint Director4ArchiveVersion = 0x00000000;
+
+    /// <summary>
+    /// Director 5 archive version marker observed in <c>imap</c> payloads.
+    /// </summary>
+    public const uint Director5ArchiveVersion = 0x000004C1;
+
+    /// <summary>
+    /// Director 6 archive version marker observed in <c>imap</c> payloads.
+    /// </summary>
+    public const uint Director6ArchiveVersion = 0x000004C7;
+
+    /// <summary>
+    /// Director 8.5 archive version marker observed in <c>imap</c> payloads.
+    /// </summary>
+    public const uint Director85ArchiveVersion = 0x00000708;
+
+    /// <summary>
+    /// Director 10 archive version marker observed in <c>imap</c> payloads.
+    /// </summary>
+    public const uint Director10ArchiveVersion = 0x00000742;
+
+    /// <summary>
+    /// Director 10.1 archive version marker observed in later <c>imap</c> payloads. Writers use this
+    /// by default so modern archives report the most recent classic release.
+    /// </summary>
+    public const uint Director101ArchiveVersion = 0x00000744;
+}

--- a/src/BlingoEngine.IO.Legacy/Files/BlCstFileWriter.cs
+++ b/src/BlingoEngine.IO.Legacy/Files/BlCstFileWriter.cs
@@ -1,0 +1,22 @@
+using BlingoEngine.IO.Legacy.Data;
+
+namespace BlingoEngine.IO.Legacy.Files;
+
+/// <summary>
+/// Writes <c>.cst</c> cast libraries with the same <c>XFIR</c>/<c>MV93</c> header used by classic Director
+/// authoring movies so the resulting archive can be imported by legacy tooling.
+/// </summary>
+public sealed class BlCstFileWriter : BlLegacyFileWriterBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BlCstFileWriter"/> class.
+    /// </summary>
+    public BlCstFileWriter()
+        : base(
+            BlTag.MV93,
+            isBigEndian: false,
+            BlLegacyFormatConstants.ClassicMapVersion,
+            BlLegacyFormatConstants.Director101ArchiveVersion)
+    {
+    }
+}

--- a/src/BlingoEngine.IO.Legacy/Files/BlDctFileWriter.cs
+++ b/src/BlingoEngine.IO.Legacy/Files/BlDctFileWriter.cs
@@ -1,0 +1,22 @@
+using BlingoEngine.IO.Legacy.Data;
+
+namespace BlingoEngine.IO.Legacy.Files;
+
+/// <summary>
+/// Writes <c>.dct</c> protected movies using the <c>XFIR</c>/<c>MC95</c> header observed in Director runtime
+/// templates while sharing the classic map layout implementation.
+/// </summary>
+public sealed class BlDctFileWriter : BlLegacyFileWriterBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BlDctFileWriter"/> class.
+    /// </summary>
+    public BlDctFileWriter()
+        : base(
+            BlTag.MC95,
+            isBigEndian: false,
+            BlLegacyFormatConstants.ClassicMapVersion,
+            BlLegacyFormatConstants.Director101ArchiveVersion)
+    {
+    }
+}

--- a/src/BlingoEngine.IO.Legacy/Files/BlDirFileWriter.cs
+++ b/src/BlingoEngine.IO.Legacy/Files/BlDirFileWriter.cs
@@ -1,0 +1,22 @@
+using BlingoEngine.IO.Legacy.Data;
+
+namespace BlingoEngine.IO.Legacy.Files;
+
+/// <summary>
+/// Writes classic <c>.dir</c> authoring movies using the little-endian <c>XFIR</c>/<c>MV93</c> header and
+/// a Director 10-style map layout.
+/// </summary>
+public sealed class BlDirFileWriter : BlLegacyFileWriterBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BlDirFileWriter"/> class.
+    /// </summary>
+    public BlDirFileWriter()
+        : base(
+            BlTag.MV93,
+            isBigEndian: false,
+            BlLegacyFormatConstants.ClassicMapVersion,
+            BlLegacyFormatConstants.Director101ArchiveVersion)
+    {
+    }
+}

--- a/src/BlingoEngine.IO.Legacy/Files/BlLegacyFileWriterBase.cs
+++ b/src/BlingoEngine.IO.Legacy/Files/BlLegacyFileWriterBase.cs
@@ -1,0 +1,312 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+
+using BlingoEngine.IO.Data.DTO;
+using BlingoEngine.IO.Legacy.Data;
+using BlingoEngine.IO.Legacy.Tools;
+
+namespace BlingoEngine.IO.Legacy.Files;
+
+/// <summary>
+/// Base class for legacy Director file writers. The derived types decide the container signature and
+/// codec tag while this class emits the shared <c>imap</c>/<c>mmap</c> layout and resource chunks from
+/// <see cref="DirFilesContainerDTO"/> instances.
+/// </summary>
+public abstract class BlLegacyFileWriterBase
+{
+    private const uint HeaderLength = 12;
+
+    private readonly BlTag _codecTag;
+    private readonly BlEndianness _endianness;
+    private readonly uint _mapVersion;
+    private readonly uint _archiveVersion;
+    private readonly string _signature;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BlLegacyFileWriterBase"/> class.
+    /// </summary>
+    /// <param name="codecTag">The four-character code written after the <c>RIFX/XFIR</c> header.</param>
+    /// <param name="isBigEndian">Determines whether the container uses the big-endian <c>RIFX</c> tag.</param>
+    /// <param name="mapVersion">Value stored in the <c>imap</c> payload to describe the map layout.</param>
+    /// <param name="archiveVersion">Director archive version recorded in the <c>imap</c> payload.</param>
+    protected BlLegacyFileWriterBase(BlTag codecTag, bool isBigEndian, uint mapVersion, uint archiveVersion)
+    {
+        _codecTag = codecTag;
+        _endianness = isBigEndian ? BlEndianness.BigEndian : BlEndianness.LittleEndian;
+        _mapVersion = mapVersion;
+        _archiveVersion = archiveVersion;
+        _signature = isBigEndian ? BlTag.RIFX.Value : BlTag.XFIR.Value;
+    }
+
+    /// <summary>
+    /// Writes the supplied container to the provided stream using the configured Director header.
+    /// </summary>
+    /// <param name="stream">Destination stream that receives the movie bytes.</param>
+    /// <param name="container">DTO container describing the resources to embed.</param>
+    public void Write(Stream stream, DirFilesContainerDTO container)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(container);
+
+        if (!stream.CanWrite)
+        {
+            throw new ArgumentException("Stream must be writable.", nameof(stream));
+        }
+
+        if (!stream.CanSeek)
+        {
+            throw new ArgumentException("Stream must support seeking.", nameof(stream));
+        }
+
+        var descriptors = BuildDescriptors(container);
+        using var payloadStream = BuildPayload(descriptors);
+
+        var payloadLength = payloadStream.Length;
+        if (payloadLength > uint.MaxValue)
+        {
+            throw new InvalidOperationException("Director containers cannot exceed 4 GB of payload data.");
+        }
+
+        stream.Position = 0;
+        stream.SetLength(0);
+
+        var headerWriter = new BlStreamWriter(stream)
+        {
+            Endianness = _endianness
+        };
+
+        headerWriter.WriteAscii(_signature);
+        headerWriter.WriteUInt32((uint)payloadLength);
+        headerWriter.WriteTag(_codecTag);
+        headerWriter.Flush();
+
+        payloadStream.Position = 0;
+        payloadStream.CopyTo(stream);
+        stream.Flush();
+    }
+
+    private List<ResourceDescriptor> BuildDescriptors(DirFilesContainerDTO container)
+    {
+        var descriptors = new List<ResourceDescriptor>(container.Files.Count);
+
+        for (int i = 0; i < container.Files.Count; i++)
+        {
+            var resource = container.Files[i];
+            if (resource is null)
+            {
+                throw new InvalidOperationException("Resource entries cannot be null.");
+            }
+
+            string baseName = ExtractBaseName(resource.FileName);
+            var tag = ParseTag(baseName, resource.FileName);
+            int id = ParseResourceId(baseName, i);
+            var bytes = resource.Bytes ?? Array.Empty<byte>();
+
+            if (bytes.LongLength > uint.MaxValue)
+            {
+                throw new InvalidOperationException($"Resource '{resource.FileName}' exceeds the maximum supported size.");
+            }
+
+            descriptors.Add(new ResourceDescriptor(tag, id, i, bytes));
+        }
+
+        descriptors.Sort(CompareDescriptors);
+        return descriptors;
+    }
+
+    private MemoryStream BuildPayload(List<ResourceDescriptor> descriptors)
+    {
+        const uint ImapPayloadLength = 16;
+        const ushort MmapHeaderSize = 12;
+        const ushort MmapEntrySize = 20;
+
+        var stream = new MemoryStream();
+        var writer = new BlStreamWriter(stream)
+        {
+            Endianness = _endianness
+        };
+
+        writer.WriteTag(BlTag.Imap);
+        writer.WriteUInt32(ImapPayloadLength);
+        writer.WriteUInt32(ImapPayloadLength);
+        writer.WriteUInt32(_mapVersion);
+
+        long mapOffsetPatchPosition = writer.Position;
+        writer.WriteUInt32(0);
+        writer.WriteUInt32(_archiveVersion);
+
+        long mmapChunkStart = writer.Position;
+        long entryCount = descriptors.Count;
+        long mmapPayloadLengthLong = MmapHeaderSize + entryCount * MmapEntrySize;
+        uint mmapPayloadLength = CheckedToUInt32(mmapPayloadLengthLong, "mmap payload length");
+
+        writer.WriteTag(BlTag.Mmap);
+        writer.WriteUInt32(mmapPayloadLength);
+        writer.WriteUInt16(MmapHeaderSize);
+        writer.WriteUInt16(MmapEntrySize);
+        writer.WriteUInt32((uint)entryCount);
+        writer.WriteUInt32((uint)entryCount);
+
+        long resourceDataStartRelative = mmapChunkStart + 8 + mmapPayloadLength;
+        long resourceDataStartAbsoluteLong = resourceDataStartRelative + HeaderLength;
+        uint currentOffset = CheckedToUInt32(resourceDataStartAbsoluteLong, "resource data start");
+        foreach (var descriptor in descriptors)
+        {
+            descriptor.Offset = currentOffset;
+            uint paddedPayload = AlignToEven(descriptor.PayloadLength);
+            uint chunkTotal = CheckedAdd(paddedPayload, 8u, "resource chunk length");
+            currentOffset = CheckedAdd(currentOffset, chunkTotal, "resource offsets");
+        }
+
+        foreach (var descriptor in descriptors)
+        {
+            writer.WriteTag(descriptor.Tag);
+            writer.WriteUInt32(descriptor.PayloadLength);
+            writer.WriteUInt32(descriptor.Offset);
+            writer.WriteUInt16(0);
+            writer.WriteUInt16(0);
+            writer.WriteUInt32(uint.MaxValue);
+        }
+
+        writer.Position = resourceDataStartRelative;
+
+        foreach (var descriptor in descriptors)
+        {
+            writer.WriteTag(descriptor.Tag);
+            writer.WriteUInt32(descriptor.PayloadLength);
+            writer.WriteBytes(descriptor.Data);
+            if ((descriptor.PayloadLength & 1) != 0)
+            {
+                writer.WriteByte(0);
+            }
+        }
+
+        writer.Position = mapOffsetPatchPosition;
+        var mapOffsetAbsoluteLong = mmapChunkStart + HeaderLength;
+        writer.WriteUInt32(CheckedToUInt32(mapOffsetAbsoluteLong, "mmap offset"));
+
+        writer.Position = writer.Length;
+        return stream;
+    }
+
+    private static string ExtractBaseName(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            throw new InvalidOperationException("Resource entries must provide a file name that begins with the resource tag.");
+        }
+
+        var baseName = Path.GetFileNameWithoutExtension(fileName);
+        if (string.IsNullOrEmpty(baseName) || baseName.Length < 4)
+        {
+            throw new InvalidOperationException($"Resource file name '{fileName}' must begin with a four-character tag.");
+        }
+
+        return baseName;
+    }
+
+    private static BlTag ParseTag(string baseName, string originalName)
+    {
+        string tagText = baseName.Substring(0, 4);
+        if (!BlTag.TryParse(tagText, out var tag))
+        {
+            throw new InvalidOperationException($"Resource file name '{originalName}' must start with a valid four-character tag.");
+        }
+
+        return tag;
+    }
+
+    private static int ParseResourceId(string baseName, int fallbackId)
+    {
+        int separatorIndex = baseName.IndexOf('_');
+        if (separatorIndex < 0 || separatorIndex >= baseName.Length - 1)
+        {
+            return fallbackId;
+        }
+
+        var span = baseName.AsSpan(separatorIndex + 1);
+        int length = 0;
+        while (length < span.Length && char.IsDigit(span[length]))
+        {
+            length++;
+        }
+
+        if (length == 0)
+        {
+            return fallbackId;
+        }
+
+        var digits = span.Slice(0, length);
+        if (int.TryParse(digits, NumberStyles.Integer, CultureInfo.InvariantCulture, out int id))
+        {
+            return id;
+        }
+
+        return fallbackId;
+    }
+
+    private static int CompareDescriptors(ResourceDescriptor left, ResourceDescriptor right)
+    {
+        int idCompare = left.Id.CompareTo(right.Id);
+        if (idCompare != 0)
+        {
+            return idCompare;
+        }
+
+        int tagCompare = string.CompareOrdinal(left.Tag.Value, right.Tag.Value);
+        if (tagCompare != 0)
+        {
+            return tagCompare;
+        }
+
+        return left.Order.CompareTo(right.Order);
+    }
+
+    private static uint AlignToEven(uint value) => (value & 1) == 0 ? value : value + 1;
+
+    private static uint CheckedToUInt32(long value, string description)
+    {
+        if (value < 0 || value > uint.MaxValue)
+        {
+            throw new InvalidOperationException($"The {description} exceeds the maximum supported size for Director archives.");
+        }
+
+        return (uint)value;
+    }
+
+    private static uint CheckedAdd(uint left, uint right, string description)
+    {
+        ulong sum = (ulong)left + right;
+        if (sum > uint.MaxValue)
+        {
+            throw new InvalidOperationException($"The {description} exceeds the maximum supported size for Director archives.");
+        }
+
+        return (uint)sum;
+    }
+
+    private sealed class ResourceDescriptor
+    {
+        public ResourceDescriptor(BlTag tag, int id, int order, byte[] data)
+        {
+            Tag = tag;
+            Id = id;
+            Order = order;
+            Data = data;
+            PayloadLength = (uint)data.Length;
+        }
+
+        public BlTag Tag { get; }
+
+        public int Id { get; }
+
+        public int Order { get; }
+
+        public byte[] Data { get; }
+
+        public uint PayloadLength { get; }
+
+        public uint Offset { get; set; }
+    }
+}

--- a/src/BlingoEngine.IO.Legacy/Sounds/BlLegacySoundLibraryBuilder.cs
+++ b/src/BlingoEngine.IO.Legacy/Sounds/BlLegacySoundLibraryBuilder.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Buffers.Binary;
+using System.Text;
+
+using BlingoEngine.IO.Data.DTO;
+using BlingoEngine.IO.Legacy.Data;
+
+namespace BlingoEngine.IO.Legacy.Sounds;
+
+/// <summary>
+/// Provides helpers for synthesising minimal cast libraries that embed MP3 sound members. The
+/// generated resources mirror the <c>KEY*</c>, <c>CAS*</c>, <c>CASt</c>, and <c>ediM</c> layout used by
+/// modern Director authoring movies so the resulting container can be consumed by the existing
+/// reader pipeline.
+/// </summary>
+public static class BlLegacySoundLibraryBuilder
+{
+    private const uint CastMemberTypeSound = 6;
+    private const uint KeyResourceId = 1;
+    private const uint CastTableResourceId = 2;
+    private const uint CastMemberResourceId = 3;
+    private const uint EditorResourceId = 4;
+
+    private static readonly BlTag EditorTag = BlTag.Register("ediM");
+
+    /// <summary>
+    /// Builds a <see cref="DirFilesContainerDTO"/> that contains a single sound cast member backed by
+    /// the supplied MP3 payload. The generated container is ready to be persisted through the
+    /// <see cref="BlCstFileWriter"/>.
+    /// </summary>
+    /// <param name="memberName">Display name stored in the <c>CASt</c> metadata.</param>
+    /// <param name="mp3Bytes">Raw MP3 bytes that populate the <c>ediM</c> chunk.</param>
+    /// <returns>A container that exposes the resources necessary to emit a cast library.</returns>
+    public static DirFilesContainerDTO BuildSingleMemberMp3Library(string? memberName, ReadOnlySpan<byte> mp3Bytes)
+    {
+        if (mp3Bytes.IsEmpty)
+        {
+            throw new ArgumentException("MP3 payload must contain at least one byte.", nameof(mp3Bytes));
+        }
+
+        if (mp3Bytes.Length > int.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(nameof(mp3Bytes), "MP3 payload exceeds the supported size for legacy archives.");
+        }
+
+        var container = new DirFilesContainerDTO();
+
+        container.Files.Add(new DirFileResourceDTO
+        {
+            FileName = $"{BlTag.KeyStar.Value}_{KeyResourceId:D4}.bin",
+            Bytes = BuildKeyTable()
+        });
+
+        container.Files.Add(new DirFileResourceDTO
+        {
+            FileName = $"{BlTag.CasStar.Value}_{CastTableResourceId:D4}.bin",
+            Bytes = BuildCastTable()
+        });
+
+        container.Files.Add(new DirFileResourceDTO
+        {
+            FileName = $"CASt_{CastMemberResourceId:D4}.bin",
+            Bytes = BuildCastMember(memberName)
+        });
+
+        container.Files.Add(new DirFileResourceDTO
+        {
+            FileName = $"ediM_{EditorResourceId:D4}.bin",
+            Bytes = mp3Bytes.ToArray()
+        });
+
+        return container;
+    }
+
+    private static byte[] BuildKeyTable()
+    {
+        Span<byte> payload = stackalloc byte[24];
+        BinaryPrimitives.WriteUInt16LittleEndian(payload[0..2], 12);
+        BinaryPrimitives.WriteUInt16LittleEndian(payload[2..4], 12);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload[4..8], 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload[8..12], 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload[12..16], EditorResourceId);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload[16..20], CastMemberResourceId);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload[20..24], EditorTag.ToUInt32BigEndian());
+        return payload.ToArray();
+    }
+
+    private static byte[] BuildCastTable()
+    {
+        var payload = new byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(payload, CastMemberResourceId);
+        return payload;
+    }
+
+    private static byte[] BuildCastMember(string? memberName)
+    {
+        var name = memberName ?? string.Empty;
+        var nameBytes = Encoding.UTF8.GetBytes(name);
+        if (nameBytes.Length > byte.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(nameof(memberName), "Cast-member names must fit in a single length byte.");
+        }
+
+        int infoLength = 1 + nameBytes.Length;
+        var payload = new byte[12 + infoLength];
+
+        BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(0, 4), CastMemberTypeSound);
+        BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(4, 4), (uint)infoLength);
+        BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(8, 4), 0u);
+
+        payload[12] = (byte)nameBytes.Length;
+        if (nameBytes.Length > 0)
+        {
+            nameBytes.CopyTo(payload.AsSpan(13));
+        }
+
+        return payload;
+    }
+}

--- a/src/BlingoEngine.IO.Legacy/docs/dir-format.md
+++ b/src/BlingoEngine.IO.Legacy/docs/dir-format.md
@@ -111,7 +111,7 @@ Classic Director movies expose two control blocks before the resource entries.
 | `imap` length | 4 bytes | Size of the `imap` block. |
 | Map version | 4 bytes | Observed values: `0` or `1`. |
 | `mmap` offset | 4 bytes | File position of the resource table. |
-| Archive version | 4 bytes | Director release marker (`0x00000000`, `0x000004C1`, `0x000004C7`, `0x00000708`, `0x00000742`). |
+| Archive version | 4 bytes | Director release marker (`0x00000000`, `0x000004C1`, `0x000004C7`, `0x00000708`, `0x00000742`, `0x00000744`). |
 
 The observed archive versions map to specific Director generations. Director MX 2004 (the final "Director 10" release) reuses
 the same map layout as the Director 10 entry below, so no additional parsing rules are required.
@@ -123,6 +123,7 @@ the same map layout as the Director 10 entry below, so no additional parsing rul
 | `0x000004C7` | Director 6 |
 | `0x00000708` | Director 8.5 |
 | `0x00000742` | Director 10 / Director MX 2004 |
+| `0x00000744` | Director 10.1 |
 
 ### `mmap` resource table
 


### PR DESCRIPTION
## Summary
- centralize legacy map and archive version markers via `BlLegacyFormatConstants` and update the classic writer implementations to use the shared values
- expose `BlLegacySoundLibraryBuilder` so tests can synthesize a cast library with an MP3-backed member and verify round-tripping through the writer and reader pipeline
- document the additional Director 10.1 archive marker alongside the existing `imap` version guidance

## Testing
- dotnet test Test/BlingoEngine.IO.Legacy.Tests/BlingoEngine.IO.Legacy.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68ccf4f954f88332a4e27a6e1e699a1a