### PR TITLE
Emit Pascal info blocks for modern shape CASt payloads

### DIFF
--- a/Test/BlingoEngine.IO.Legacy.Tests/Files/BlLegacyFileWriterTests.cs
+++ b/Test/BlingoEngine.IO.Legacy.Tests/Files/BlLegacyFileWriterTests.cs
@@ -1,7 +1,11 @@
+using System;
+using System.Buffers.Binary;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 using BlingoEngine.IO.Data.DTO;
+using BlingoEngine.IO.Legacy.Cast;
 using BlingoEngine.IO.Legacy.Bitmaps;
 using BlingoEngine.IO.Legacy.Core;
 using BlingoEngine.IO.Legacy.Data;
@@ -222,9 +226,25 @@ public class BlLegacyFileWriterTests
             0x02
         };
 
+        const string memberName = "shape member";
         var container = BlLegacyShapeLibraryBuilder.BuildSingleMemberShapeLibrary(
-            "shape member",
+            memberName,
             shapeRecord);
+
+        var castResource = container.Files.Single(file => file.FileName == "CASt_0003.bin");
+        var header = castResource.Bytes.AsSpan();
+        var nameByteCount = Encoding.UTF8.GetByteCount(memberName);
+        var expectedInfoLength = (uint)(1 + nameByteCount);
+        BinaryPrimitives.ReadUInt32BigEndian(header.Slice(0, 4)).Should().Be((uint)BlLegacyCastMemberType.Shape);
+        BinaryPrimitives.ReadUInt32BigEndian(header.Slice(4, 4)).Should().Be(expectedInfoLength);
+        BinaryPrimitives.ReadUInt32BigEndian(header.Slice(8, 4)).Should().Be((uint)shapeRecord.Length);
+
+        var info = header.Slice(12, (int)expectedInfoLength);
+        info[0].Should().Be((byte)nameByteCount);
+        Encoding.UTF8.GetString(info.Slice(1)).Should().Be(memberName);
+
+        var encodedShape = header.Slice(12 + (int)expectedInfoLength, shapeRecord.Length);
+        encodedShape.ToArray().Should().Equal(shapeRecord);
 
         var writer = new BlCstFileWriter();
         using var stream = new MemoryStream();
@@ -237,6 +257,7 @@ public class BlLegacyFileWriterTests
         var shapes = context.ReadShapes();
         shapes.Should().ContainSingle();
         var shape = shapes[0];
+        shape.Format.Should().Be(BlLegacyShapeFormatKind.Director4To10UnsignedColors);
         shape.Bytes.Should().Equal(shapeRecord);
     }
 

--- a/src/BlingoEngine.IO.Legacy/Cast/BlLegacyCastMemberType.cs
+++ b/src/BlingoEngine.IO.Legacy/Cast/BlLegacyCastMemberType.cs
@@ -5,22 +5,89 @@ namespace BlingoEngine.IO.Legacy.Cast;
 /// </summary>
 public enum BlLegacyCastMemberType
 {
+    /// <summary>
+    /// Type code returned when the loader cannot map the stored identifier.
+    /// </summary>
     Unknown = -1,
+
+    /// <summary>
+    /// Placeholder slot that contains no cast data.
+    /// </summary>
     Null = 0,
+
+    /// <summary>
+    /// Bitmap member that resolves to <c>BITD</c>, <c>DIB </c>, or authoring metadata. See docs/LegacyBitmapLoading.md.
+    /// </summary>
     Bitmap = 1,
+
+    /// <summary>
+    /// Film loop that replays a timeline sequence embedded in the cast library.
+    /// </summary>
     FilmLoop = 2,
+
+    /// <summary>
+    /// Static text member described in docs/LegacyTextFieldMembers.md.
+    /// </summary>
     Text = 3,
+
+    /// <summary>
+    /// Palette entry that provides colour tables for bitmap members.
+    /// </summary>
     Palette = 4,
+
+    /// <summary>
+    /// Picture member, typically QuickDraw <c>PICT</c> drawings.
+    /// </summary>
     Picture = 5,
+
+    /// <summary>
+    /// Sound member stored as <c>ediM</c>, <c>sndS</c>, or classic <c>SND </c> bytes. See docs/LegacySoundLoading.md.
+    /// </summary>
     Sound = 6,
+
+    /// <summary>
+    /// Button member that combines bitmaps with interaction states.
+    /// </summary>
     Button = 7,
+
+    /// <summary>
+    /// QuickDraw shape member documented in docs/LegacyShapeRecords.md.
+    /// </summary>
     Shape = 8,
+
+    /// <summary>
+    /// Linked movie asset (commonly QuickTime clips).
+    /// </summary>
     Movie = 9,
+
+    /// <summary>
+    /// Digital video member that wraps platform-specific codecs.
+    /// </summary>
     DigitalVideo = 10,
+
+    /// <summary>
+    /// Lingo script member. See docs/LegacyScriptMembers.md.
+    /// </summary>
     Script = 11,
+
+    /// <summary>
+    /// Rich-text edit field member introduced in later Director releases.
+    /// </summary>
     Rte = 12,
+
+    /// <summary>
+    /// Embedded font resource registered inside the cast.
+    /// </summary>
     Font = 13,
+
+    /// <summary>
+    /// External Xtra component (plug-in) entry.
+    /// </summary>
     Xtra = 14,
+
+    /// <summary>
+    /// Editable text field documented in docs/LegacyTextFieldMembers.md.
+    /// </summary>
     Field = 15
 }
 

