### PR TITLE
Document Director 10+ score tags and workflow

### DIFF
--- a/src/BlingoEngine.IO.Legacy/docs/Director10PlusScoreTemplate.md
+++ b/src/BlingoEngine.IO.Legacy/docs/Director10PlusScoreTemplate.md
@@ -1,0 +1,387 @@
+# Director 10+ Score Stream (VWSC)
+
+[\u2190 Back to documentation home](README.md)
+
+Director MX 2004 (version 10) introduced an updated score stream inside the `VWSC` chunk. The
+material below consolidates observations from ProjectorRays research samples so a new
+implementation can parse, interpret, and render the timeline without relying on external tools. All
+multi-byte integers are big-endian unless stated otherwise.
+
+## Score entry table
+
+Each `VWSC` chunk is composed of an outer header followed by a table of entry offsets. Every entry
+provides either global score metadata or a per-sprite interval descriptor.
+
+### Outer header (24 bytes)
+
+| Offset | Type  | Name            | Notes |
+| ------ | ----- | --------------- | ----- |
+| `0x00` | `u32` | `totalLength`   | Total length of the score payload covered by this table. |
+| `0x04` | `s32` | `headerType`    | Constant `-3` (`0xFFFFFFFD`). |
+| `0x08` | `u32` | `offsetsOffset` | Start of the offset table. Observed `12`, but treat the field as a pointer in case other layouts emerge. |
+| `0x0C` | `u32` | `entryCount`    | Number of entries described in the table. |
+| `0x10` | `u32` | `notationBase`  | Observed to equal `entryCount + 1`. |
+| `0x14` | `u32` | `entrySizeSum`  | Sum of individual entry lengths (matches the last offset). |
+
+Immediately after the header sits an array of `entryCount + 1` 32-bit offsets. These offsets are
+relative to the start of the array. The final offset equals `entrySizeSum` and therefore the total
+payload length.
+
+### Entry layout
+
+Research samples arrange the entries in the following order:
+
+1. **Entry 0 – Frame data block.** Contains the timeline header plus the variable-length keyframe
+   stream detailed in the sections below.
+2. **Entry 1 – Interval order list.** Begins with `u32 count` followed by `count` big-endian
+   32-bit integers. Each integer indexes a descriptor entry (see item 4). When the list is empty the
+   natural progression `3, 6, 9, …` is implied.
+3. **Entries 2–(n).** Reserved slots frequently left empty. The order list skips them.
+4. **Descriptor triplets.** Each sprite interval occupies three consecutive entries:
+   - **Primary entry:** 44–48 byte interval descriptor.
+   - **Secondary entry:** Behaviour references (`castLib`, `castMember`, `u32 reserved`).
+   - **Tertiary entry:** Reserved. Director-generated files often leave it empty, but older
+     documentation mentions sprite-name storage.
+
+## Frame data block (entry 0)
+
+### Frame data header (20 bytes)
+
+| Offset | Field name         | Type | Meaning | Typical values |
+| ------ | ------------------ | ---- | ------- | -------------- |
+| `0x00` | `actualSize`       | `u32`| Total size of the keyframe payload. | Varies per file (e.g., `0x0000029E`). |
+| `0x04` | `headerByte0`      | `u8` | Historically labelled `unkA1`. | `0x00`. |
+| `0x05` | `headerByte1`      | `u8` | Historically labelled `unkA2`. | `0x00`. |
+| `0x06` | `headerByte2`      | `u8` | Historically labelled `unkA3`. | `0x00`. |
+| `0x07` | `headerLength`     | `u8` | Total header length. | `0x14` (20 bytes). |
+| `0x08` | `highestFrame`     | `u32`| Highest referenced frame index (inclusive). | `0x00000006`–`0x00000037` in samples. |
+| `0x0C` | `unkB1`            | `u8` | Constant so far. | `0x00`. |
+| `0x0D` | `channelGroup`     | `u8` | Director exports show `0x0D`. Early notes called this `firstBlockSize` because the first nested block often spans 54–66 bytes. |
+| `0x0E` | `spriteSize`       | `u16`| Size of each sprite record. | Always `0x0030` (48 bytes). |
+| `0x10` | `timelineVersion`  | `u8` | Timeline format version. | `0x03`. |
+| `0x11` | `timelineFlags`    | `s8` | Timeline feature flags. | Observed `0xEE` (`-18`). |
+| `0x12` | `channelCount`     | `u16`| Maximum sprite channel slots. | Typically `150`. |
+
+#### Sample header values
+
+| File                          | Header length (bytes) | `actualSize` | `highestFrame` | `spriteSize` | `channelCount` | First nested block length* | Notes |
+|-------------------------------|-----------------------|--------------|----------------|--------------|----------------|----------------------------|-------|
+| `5spritesTest.dir`            | 20                    | 670          | 15             | 48           | 150            | 54                         | Standard multi-block. |
+| `KeyFramesTestMultiple.dir`   | 20                    | 1908         | 44             | 48           | 150            | 66                         | Large block with many frames. |
+| `KeyFramesTest.dir`           | 20                    | 834          | 30             | 48           | 150            | 66                         | Mid-size timeline with nested blocks. |
+| `Dir_With_One_Img_Sprite_Hallo.dir` | 20             | 138          | 30             | 48           | 150            | 54                         | Minimal score containing a single sprite. |
+| `KeyFrames_Lenear5.dir`       | 20                    | 302          | 55             | 48           | 150            | 8                          | Linear frames with a small first block. |
+| `Animation_types.dir`         | 20                    | 1344         | 6              | 48           | 150            | 610                        | Extensive control data inside the first block. |
+
+\*The first nested block length matches the first `0x0036` wrapper encountered after the header.
+
+#### Header observations
+
+- Bytes `0x04–0x06` have remained zero in all collected samples.
+- `headerLength` at `0x07` consistently stores the literal value `20` (`0x14`).
+- Timeline byte pair (`timelineVersion`, `timelineFlags`) mirrors the values seen in Director MX 2004.
+
+### Sprite record (48 bytes)
+
+Sprite defaults are stored in 48-byte records. Each keyframe update embeds one record using the
+wrapper described in [Prefix words](#prefix-words-inside-the-frame-stream).
+
+| Offset | Type     | Meaning |
+| ------ | -------- | ------- |
+| `0x00` | `u8`     | Tween flag bitfield for the sprite. See [Sprite-based tweening](#sprite-based-tweening) for bit meanings. |
+| `0x01` | `s16`    | Control word affecting playback (`0x2010` or `0x1008` observed). |
+| `0x03` | `u8`     | Ink mode (lower 7 bits). |
+| `0x04` | `u8`     | Foreground colour index. |
+| `0x05` | `u8`     | Background colour index. |
+| `0x06` | `u16`    | Cast library identifier. |
+| `0x08` | `u16`    | Cast member identifier. |
+| `0x0A` | `u16`    | Reserved (zero). |
+| `0x0C` | `u16`    | Sprite-property table offset used for behaviour lookup. |
+| `0x0E` | `s16`    | Vertical position (`locV`). |
+| `0x10` | `s16`    | Horizontal position (`locH`). |
+| `0x12` | `s16`    | Height in pixels. |
+| `0x14` | `s16`    | Width in pixels. |
+| `0x16` | `u8`     | Channel chip colour. Bit `0x40` marks editable sprites; low nibble selects the score colour. |
+| `0x17` | `u8`     | Blend value (0–255). Runtime converts to 0–100%. |
+| `0x18` | `u8`     | Flip flags (`0x02` horizontal, `0x04` vertical). |
+| `0x19` | `u8[5]`  | Reserved padding. |
+| `0x1E` | `s32`    | Rotation (hundredths of a degree). |
+| `0x22` | `s32`    | Skew (hundredths of a degree). |
+| `0x26` | `u8[10]` | Padding to align the record to 48 bytes. |
+
+### Sprite-based tweening
+
+Tween settings belong to the sprite as a whole rather than individual keyframes. Director stores the
+current tween flags inside the sprite record and updates ease, curvature, speed, and flag masks via
+control tags described later in this guide. Grouped metadata (for example tag `0x0180` announcing a
+payload length) always precedes the actual tween parameters to ensure the data is scoped to the
+correct sprite channel.
+
+## Frame stream organisation
+
+### Nested block structure
+
+Director encodes the frame stream as a series of nested blocks:
+
+```
+[Frame data header (20 bytes)]
+[Sprite block wrapper]
+├─ Block length prefix (`0x0036`)
+├─ Sprite record (`0x0030` bytes)
+├─ Control bytes (typically 6 bytes)
+└─ Terminator (`0x0008`)
+[Next block]
+└─ …
+```
+
+Each 48-byte sprite record is typically followed by approximately 6 bytes of control data before the
+`0x0008` end marker. The exact number varies with the payload tags required for the frame.
+
+### Prefix words inside the frame stream
+
+| Word     | Role | Notes |
+| -------- | ---- | ----- |
+| `0x0000` | Padding | Separates records or aligns subsequent data. |
+| `0x0002` | Short payload prefix | The next word is the tag ID and the prefix encodes the payload length. |
+| `0x0004` | Four-byte payload prefix | Used by composite tags such as size and position. |
+| `0x0008` | End marker | Terminates the current nested block. If an advance-frame tag is pending this concludes the frame change. |
+| `0x000C` | Composite marker | Often introduces frame-rectangle payloads. |
+| `0x001E`, `0x0020` | Control markers | Seen near frame-level control flags; semantics unknown. |
+| `0x0026`, `0x0028`, `0x0094` | Control markers | Additional transition points captured from samples. Preserve raw bytes for future study. |
+| `0x0030` | Sprite record length | Always appears inside the `0x0036` wrapper. |
+| `0x0036` | Sprite block wrapper | Announces a 54-byte sprite block: record plus trailing terminator. |
+| `0x0120` | Channel tag prefix | Selects a sprite channel by index (payload = channel number relative to `0x10`). |
+| `0x1000` | Block header | Signals that a sprite block (`0x0030`) follows. |
+
+### Reading logic
+
+When consuming the keyframe stream:
+
+1. Read a prefix word (e.g., `0x0002` or `0x0004`) to learn the payload style.
+2. Consume the tag word and interpret it according to the tables below.
+3. Read the payload bytes announced by the prefix and apply them to the active sprite or control
+   structure.
+
+Capture any unrecognised prefix or tag verbatim so the research tables can grow with new samples.
+
+### Keyframe payload tags
+
+Unless noted, tags use the short payload prefix `0x0002` and the bytes that follow are interpreted as
+big-endian values.
+
+| Tag | Payload bytes | Applies to | Description |
+| --- | ------------- | ---------- | ----------- |
+| `0x0120` | 2 | Sprite defaults | Ease-in and ease-out values expressed as single bytes. Research still considers alternative roles for this tag; see [Tag 0x0120 hypotheses](#tag-0x0120-hypotheses). |
+| `0x012E` | 2 | Sprite defaults | Tween speed scalar controlling intermediate steps along the motion path. |
+| `0x0130` | 4 | Keyframe | Width and height (`s16` each). |
+| `0x0136` | 2 | Control block | Advance-frame tag for channel 6. Payload bits match [Advance-frame flag bits](#advance-frame-flag-bits). |
+| `0x015C` | 4 | Keyframe | Horizontal and vertical position (`s16` each). |
+| `0x0166` | 2 | Control block | Advance-frame tag for channel 7. |
+| `0x0180` | 2 | Control block | Announces the byte length of the upcoming nested payload (tween groups, behaviour lists). |
+| `0x0182` | 2 | Keyframe | Foreground and background colour indices (`u8` each). |
+| `0x018A` | Variable | Control block | Seen in composite metadata groups after `0x0180`; semantics under investigation. |
+| `0x0190` | 6 | Keyframe | Width, height, blend (byte), and ink (byte) packed together. |
+| `0x0196` | 2 | Control block | Advance-frame tag for channel 8. |
+| `0x019E` | 2 | Keyframe | Rotation angle stored as hundredths of a degree (`s16`). |
+| `0x01A2` | 2 | Keyframe | Skew angle stored as hundredths of a degree (`s16`). |
+| `0x01B0` | Variable | Control block | Rare tag encountered near tween metadata; payload currently unidentified. |
+| `0x01BA` | Variable | Control block | Additional control bytes, observed near the end of nested blocks. |
+| `0x01C6` | 2 | Control block | Advance-frame tag for channel 9; also appears in sprite metadata sequences. |
+| `0x01CE` | 2 | Keyframe | Rare tag with small payload; capture raw bytes for later analysis. |
+| `0x01D2` | 2 | Keyframe | Seen alongside rotation/skew updates; semantics unresolved. |
+| `0x01EC` | 8 | Keyframe | Frame rectangle (`locH`, `locV`, `width`, `height`). |
+| `0x01F4` | 2 | Sprite defaults | Curvature strength for tweened motion (0–65535). |
+| `0x01F6` | 1–2 | Sprite defaults | Tween-property bitmask. See [Tween flag mask (tags `0x01F6`/`0x1CF6`)](#tween-flag-mask-tags-0x01f6-0x1cf6). |
+| `0x01FC` | 2 | Control block | Additional sprite flags toggled at runtime (bits under review). |
+| `0x01FE` | 2 | Control block | Frame-level flags linked to transitions and sprite locks. |
+| `0x0202` | 1 | Control block | Transition code associated with `0x01FE`. |
+| `0x0212` | 2 | Keyframe | Foreground and background colour indices (`u8` each). |
+| `0x0226` | 2 | Control block | Advance-frame tag commonly pointing to channel 10. |
+| `0x0240` | 2 | Control block | Auxiliary sprite-channel helper (observed near `0x0226`). |
+| `0x0256` | 2 | Control block | Advance-frame tag for channel 11. |
+| `0x0286` | 2 | Control block | Advance-frame tag for channel 12. |
+| `0x0316` | 2 | Control block | High-range channel selector (suspected channel 13). |
+| `0x04B0` | 2 | Control block | Additional channel selector (channel 14 observed). |
+| `0x04C0` | 4 | Keyframe | Duplicate of size tag `0x0130`. |
+| `0x04C6` | 2 | Control block | Secondary channel or sprite index marker. |
+| `0x1020` | 2 | Control block | Channel-linked metadata often preceding `0x0130`. |
+| `0x1030` | 4 | Keyframe | Size repeat mirroring `0x0130`. |
+| `0x1036` | 2 | Control block | Unknown flag near multi-channel payloads. |
+| `0x13B0` | 2 | Control block | Channel link observed in multi-sprite payloads. |
+| `0x13C0` | 4 | Keyframe | Size repeat variant. |
+| `0x13C6` | 2 | Control block | Channel selector used alongside the `0x13C0` duplicate. |
+| `0x1CE0` | 2 | Control block | Channel link observed in extended payloads. |
+| `0x1CF0` | 4 | Keyframe | Size repeat for high channels. |
+| `0x1CF6` | 2 | Sprite defaults | Extended tween flag payload (mirrors `0x01F6`). |
+
+### Composite payload layouts
+
+When a tag lists multiple properties, decode the payload using the layouts below. All values are
+big-endian.
+
+| Tag | Payload structure | Notes |
+| --- | ----------------- | ----- |
+| `0x0130`, `0x04C0`, `0x1030`, `0x13C0`, `0x1CF0` | `s16 width`, `s16 height` | Sprite bounds in pixels. |
+| `0x015C` | `s16 locH`, `s16 locV` | Stage position relative to the top-left corner. |
+| `0x0182`, `0x0212` | `u8 foreColor`, `u8 backColor` | Palette indices for the sprite. |
+| `0x0190` | `s16 width`, `s16 height`, `u8 blend`, `u8 ink` | Blend converts to percentages with `blend / 255`. |
+| `0x01EC` | `s16 locH`, `s16 locV`, `s16 width`, `s16 height` | Frame rectangle used by the stage editor. |
+| `0x01F6`, `0x1CF6` | `u8 flags`, `[u8 mask]` | Tween-property mask; see [Tween flag mask](#tween-flag-mask-tags-0x01f6-0x1cf6). |
+
+### Channel selectors and advance-frame tags
+
+Channel tags follow a repeating pattern:
+
+```
+channel = ((tag - 0x0136) / 0x30) + 6
+```
+
+This formula matches most samples but remains under investigation—sprite data on channel 10 in one
+ProjectorRays test did **not** obey the progression, so treat the mapping as speculative until more
+files confirm it.
+
+Known tag/channel pairs:
+
+| Tag | Expected channel | Notes |
+| --- | ---------------- | ----- |
+| `0x0136` | 6 | Advance-frame payload follows. |
+| `0x0166` | 7 | |
+| `0x0196` | 8 | |
+| `0x01C6` | 9 | |
+| `0x0226` | 10 | Seen in most samples but the mapping failed for at least one sprite. |
+| `0x0256` | 11 | |
+| `0x0286` | 12 | |
+| `0x0316` | 13 | |
+| `0x04B0` | 14 | High-range selector. |
+
+### Advance-frame flag bits
+
+The 16-bit payload that accompanies channel tags encodes frame timing and additional control flags:
+
+| Bits | Mask | Meaning |
+| ---- | ---- | ------- |
+| 15   | `0x8000` | Create a new keyframe for the active sprite when set. |
+| 8–14 | `0x7F00` | Frame delta. Treat zero as one frame. |
+| 5    | `0x0020` | Flip horizontal (FlipH). |
+| 6    | `0x0040` | Flip vertical (FlipV). |
+| 7    | `0x0080` | Tween continuation flag (no new keyframe). |
+| 0–4  | `0x001F` | Reserved or currently unknown. |
+
+For tag `0x0136` specifically, payload byte `0x01` creates a real keyframe while `0x81` keeps the
+sprite in tween-only mode. The sequence `0x0000 0x0002` after the flag payload advances playback by
+one frame.
+
+### Tag `0x0120` hypotheses
+
+Although ProjectorRays treats tag `0x0120` as the ease-in/ease-out pair for the active sprite, earlier
+notes captured alternative interpretations. Keep these possibilities in mind when analysing new
+samples:
+
+- Structural block separator dividing logical tag groups.
+- Block type identifier comparable to the behaviour of `0x1CF6` flag blocks.
+- Data-alignment padding or legacy opcode.
+- Frame-state reset marker bracketing control bytes.
+
+### Tween flag mask (tags `0x01F6`/`0x1CF6`)
+
+The tween flag payload indicates which sprite properties interpolate between keyframes.
+
+| Bit | Mask   | Meaning |
+| --- | ------ | ------- |
+| 0   | `0x01` | Path (position). |
+| 1   | `0x02` | Size. |
+| 2   | `0x04` | Rotation. |
+| 3   | `0x08` | Skew. |
+| 4   | `0x10` | Blend. |
+| 5   | `0x20` | Foreground colour. |
+| 6   | `0x40` | Background colour. |
+| 7   | `0x80` | Sprite carries tweening data (global enable flag). |
+
+Example: payload `0x4A` (`01001010b`) enables rotation, blend, and path interpolation. Payload
+`0x81` enables tweening plus background-colour interpolation.
+
+### Example sprite-level tween block
+
+```
+00 04 01 80 00 30 00 00   ; 48 bytes follow
+00 02 01 20 10 80         ; Sprite 8 (channel = 8)
+00 02 01 F4 00 96         ; Curvature = 150 (~59%)
+00 02 01 20 10 80         ; EaseIn = 0x10, EaseOut = 0x80
+00 02 01 F6 00 4A         ; Tween Flags = Path, Rotation, Blend
+```
+
+### Tag ranges (hypothesis)
+
+Tag values cluster into broad groups. Treat these ranges as guidance only until additional samples
+confirm them.
+
+| Range | Purpose / group | Examples | Notes |
+| ----- | ---------------- | -------- | ----- |
+| `0x0100–0x01FF` | Sprite and tweening tags | `0x0130` (Size), `0x015C` (Position), `0x0120` (Ease), `0x01F4` (Curvature), `0x01F6` (Tween flags) | Primary animation data. |
+| `0x0200–0x02FF` | Colour, palette, and extensions | `0x0212` (Colours), `0x0226` (Channel selector) | Handles palette indices and higher sprite channels. |
+| `0x0300–0x03FF` | Special control tags | `0x0316` (High-range channel selector) | Rare in simple scores. |
+| `0x0400–0x04FF` | Per-channel repeats and helpers | `0x04C0` (Size repeat), `0x04B0` (Channel selector) | Duplicate payloads emitted for grouped sprites. |
+| `0x1000–0x1FFF` | Multi-sprite or multi-frame tags | `0x1030`, `0x13C0`, `0x1CF6` | Used when the engine repeats payloads across sprite groups. |
+| `0xFF00–0xFFFF` | Frame/keyframe headers | `0xFF00` | Used in start-of-block headers, not as standalone tags. |
+
+### Composite-tag bit layout hypothesis
+
+Several composite tags (`0x0190`, `0x01FE`, `0x01F6`) appear to encode multiple sprite properties via
+bitfields where each bit corresponds to attributes such as path, size, rotation, skew, blend, and
+colour channels. This hypothesis explains why certain payloads bundle properties together and should
+be considered when reverse-engineering new opcodes.
+
+## Interval descriptors and behaviours
+
+### Interval descriptor record (44+ bytes)
+
+| Offset | Type   | Meaning |
+| ------ | ------ | ------- |
+| `0x00` | `s32`  | Start frame (inclusive). |
+| `0x04` | `s32`  | End frame (inclusive). |
+| `0x08` | `s32`  | Unknown; currently observed as zero. |
+| `0x0C` | `s16`  | Unknown; currently zero. |
+| `0x0E` | `u16`  | Sprite flags (bits correspond to flip, lock, trails, moveable, editable, etc.). |
+| `0x10` | `s32`  | Channel number (6-based; aligns with sprite record channel). |
+| `0x14` | `s16`  | Constant `1` in observed files. |
+| `0x16` | `s16`  | Unknown A (typically zero). |
+| `0x18` | `s16`  | Unknown B (values around `15`). |
+| `0x1A` | `u8`   | Unknown constant `0xE1`. |
+| `0x1B` | `u8`   | Unknown constant `0xFD`. |
+| `0x1C` | `s16`  | Unknown (zero so far). |
+| `0x1E` | `s32`  | Unknown (zero so far). |
+| `0x22` | `s32[]`| Optional trailing integers (commonly `0` or the descriptor size). |
+
+### Behaviour list entry (secondary descriptor)
+
+Each 8-byte tuple binds a behaviour script to the interval:
+
+| Offset | Type | Meaning |
+| ------ | ---- | ------- |
+| `0x00` | `s16`| Cast library ID. |
+| `0x02` | `s16`| Cast member ID. |
+| `0x04` | `u32`| Reserved (zero). |
+
+### Entry ordering
+
+The interval order list (entry 1) references the **primary** descriptor entries. If the list is empty,
+interpret the descriptors sequentially in groups of three (`primary`, `secondary`, `tertiary`) until
+the offset table is exhausted. Skip zero-length entries automatically.
+
+## Rendering workflow
+
+A renderer targeting Director 10+ score data should:
+
+1. Parse the outer header and offset table to isolate each entry.
+2. Consume the frame data header to learn the sprite record size, timeline metadata, and channel
+   count.
+3. Iterate the keyframe stream, using the prefix words and tag tables above to decode sprite blocks
+   and apply property updates.
+4. Track active sprites with the advance-frame channel tags while respecting the speculative mapping
+   notes for higher channels.
+5. Merge sprite defaults with keyframe deltas to reconstruct per-frame stage state, preserving any
+   unknown tags for later analysis.
+6. Load interval descriptors to determine sprite lifetimes and attach behaviour references.
+7. Apply sprite-level tween flags, ease curves, curvature, and speed metadata to interpolate between
+   keyframes, noting that tweening is scoped to sprites rather than individual frames.
+

--- a/src/BlingoEngine.IO.Legacy/docs/LegacyScorePre10.md
+++ b/src/BlingoEngine.IO.Legacy/docs/LegacyScorePre10.md
@@ -1,0 +1,498 @@
+# Director Pre-10 Score and Frame Layout
+
+[\u2190 Back to documentation home](README.md)
+
+Classic Director movies drive their stage from a collection of timeline resources. Each movie ships a
+`VWSC` score stream that holds the frame records, optional `VWLB` label tables, and `VWAC` action
+blocks. This page distils the byte layouts into versioned tables so a new loader can rebuild the
+Director runtime without consulting external tools. Director 10 and newer projectors introduced
+additional structures that are not yet documented here; see the [Director 10+ score template](Director10PlusScoreTemplate.md)
+for the placeholders that still need samples.
+
+## Resource bundle overview
+
+A complete legacy score implementation needs to handle three container types:
+
+- **`VWSC` score stream:** frame descriptors, channel records, and Afterburner detail tables.
+- **`VWLB` label stream:** packed frame labels and comments.
+- **`VWAC` action stream:** packed frame-action scripts.
+
+Each stream begins with a byte-count guard and uses big-endian encoding regardless of platform. On
+Afterburner builds (Director 6 and later) the `VWSC` body is sometimes compressed; inflate it before
+parsing the headers below.
+
+## Score stream headers
+
+### Director 2–3 minimal header (version < `0x400`)
+
+Early Mac and Windows movies announce only the overall byte count before the first frame payload.
+Stage geometry defaults to 30 sprite channels.
+
+| Bytes | Length | Description |
+| --- | --- | --- |
+| `0x0000`..`0x0003` | 4 bytes | Total score size stored as an unsigned 32-bit integer. The parser copies this into its frame-stream guard. |
+
+### Afterburner preamble (Director 6 and later, `0x600 ≤ version < 0x1100`)
+
+Afterburner-enabled scores reserve twelve bytes ahead of the standard header. The detail table
+provides sprite metadata, behaviour lists, and names.
+
+| Bytes | Length | Description |
+| --- | --- | --- |
+| `0x0000`..`0x0003` | 4 bytes | Repeated frame-stream size used to guard Afterburner lookups. |
+| `0x0004`..`0x0007` | 4 bytes | Detail-table format version. Values observed in historic projectors include `0x00000001` and `0x00000002`. |
+| `0x0008`..`0x000B` | 4 bytes | Offset from the beginning of the score stream to the detail list. Readers seek here after the main header is parsed. |
+
+### Detail list header (Director 6 and later)
+
+The list header sits at the offset announced above. Offsets in this table are absolute positions
+inside the score stream and are relative to the start of the detail data block.
+
+| Bytes | Length | Description |
+| --- | --- | --- |
+| `list+0x00`..`list+0x03` | 4 bytes | Entry count covering sprite info, behaviour arrays, and sprite names. |
+| `list+0x04`..`list+0x07` | 4 bytes | Count of 32-bit offsets in the pointer table. Multiply by four and add `list+0x08` to locate the payload area. |
+| `list+0x08`..`list+0x0B` | 4 bytes | Maximum payload length for any detail record. Useful when preallocating buffers. |
+| `list+0x0C`..`list+0x0C+4*count-1` | `4 * count` bytes | Offset table. Each entry is added to the base address announced above to reach the corresponding detail record. |
+
+### Director 4–10 score header (`0x400 ≤ version < 0x1100`)
+
+Director 4 expanded the header so that loaders know where the first frame begins, how many channels
+are encoded, and the advertised frame count. Later versions reuse the same structure.
+
+| Bytes | Length | Description |
+| --- | --- | --- |
+| `0x0000`..`0x0003` | 4 bytes | Frame-stream size in bytes. Duplicate of the Director 2 guard when no Afterburner preamble is present. |
+| `0x0004`..`0x0007` | 4 bytes | Offset to the first frame payload relative to the start of the score stream. |
+| `0x0008`..`0x000B` | 4 bytes | Claimed frame count. Some projectors exaggerate this value, so implementations should recompute the true count while decoding. |
+| `0x000C`..`0x000D` | 2 bytes | Frame-format version. Values `0`–`7` map to Director 4–5, `8`–`13` to Director 6, and higher numbers to Director 7–9. |
+| `0x000E`..`0x000F` | 2 bytes | Sprite-channel record size in bytes. Used to step through sprite data within each frame. |
+| `0x0010`..`0x0011` | 2 bytes | Total sprite channels allocated in the score. |
+| `0x0012`..`0x0013` | 2 bytes | Displayed channel count. Director 5 defaults to 48 when zero, Director 6 to 120. Later versions provide an explicit value. |
+| `0x0014`..`0x0015` | 2 bytes | Reserved padding. Retained for compatibility; usually zero. |
+
+### Frame index (Director 6 and later)
+
+When the frame-format version is Director 6 or newer, the score keeps a frame index immediately
+before the frame payloads. Each entry contributes a start offset and the next frame’s start so the
+loader can compute the compressed size.
+
+| Bytes | Length | Description |
+| --- | --- | --- |
+| `entry*8+0x00`..`+0x03` | 4 bytes | Relative frame start. Add the base frame-data offset to reach the payload. |
+| `entry*8+0x04`..`+0x07` | 4 bytes | Next frame start. Subtract the previous start to obtain the compressed size for logging or validation. |
+
+## Frame payloads
+
+Each frame begins with a length word followed by channel descriptors. The descriptors identify which
+channels are present and how many bytes belong to each block.
+
+| Bytes | Length | Description |
+| --- | --- | --- |
+| `frame+0x0000`..`frame+0x0001` | 2 bytes | Frame payload size excluding the length word. The reader subtracts two and loops until all channel descriptors are consumed. |
+| `frame+0x0002`..`frame+0x0003` | 2 bytes | Channel count for the frame (main + sprite channels). |
+| `frame+0x0004`..`frame+0x0005` | 2 bytes | Offset of the first channel block relative to `frame+0x0002`. |
+| `frame+0x0006`.. | Variable | For each channel: 2-byte offset followed by a 2-byte size. Director 2–3 pack offsets and sizes into single bytes; later versions promote them to 16-bit values. |
+
+After the descriptor table, channel payloads are stored back-to-back. The loader slices the data into
+a main channel block and `numChannels` sprite blocks using the sizes announced above.
+
+## Channel dispatch by version
+
+Main-channel and sprite-channel sizes depend on the frame-format version stored in the header. The
+loader maps the version to the appropriate decoder using the table below.
+
+| Version range | Main channel bytes | Sprite channel bytes | Decoder hints |
+| --- | --- | --- | --- |
+| `< 0x400` | `0x20` (`kMainChannelSizeD2`) | `0x10` (`kSprChannelSizeD2`) | Director 2–3 records with signed colour bytes. |
+| `0x400–0x4FF` | `0x28` (`kMainChannelSizeD4`) | `0x14` (`kSprChannelSizeD4`) | Director 4 layout with colour chips and blend fields. |
+| `0x500–0x5FF` | `0x30` (`kMainChannelSizeD5`) | `0x18` (`kSprChannelSizeD5`) | Director 5 adds cast-library identifiers. |
+| `0x600–0x6FF` | `0x90` (`kMainChannelSizeD6`) | `0x18` (`kSprChannelSizeD6`) | Director 6 Afterburner records with sprite-detail pointers. |
+| `0x700–0x10FF` | `0x120` (`kMainChannelSizeD7`) | `0x30` (`kSprChannelSizeD7`) | Director 7–9 extend the Afterburner format with RGB triples and rotation/skew fields. |
+
+## Main channel layouts
+
+The main channel controls score-wide state: tempo, transitions, palette animation, and the IDs used
+for script or sound cast members. Tables below record every byte so the parser can update the runtime
+state precisely.
+
+### Director 2 main channel (`0x20` bytes)
+
+| Offset | Length | Description |
+| --- | --- | --- |
+| `0x00` | 1 byte | Frame-action cast member id. |
+| `0x01` | 1 byte | Sound type for `sound1` (0x17 = sampled, 0x16 = MIDI). |
+| `0x02` | 1 byte | Transition flags and duration. Bit 7 toggles whole-stage fades; low bits encode duration in quarter-seconds. |
+| `0x03` | 1 byte | Transition chunk size for wiped regions. |
+| `0x04` | 1 byte | Frame tempo. Cache values between 1 and 120 bpm. |
+| `0x05` | 1 byte | Transition type enumeration. |
+| `0x06`..`0x07` | 2 bytes | `sound1` cast member id. |
+| `0x08`..`0x09` | 2 bytes | `sound2` cast member id. |
+| `0x0A` | 1 byte | Sound type for `sound2`. |
+| `0x0B` | 1 byte | Skip-frame flag that forces tempo-based frame drops. |
+| `0x0C` | 1 byte | Transition blend amount. |
+| `0x0D` | 1 byte | Reserved byte logged when non-zero. |
+| `0x0E`..`0x0F` | 2 bytes | Reserved words. |
+| `0x10`..`0x11` | 2 bytes | Palette cast member id (signed; negative values reference external casts). |
+| `0x12` | 1 byte | Palette first colour index (signed QuickDraw byte converted with `(value + 128) & 0xFF`). |
+| `0x13` | 1 byte | Palette last colour index. |
+| `0x14` | 1 byte | Palette flags: cycling, auto-reverse, fade, overtime bits. |
+| `0x15` | 1 byte | Palette speed. |
+| `0x16`..`0x17` | 2 bytes | Palette frame count. |
+| `0x18`..`0x19` | 2 bytes | Palette cycle count. |
+| `0x1A`..`0x1F` | 6 bytes | Reserved palette bytes. |
+
+### Director 4 main channel (`0x28` bytes)
+
+| Offset | Length | Description |
+| --- | --- | --- |
+| `0x00` | 1 byte | Reserved byte; log unexpected values for diagnostics. |
+| `0x01` | 1 byte | Sound type for `sound1`. |
+| `0x02` | 1 byte | Transition flags and duration. |
+| `0x03` | 1 byte | Transition chunk size. |
+| `0x04` | 1 byte | Frame tempo (1–120 bpm cached). |
+| `0x05` | 1 byte | Transition type. |
+| `0x06`..`0x07` | 2 bytes | `sound1` cast member id. |
+| `0x08`..`0x09` | 2 bytes | `sound2` cast member id. |
+| `0x0A` | 1 byte | Sound type for `sound2`. |
+| `0x0B` | 1 byte | Skip-frame flag. |
+| `0x0C` | 1 byte | Transition blend. |
+| `0x0D` | 1 byte | Tempo channel colour chip. |
+| `0x0E` | 1 byte | Sound1 channel colour chip. |
+| `0x0F` | 1 byte | Sound2 channel colour chip. |
+| `0x10`..`0x11` | 2 bytes | Script action cast member id. |
+| `0x12` | 1 byte | Script channel colour chip. |
+| `0x13` | 1 byte | Transition channel colour chip. |
+| `0x14`..`0x25` | 18 bytes | Palette control block (cast id, cycling range, flags, timing, style, colour code). |
+| `0x26` | 1 byte | Reserved byte. |
+| `0x27`..`0x29` | 3 bytes | Reserved words/dword. |
+| `0x2A` | 1 byte | Palette colour-code (stage swatch index). |
+| `0x2B` | 1 byte | Reserved byte. |
+
+### Director 5 main channel (`0x30` bytes)
+
+| Offset | Length | Description |
+| --- | --- | --- |
+| `0x00`..`0x01` | 2 bytes | Script action cast-library id (signed). |
+| `0x02`..`0x03` | 2 bytes | Script action cast-member id. |
+| `0x04`..`0x05` | 2 bytes | Sound1 cast-library id. |
+| `0x06`..`0x07` | 2 bytes | Sound1 cast-member id. |
+| `0x08`..`0x09` | 2 bytes | Sound2 cast-library id. |
+| `0x0A`..`0x0B` | 2 bytes | Sound2 cast-member id. |
+| `0x0C`..`0x0D` | 2 bytes | Transition cast-library id. |
+| `0x0E`..`0x0F` | 2 bytes | Transition cast-member id. |
+| `0x10` | 1 byte | Tempo channel colour chip. |
+| `0x11` | 1 byte | Sound1 channel colour chip. |
+| `0x12` | 1 byte | Sound2 channel colour chip. |
+| `0x13` | 1 byte | Script channel colour chip. |
+| `0x14` | 1 byte | Transition channel colour chip. |
+| `0x15` | 1 byte | Frame tempo (cached 1–120 bpm). |
+| `0x16`..`0x17` | 2 bytes | Alignment padding; warn if non-zero. |
+| `0x18`..`0x19` | 2 bytes | Palette cast-library id (signed). |
+| `0x1A`..`0x1B` | 2 bytes | Palette cast-member id (signed). |
+| `0x1C` | 1 byte | Palette speed. |
+| `0x1D` | 1 byte | Palette flags (cycling, overtime, fade). |
+| `0x1E` | 1 byte | Palette first colour (Mac signed byte). |
+| `0x1F` | 1 byte | Palette last colour. |
+| `0x20`..`0x21` | 2 bytes | Palette frame count. |
+| `0x22`..`0x23` | 2 bytes | Palette cycle count. |
+| `0x24` | 1 byte | Palette fade target. |
+| `0x25` | 1 byte | Palette delay. |
+| `0x26` | 1 byte | Palette style. |
+| `0x27` | 1 byte | Palette colour-code. |
+| `0x28`..`0x2F` | 8 bytes | Reserved padding. |
+
+### Director 6 main channel (`0x90` bytes)
+
+Director 6 splits the header into six 24-byte blocks (script, tempo, transition, sound2, sound1,
+palette). Each block stores cast-library ids, sprite-detail pointers, colour chips, and alignment
+padding. Low-word shadows exist for delta updates that only modify the low 16 bits of a pointer.
+
+| Offset | Length | Description |
+| --- | --- | --- |
+| `0x00`..`0x01` | 2 bytes | Script action cast-library id. |
+| `0x02`..`0x03` | 2 bytes | Script action cast-member id. |
+| `0x04`..`0x07` | 4 bytes | Script sprite-detail index (32-bit). |
+| `0x06`..`0x07` | 2 bytes | Low-word shadow for the script detail index. |
+| `0x08` | 1 byte | Script channel colour chip. |
+| `0x09`..`0x17` | 15 bytes | Alignment padding for the script block. |
+| `0x18`..`0x19` | 2 bytes | Tempo cast-library id. |
+| `0x1A`..`0x1B` | 2 bytes | Tempo cast-member id. |
+| `0x1C`..`0x1F` | 4 bytes | Tempo sprite-detail index. |
+| `0x1E`..`0x1F` | 2 bytes | Low-word shadow for the tempo detail index. |
+| `0x20` | 1 byte | Tempo channel flags (`tempoD6Flags`). |
+| `0x21` | 1 byte | Tempo value cached for puppet tempo (1–120 bpm). |
+| `0x22` | 1 byte | Tempo channel colour chip. |
+| `0x23`..`0x2F` | 13 bytes | Alignment padding. |
+| `0x30`..`0x31` | 2 bytes | Transition cast-library id. |
+| `0x32`..`0x33` | 2 bytes | Transition cast-member id. |
+| `0x34`..`0x37` | 4 bytes | Transition sprite-detail index. |
+| `0x36`..`0x37` | 2 bytes | Low-word shadow for the transition detail index. |
+| `0x38` | 1 byte | Transition channel colour chip. |
+| `0x39`..`0x47` | 15 bytes | Alignment padding. |
+| `0x48`..`0x49` | 2 bytes | Sound2 cast-library id. |
+| `0x4A`..`0x4B` | 2 bytes | Sound2 cast-member id. |
+| `0x4C`..`0x4F` | 4 bytes | Sound2 sprite-detail index. |
+| `0x4E`..`0x4F` | 2 bytes | Low-word shadow for the sound2 detail index. |
+| `0x50` | 1 byte | Sound2 channel colour chip. |
+| `0x51`..`0x5F` | 15 bytes | Alignment padding. |
+| `0x60`..`0x61` | 2 bytes | Sound1 cast-library id. |
+| `0x62`..`0x63` | 2 bytes | Sound1 cast-member id. |
+| `0x64`..`0x67` | 4 bytes | Sound1 sprite-detail index. |
+| `0x66`..`0x67` | 2 bytes | Low-word shadow for the sound1 detail index. |
+| `0x68` | 1 byte | Sound1 channel colour chip. |
+| `0x69`..`0x77` | 15 bytes | Alignment padding. |
+| `0x78`..`0x79` | 2 bytes | Palette cast-library id (signed). |
+| `0x7A`..`0x7B` | 2 bytes | Palette cast-member id (signed). |
+| `0x7C` | 1 byte | Palette speed. |
+| `0x7D` | 1 byte | Palette flags (cycling/fade/overtime bits). |
+| `0x7E` | 1 byte | Palette first colour (Mac signed byte). |
+| `0x7F` | 1 byte | Palette last colour. |
+| `0x80`..`0x81` | 2 bytes | Palette frame count. |
+| `0x82`..`0x83` | 2 bytes | Palette cycle count. |
+| `0x84` | 1 byte | Palette fade value. |
+| `0x85` | 1 byte | Palette delay. |
+| `0x86` | 1 byte | Palette style selector. |
+| `0x87` | 1 byte | Palette colour code. |
+| `0x88`..`0x8B` | 4 bytes | Palette sprite-detail index. |
+| `0x8A`..`0x8B` | 2 bytes | Low-word shadow for the palette detail index. |
+| `0x8C`..`0x8F` | 4 bytes | Alignment padding. |
+
+### Director 7 main channel (`0x120` bytes)
+
+Director 7 doubles each block to 48 bytes, keeping the same order while expanding the padding. The
+field meanings mirror Director 6; only the offsets change. Each block still exposes cast ids,
+sprite-detail pointers, colour chips, and low-word shadows.
+
+| Offset | Length | Description |
+| --- | --- | --- |
+| `0x00`..`0x01` | 2 bytes | Script action cast-library id. |
+| `0x02`..`0x03` | 2 bytes | Script action cast-member id. |
+| `0x04`..`0x07` | 4 bytes | Script sprite-detail index. |
+| `0x06`..`0x07` | 2 bytes | Low-word shadow for the script detail index. |
+| `0x08` | 1 byte | Script channel colour chip. |
+| `0x09`..`0x2F` | 39 bytes | Alignment padding. |
+| `0x30`..`0x33` | 4 bytes | Tempo sprite-detail index. |
+| `0x32`..`0x33` | 2 bytes | Low-word shadow for the tempo detail index. |
+| `0x34`..`0x35` | 2 bytes | Tempo flags. |
+| `0x36` | 1 byte | Tempo value (1–120 bpm cached). |
+| `0x37` | 1 byte | Tempo channel colour chip. |
+| `0x38`..`0x5F` | 40 bytes | Alignment padding. |
+| `0x60`..`0x61` | 2 bytes | Transition cast-library id. |
+| `0x62`..`0x63` | 2 bytes | Transition cast-member id. |
+| `0x64`..`0x67` | 4 bytes | Transition sprite-detail index. |
+| `0x66`..`0x67` | 2 bytes | Low-word shadow for the transition detail index. |
+| `0x68` | 1 byte | Transition channel colour chip. |
+| `0x69`..`0x8F` | 39 bytes | Alignment padding. |
+| `0x90`..`0x91` | 2 bytes | Sound2 cast-library id. |
+| `0x92`..`0x93` | 2 bytes | Sound2 cast-member id. |
+| `0x94`..`0x97` | 4 bytes | Sound2 sprite-detail index. |
+| `0x96`..`0x97` | 2 bytes | Low-word shadow for the sound2 detail index. |
+| `0x98` | 1 byte | Sound2 channel colour chip. |
+| `0x99`..`0xBF` | 39 bytes | Alignment padding. |
+| `0xC0`..`0xC1` | 2 bytes | Sound1 cast-library id. |
+| `0xC2`..`0xC3` | 2 bytes | Sound1 cast-member id. |
+| `0xC4`..`0xC7` | 4 bytes | Sound1 sprite-detail index. |
+| `0xC6`..`0xC7` | 2 bytes | Low-word shadow for the sound1 detail index. |
+| `0xC8` | 1 byte | Sound1 channel colour chip. |
+| `0xC9`..`0xEF` | 39 bytes | Alignment padding. |
+| `0xF0`..`0xF1` | 2 bytes | Palette cast-library id (signed). |
+| `0xF2`..`0xF3` | 2 bytes | Palette cast-member id (signed). |
+| `0xF4` | 1 byte | Palette speed. |
+| `0xF5` | 1 byte | Palette flags. |
+| `0xF6` | 1 byte | Palette first colour. |
+| `0xF7` | 1 byte | Palette last colour. |
+| `0xF8`..`0xF9` | 2 bytes | Palette frame count. |
+| `0xFA`..`0xFB` | 2 bytes | Palette cycle count. |
+| `0xFC` | 1 byte | Palette fade value. |
+| `0xFD` | 1 byte | Palette delay. |
+| `0xFE` | 1 byte | Palette style selector. |
+| `0xFF` | 1 byte | Palette colour code. |
+| `0x100`..`0x103` | 4 bytes | Palette sprite-detail index. |
+| `0x102`..`0x103` | 2 bytes | Low-word shadow for the palette detail index. |
+| `0x104`..`0x11F` | 28 bytes | Alignment padding. |
+
+## Sprite channel layouts
+
+Sprite channels describe on-stage cast members. Puppet control suppresses updates to individual
+fields; when a flag is set, the loader keeps the previous value instead of applying the new bytes.
+
+### Director 2 sprite channel (`0x10` bytes)
+
+| Offset | Length | Description |
+| --- | --- | --- |
+| `0x00` | 1 byte | Script cast-member id. |
+| `0x01` | 1 byte | Sprite type (0 = inactive). Puppet sprites skip the update. |
+| `0x02` | 1 byte | Foreground colour (signed byte converted with `(value + 128) & 0xFF`). Puppet sprites keep the prior colour. |
+| `0x03` | 1 byte | Background colour (signed). |
+| `0x04` | 1 byte | Line thickness (upper bit cleared). |
+| `0x05` | 1 byte | Ink flags: low six bits ink mode, bit 6 trails, bit 7 stretch. |
+| `0x06`..`0x07` | 2 bytes | Cast member id or QuickDraw pattern id for shapes. Puppet sprites skip the update. |
+| `0x08`..`0x09` | 2 bytes | Top coordinate. |
+| `0x0A`..`0x0B` | 2 bytes | Left coordinate. |
+| `0x0C`..`0x0D` | 2 bytes | Height in pixels. |
+| `0x0E`..`0x0F` | 2 bytes | Width in pixels. Negative or zero values collapse the sprite. |
+
+### Director 4 sprite channel (`0x14` bytes)
+
+| Offset | Length | Description |
+| --- | --- | --- |
+| `0x00` | 1 byte | Script cast-member id. |
+| `0x01` | 1 byte | Sprite type (puppet-aware). |
+| `0x02` | 1 byte | Foreground colour (0–255). Puppet sprites keep previous colour. |
+| `0x03` | 1 byte | Background colour. |
+| `0x04` | 1 byte | Thickness. |
+| `0x05` | 1 byte | Ink flags (mode/trails/stretch). |
+| `0x06`..`0x07` | 2 bytes | Cast member id or QuickDraw pattern. |
+| `0x08`..`0x09` | 2 bytes | Top coordinate. |
+| `0x0A`..`0x0B` | 2 bytes | Left coordinate. |
+| `0x0C`..`0x0D` | 2 bytes | Height. |
+| `0x0E`..`0x0F` | 2 bytes | Width. |
+| `0x10`..`0x11` | 2 bytes | Script id (16-bit) reused for behaviour dispatch. |
+| `0x12` | 1 byte | Colour-code flags: low nibble stage colour, bit 6 editable, bit 7 moveable. |
+| `0x13` | 1 byte | Blend amount for inks with opacity. |
+
+### Director 5 sprite channel (`0x18` bytes)
+
+| Offset | Length | Description |
+| --- | --- | --- |
+| `0x00` | 1 byte | Sprite type (puppet-aware). |
+| `0x01` | 1 byte | Ink flags. |
+| `0x02`..`0x03` | 2 bytes | Cast-library id (signed). Puppet sprites keep previous value. |
+| `0x04`..`0x05` | 2 bytes | Cast-member id. |
+| `0x06`..`0x07` | 2 bytes | Script cast-library id. |
+| `0x08`..`0x09` | 2 bytes | Script cast-member id. |
+| `0x0A` | 1 byte | Foreground colour. |
+| `0x0B` | 1 byte | Background colour. |
+| `0x0C`..`0x0D` | 2 bytes | Top coordinate. |
+| `0x0E`..`0x0F` | 2 bytes | Left coordinate. |
+| `0x10`..`0x11` | 2 bytes | Height. |
+| `0x12`..`0x13` | 2 bytes | Width. |
+| `0x14` | 1 byte | Colour-code flags (editable, moveable, RGB hints). |
+| `0x15` | 1 byte | Blend amount. |
+| `0x16` | 1 byte | Thickness. |
+| `0x17` | 1 byte | Reserved padding. |
+
+### Director 6 sprite channel (`0x18` bytes)
+
+Afterburner sprite records reuse the 24-byte footprint but replace the early words with sprite-detail
+pointers. Auto-puppet flags suppress updates for individual fields.
+
+| Offset | Length | Description |
+| --- | --- | --- |
+| `0x00` | 1 byte | Sprite type (puppet-aware). |
+| `0x01` | 1 byte | Ink flags (auto-puppet aware). |
+| `0x02` | 1 byte | Foreground colour (skipped when auto-puppet fore-colour is set). |
+| `0x03` | 1 byte | Background colour (auto-puppet aware). |
+| `0x04`..`0x05` | 2 bytes | Cast-library id (skipped when puppet or auto-puppet-cast is active). |
+| `0x06`..`0x07` | 2 bytes | Cast-member id. |
+| `0x08`..`0x0B` | 4 bytes | Primary sprite-detail index. |
+| `0x0C`..`0x0D` | 2 bytes | Low-word shadow for the detail index. |
+| `0x0E`..`0x0F` | 2 bytes | Top coordinate (auto-puppet location aware). |
+| `0x10`..`0x11` | 2 bytes | Left coordinate. |
+| `0x12`..`0x13` | 2 bytes | Height (auto-puppet aware). |
+| `0x14`..`0x15` | 2 bytes | Width (auto-puppet aware). |
+| `0x16` | 1 byte | Colour-code flags (skipped when auto-puppet moveable is set). |
+| `0x17` | 1 byte | Blend amount (skipped for puppet sprites). |
+| `0x18` | 1 byte | Thickness (skipped for puppet sprites). |
+| `0x19` | 1 byte | Reserved padding. |
+
+### Director 7 sprite channel (`0x30` bytes)
+
+Director 7 doubles the record and introduces per-channel RGB components, rotation, skew, and a sprite
+flag byte. Auto-puppet suppression still applies to the same fields as Director 6.
+
+| Offset | Length | Description |
+| --- | --- | --- |
+| `0x00` | 1 byte | Sprite type (auto-puppet aware). |
+| `0x01` | 1 byte | Ink flags. |
+| `0x02` | 1 byte | Foreground colour (auto-puppet aware). |
+| `0x03` | 1 byte | Background colour. |
+| `0x04`..`0x05` | 2 bytes | Cast-library id (auto-puppet aware). |
+| `0x06`..`0x07` | 2 bytes | Cast-member id. |
+| `0x08`..`0x0B` | 4 bytes | Sprite-detail index. |
+| `0x0C`..`0x0D` | 2 bytes | Low-word shadow for the detail index. |
+| `0x0E`..`0x0F` | 2 bytes | Top coordinate (auto-puppet aware). |
+| `0x10`..`0x11` | 2 bytes | Left coordinate. |
+| `0x12`..`0x13` | 2 bytes | Height. |
+| `0x14`..`0x15` | 2 bytes | Width. |
+| `0x16` | 1 byte | Colour-code flags. |
+| `0x17` | 1 byte | Blend amount. |
+| `0x18` | 1 byte | Thickness. |
+| `0x19` | 1 byte | Sprite flags (Director 7+ specific). |
+| `0x1A` | 1 byte | Foreground green component (auto-puppet aware). |
+| `0x1B` | 1 byte | Background green component. |
+| `0x1C` | 1 byte | Foreground blue component. |
+| `0x1D` | 1 byte | Background blue component. |
+| `0x1E`..`0x21` | 4 bytes | Rotation angle in fixed-point units. |
+| `0x22`..`0x23` | 2 bytes | Lower half of the rotation word (used by some projectors). |
+| `0x24`..`0x27` | 4 bytes | Skew angle. |
+| `0x28`..`0x2F` | 8 bytes | Reserved padding. |
+
+## Sprite detail lookups (Director 6+)
+
+Any sprite channel with a non-zero detail index resolves three adjacent records in the Afterburner
+detail list:
+
+| Entry | Description |
+| --- | --- |
+| `index` | `SpriteInfo` structure with behaviours, initialisation flags, and bounding boxes. |
+| `index + 1` | Behaviour list describing scripts attached to the sprite. |
+| `index + 2` | Pascal-style sprite name string. |
+
+Offsets are read from the detail pointer table described earlier. Each pointer is added to the base
+detail offset to locate the record.
+
+## Label stream (`VWLB`)
+
+Labels use a packed table followed by CR-delimited UTF-8 strings. The first tuple stores the base
+offset for the string block.
+
+| Bytes | Length | Description |
+| --- | --- | --- |
+| `0x0000`..`0x0001` | 2 bytes | `countMinusOne`; add one to obtain the number of label entries. |
+| `0x0002`..`0x0003` | 2 bytes | Base offset: `count * 4 + 2`. Subsequent offsets are relative to this value. |
+| `0x0004`..`0x0005` | 2 bytes | Frame number of the first label. |
+| `0x0006`..`0x0007` | 2 bytes | String offset of the first label. |
+| `0x0008`.. | `count * 4` bytes | Frame number and string offset pairs for remaining labels. |
+| `strings` | Variable | CR-terminated label text and optional comment text stored sequentially. |
+
+## Action stream (`VWAC`)
+
+Frame actions reuse the same packed-table scheme as labels but include id/sub-id pairs.
+
+| Bytes | Length | Description |
+| --- | --- | --- |
+| `0x0000`..`0x0001` | 2 bytes | `countMinusOne`; plus one yields the number of action entries. |
+| `0x0002`..`0x0003` | 2 bytes | Base offset: `count * 4 + 2`. |
+| `0x0004` | 1 byte | Initial action id. |
+| `0x0005` | 1 byte | Initial sub-id (for grouping related scripts). |
+| `0x0006`..`0x0007` | 2 bytes | Offset of the first action script relative to the base. |
+| `0x0008`.. | `count * 4` bytes | Repeated id, sub-id, and offset tuples for additional entries. |
+| `strings` | Variable | Script text stored as length-prefixed strings that should be decoded using the movie’s encoding table. |
+
+## Rendering workflow
+
+A renderer that targets Director 2–9 can follow the sequence below:
+
+1. **Inflate and parse headers:** Load the `VWSC` stream, decompress if necessary, and record the
+   version, channel sizes, and frame index.
+2. **Preload detail tables:** For Director 6+, capture the Afterburner detail pointers so sprite
+   channels can resolve behaviours and names on demand.
+3. **Iterate frames:** For each frame request, read the payload size, walk the channel descriptors,
+   and slice the main/sprite blocks according to the version-specific sizes.
+4. **Apply the main channel:** Update tempo, palette animation, transition state, and control-channel
+   cast IDs directly from the main channel layout for the current version.
+5. **Update sprite channels:** For each sprite block, honour puppet and auto-puppet flags, then apply
+   geometry, ink, colour, and cast references. When a detail index is present, resolve sprite info,
+   behaviours, and names through the detail list.
+6. **Process labels and actions:** Load the optional `VWLB` and `VWAC` streams to attach frame labels
+   and frame-action scripts. Both use packed offset tables guarded by the same `countMinusOne`
+   convention.
+7. **Render the stage:** Once the runtime state is updated, draw sprites in channel order using the
+   ink mode, blend, colour, and geometry recorded above. Puppet sprites keep their prior values when
+   the frame omits an update, so the renderer must cache previous state.
+
+These rules preserve byte-for-byte compatibility with legacy Director projectors through Director 9.
+Future work on Director 10+ should extend the [template](Director10PlusScoreTemplate.md) with the
+same level of detail once sample files are available.

--- a/src/BlingoEngine.IO.Legacy/docs/README.md
+++ b/src/BlingoEngine.IO.Legacy/docs/README.md
@@ -10,4 +10,6 @@ These notes summarize the on-disk formats handled by `BlingoEngine.IO.Legacy`. T
 - [Legacy Sound Loading](./LegacySoundLoading.md)
 - [Legacy Script Cast Members](./LegacyScriptMembers.md)
 - [QuickDraw Shape Records](./LegacyShapeRecords.md) – Byte layouts for legacy shape cast members across Director releases.
+- [Director Score Timeline (Pre-10)](./LegacyScorePre10.md)
+- [Director 10+ Score Layout](./Director10PlusScoreTemplate.md)
 


### PR DESCRIPTION
## Summary
- expand the Director 10+ score template into a comprehensive reference covering headers, nested blocks, sprite records, and timeline decoding
- fold in the ProjectorRays keyframe tag research, including composite payload layouts, tween metadata, channel selectors, and range hypotheses
- document sample header values, frame-advance flag bits, and sprite-level tween workflows so new implementations can render the stream end to end

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d0dbba5b3483328dd70f269d1d453d