--- a/src/BlingoEngine.IO.Legacy/Shapes/BlLegacyShapeReader.cs
+++ b/src/BlingoEngine.IO.Legacy/Shapes/BlLegacyShapeReader.cs
@@ -90,14 +90,31 @@ internal sealed class BlLegacyShapeReader
     {
         var span = payload.AsSpan();
 
-        if (TryParseModern(span, isBigEndian, out var offset, out var length) &&
+        int offset;
+        int length;
+
+        if (TryParseModern(span, isBigEndian: true, out offset, out length) &&
             TryExtractShapeRecord(span.Slice(offset, length), isBigEndian, out bytes))
         {
             format = BlLegacyShapeFormatKind.Director4To10UnsignedColors;
             return true;
         }
 
-        if (TryParseTransitional(span, isBigEndian, out offset, out length) &&
+        if (TryParseModern(span, isBigEndian: false, out offset, out length) &&
+            TryExtractShapeRecord(span.Slice(offset, length), isBigEndian, out bytes))
+        {
+            format = BlLegacyShapeFormatKind.Director4To10UnsignedColors;
+            return true;
+        }
+
+        if (TryParseTransitional(span, isBigEndian: true, out offset, out length) &&
+            TryExtractShapeRecord(span.Slice(offset, length), isBigEndian, out bytes))
+        {
+            format = BlLegacyShapeFormatKind.Director4To10UnsignedColors;
+            return true;
+        }
+
+        if (TryParseTransitional(span, isBigEndian: false, out offset, out length) &&
             TryExtractShapeRecord(span.Slice(offset, length), isBigEndian, out bytes))
         {
             format = BlLegacyShapeFormatKind.Director4To10UnsignedColors;

--- a/src/BlingoEngine.IO.Legacy/Shapes/BlLegacyShapeWriter.cs
+++ b/src/BlingoEngine.IO.Legacy/Shapes/BlLegacyShapeWriter.cs
@@ -204,7 +204,7 @@ public static class BlLegacyShapeLibraryBuilder
             Bytes = BlLegacyCastLibraryBuilderHelpers.BuildCastTable(CastMemberResourceId)
         });
 
-        var castPayload = BuildCastPayload(shapeRecord, infoBytes);
+        var castPayload = BuildCastPayload(memberName, shapeRecord, infoBytes);
 
         container.Files.Add(new DirFileResourceDTO
         {
@@ -215,14 +215,14 @@ public static class BlLegacyShapeLibraryBuilder
         return container;
     }
 
-    private static byte[] BuildCastPayload(ReadOnlySpan<byte> shapeRecord, byte[]? infoBytes)
+    private static byte[] BuildCastPayload(string? memberName, ReadOnlySpan<byte> shapeRecord, byte[]? infoBytes)
     {
-        var info = infoBytes ?? Array.Empty<byte>();
+        var info = infoBytes ?? BlLegacyCastLibraryBuilderHelpers.BuildNameInfoBytes(memberName);
         var payload = new byte[12 + info.Length + shapeRecord.Length];
 
-        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(0, 4), (uint)BlLegacyCastMemberType.Shape);
-        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(4, 4), (uint)info.Length);
-        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(8, 4), (uint)shapeRecord.Length);
+        BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(0, 4), (uint)BlLegacyCastMemberType.Shape);
+        BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(4, 4), (uint)info.Length);
+        BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(8, 4), (uint)shapeRecord.Length);
 
         if (info.Length > 0)
         {

--- a/src/BlingoEngine.IO.Legacy/docs/cst-format.md
+++ b/src/BlingoEngine.IO.Legacy/docs/cst-format.md
@@ -59,18 +59,64 @@ Director 4 introduces explicit `CASt` chunks with a short header:
 | Cast data payload | `cast data size` − consumed bytes | Bytes passed to the cast-specific parser. |
 | Cast info payload | `cast info size` bytes | Optional metadata strings or timestamps. |
 
-### Director 5–10 (`CASt` header)
+### Director 5–10.1 (`CASt` header)
 
-Later versions expand the header and reorder the fields:
+Later versions expand the header and reorder the fields. Director 10 and the final Director 10.1 maintenance release reuse this layout unchanged, so the same parsing rules cover all modern classic exports:
 
 | Field | Length | Notes |
 | --- | --- | --- |
-| Cast type | 4 bytes | Four-character tag stored in big endian. |
+| Cast type | 4 bytes | Big-endian 32-bit member-type identifier. Values map to the classic type table summarised in [Cast member types](#cast-member-types). |
 | Cast info size | 4 bytes | Big-endian length of the metadata block that immediately follows. |
 | Cast data size | 4 bytes | Big-endian length of the cast-data section stored after the info block. |
 | Cast info payload | `cast info size` bytes | Optional metadata strings or timestamps. |
 | Cast data payload | `cast data size` bytes | Bytes forwarded to the cast-specific parser. |
 
+Classic authoring tools usually store the cast-member name at the start of the info payload using a
+Pascal-style string: the first byte encodes the number of UTF-8 characters that follow. Additional
+metadata, such as authoring timestamps or flags, may appear after the name depending on the Director
+release.
+
 ### Loading process
 
 Regardless of the version, the loader wraps the cast-data payload in a memory stream, instantiates the matching cast member class, and attaches any linked resources recorded in the `KEY*` table. This allows higher-level systems to fetch sprites, scripts, and media by cast member number without re-reading the tables.
+
+### Cast member types
+
+Director stores the cast-member classification as a big-endian 32-bit word at the start of the modern `CASt` header. The values below match the enumeration in `BlLegacyCastMemberType`. Later Shockwave releases introduced additional codes; until those layouts are documented the loader reports them as `Unknown` while still exposing the raw payload bytes.
+
+| Value | Type | Notes |
+| --- | --- | --- |
+| `0` | Null | Placeholder slot; older movies use this for empty cast entries. |
+| `1` | Bitmap | Raster member backed by `BITD`, `DIB `, or authoring metadata. See [Legacy Bitmap Loading](./LegacyBitmapLoading.md). |
+| `2` | Film loop | Timeline snippets that replay a sequence of sprites. |
+| `3` | Text | Static text members documented in [Legacy Text and Field Members](./LegacyTextFieldMembers.md). |
+| `4` | Palette | Colour table resources referenced by bitmap members. |
+| `5` | Picture | QuickDraw `PICT` drawings or embedded images exposed as pictures. |
+| `6` | Sound | Audio members that resolve to `ediM`, `sndS`, or classic `SND ` payloads. See [Legacy Sound Loading](./LegacySoundLoading.md). |
+| `7` | Button | Interactive sprites that bind scripts and button states. |
+| `8` | Shape | QuickDraw shape records described in [LegacyShapeRecords](./LegacyShapeRecords.md). |
+| `9` | Movie | Linked movie assets (commonly QuickTime clips). |
+| `10` | Digital video | Digital video members that wrap platform-specific codecs. |
+| `11` | Script | Lingo scripts; see [Legacy Script Cast Members](./LegacyScriptMembers.md). |
+| `12` | RTE field | Rich-text edit fields introduced in later Director releases. |
+| `13` | Font | Embedded font resources registered in the cast. |
+| `14` | Xtra | Third-party Xtras and internal extensions. |
+| `15` | Field | Editable text fields documented in [Legacy Text and Field Members](./LegacyTextFieldMembers.md). |
+
+#### Bitmap cast members
+
+Bitmap entries reserve their cast-data length for zero bytes because the actual raster payloads live
+in sibling resources linked through the `KEY*` table. Director 5–10 exports commonly attach
+combinations of `BITD`, `DIB `, `PICT`, `ALFA`, `Thum`, and modern `ediM` metadata streams to describe
+the surface, colour depth, and optional thumbnails. The Pascal-style name described above remains in
+the info block so cataloguing tools can display the member without reading any media chunks. See
+[Legacy Bitmap Loading](./LegacyBitmapLoading.md) for byte-level layouts.
+
+#### Sound cast members
+
+Sound members follow the same pattern: the info payload stores the Pascal-style name and optional
+authoring metadata, while the audio bytes remain in dedicated media resources referenced from the
+`KEY*` table. Classic movies point at `sndS` or `SND ` payloads, whereas Director 7+ authoring tools
+prefer `ediM` containers for MP3 and streaming media. The cast-data length therefore stays at zero
+because the loader pulls audio directly from the linked resource. Refer to [Legacy Sound
+Loading](./LegacySoundLoading.md) for per-format parsing rules.


### PR DESCRIPTION
## Summary
- write modern shape `CASt` metadata using big-endian fields to match Director 10+ exports and emit the Pascal-style name info block so the payload mirrors authoring output
- try both big- and little-endian interpretations when parsing modern and transitional shape entries so actual big-endian headers are recognised
- extend the shape cast writer test to assert the encoded header, Pascal info bytes, and detected format
- document modern `CASt` info payload conventions along with bitmap and sound member resource layouts

## Testing
- dotnet test Test/BlingoEngine.IO.Legacy.Tests/BlingoEngine.IO.Legacy.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d0dc82ac40833283edeb6670312a55