### PR TITLE
Refactor legacy handler converter helpers and expand coverage

### DIFF
--- a/Test/BlingoEngine.Legacy.Lingo.Tests/BlLegacyClassGeneratorTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/BlLegacyClassGeneratorTests.cs
@@ -1,0 +1,74 @@
+using BlingoEngine.Legacy.Lingo.Analysis;
+using BlingoEngine.Legacy.Lingo.CodeGen;
+using Xunit;
+
+namespace BlingoEngine.Legacy.Lingo.Tests;
+
+public sealed class BlLegacyClassGeneratorTests
+{
+    private readonly BlLegacyClassGenerator _generator = new();
+
+    [Fact]
+    public void BehaviorScript_IncludesEnvironmentConstructor()
+    {
+        var code = _generator.GenerateClass("MyBehavior", string.Empty, BlLingoScriptKind.Behavior);
+        Assert.Contains("public class MyBehaviorBehavior : BlingoSpriteBehavior", code);
+        Assert.Contains("public MyBehaviorBehavior(IBlingoMovieEnvironment env) : base(env) { }", code);
+    }
+
+    [Fact]
+    public void ParentScript_IncludesGlobalFieldAndConstructor()
+    {
+        var code = _generator.GenerateClass("MyParent", string.Empty, BlLingoScriptKind.Parent);
+        Assert.Contains("private readonly GlobalVars _global;", code);
+        Assert.Contains("public MyParentParent(IBlingoMovieEnvironment env, GlobalVars global) : base(env)", code);
+        Assert.Contains("_global = global;", code);
+    }
+
+    [Fact]
+    public void PropertyDescriptionList_AddsInterface()
+    {
+        const string source = "on getPropertyDescriptionList\nend";
+        var code = _generator.GenerateClass("MyBehavior", source, BlLingoScriptKind.Behavior);
+        Assert.Contains(
+            "public class MyBehaviorBehavior : BlingoSpriteBehavior, IBlingoPropertyDescriptionList",
+            code);
+        Assert.Contains("public BehaviorPropertyDescriptionList? GetPropertyDescriptionList()", code);
+    }
+
+    [Fact]
+    public void EventHandler_AddsEventInterface()
+    {
+        const string source = "on beginSprite me\nend";
+        var code = _generator.GenerateClass("MyBehavior", source, BlLingoScriptKind.Behavior);
+        Assert.Contains("IHasBeginSpriteEvent", code);
+    }
+
+    [Fact]
+    public void CustomSuffixes_AreApplied()
+    {
+        var options = new BlLegacyClassGeneratorOptions
+        {
+            BehaviorSuffix = "Beh",
+            ParentSuffix = "Par",
+            MovieScriptSuffix = "Movie",
+            ScriptSuffix = "Script",
+        };
+
+        var generator = new BlLegacyClassGenerator(options);
+        var code = generator.GenerateClass("MyBehavior", string.Empty, BlLingoScriptKind.Behavior);
+        Assert.Contains("public class MyBehaviorBeh : BlingoSpriteBehavior", code);
+    }
+
+    [Fact]
+    public void Handler_IsConvertedToMethod()
+    {
+        const string source = "on mouseUp me, btn\n  put 1 into value\nend";
+        var code = _generator.GenerateClass("MyBehavior", source, BlLingoScriptKind.Behavior);
+
+        Assert.Contains("public void MouseUp(object? btn)", code);
+        Assert.DoesNotContain("object? me", code);
+        Assert.Contains("value = 1;", code);
+    }
+
+}

--- a/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerActorListTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerActorListTests.cs
@@ -1,0 +1,32 @@
+using Xunit;
+
+namespace BlingoEngine.Legacy.Lingo.Tests;
+
+public sealed class LegacyHandlerActorListTests : LegacyHandlerTestBase
+{
+    [Fact]
+    public void ActorListAppend_AddsToMovieList()
+    {
+        const string source = """
+on test
+  the actorList.append(me)
+end
+""";
+
+        var code = GenerateBehavior(source);
+        Assert.Contains("_Movie.ActorList.Add(this);", code);
+    }
+
+    [Fact]
+    public void ActorListDeleteOne_RemovesFromMovieList()
+    {
+        const string source = """
+on test
+  the actorList.deleteOne(me)
+end
+""";
+
+        var code = GenerateBehavior(source);
+        Assert.Contains("_Movie.ActorList.Remove(this);", code);
+    }
+}

--- a/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerConditionalTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerConditionalTests.cs
@@ -1,0 +1,70 @@
+using Xunit;
+
+namespace BlingoEngine.Legacy.Lingo.Tests;
+
+public sealed class LegacyHandlerConditionalTests : LegacyHandlerTestBase
+{
+    [Fact]
+    public void IfThenElse_TranslatesComparison()
+    {
+        const string source = """
+on test
+  if a <> b then
+    put 1 into value
+  else
+    put 0 into value
+  end if
+end
+""";
+
+        var code = GenerateBehavior(source);
+        Assert.Contains("if (a != b)", code);
+        Assert.Contains("value = 1;", code);
+        Assert.Contains("value = 0;", code);
+    }
+
+    [Fact]
+    public void ElseIf_BecomesElseIf()
+    {
+        const string source = """
+on test
+  if a > 10 then
+    put 1 into value
+  else if a < 5 then
+    put 2 into value
+  else
+    put 3 into value
+  end if
+end
+""";
+
+        var code = GenerateBehavior(source);
+        Assert.Contains("if (a > 10)", code);
+        Assert.Contains("else if (a <5)", code);
+        Assert.Contains("value = 3;", code);
+    }
+
+    [Fact]
+    public void CaseStatement_TranslatesToSwitch()
+    {
+        const string source = """
+on test
+  case state of
+    when 1
+      put 1 into value
+    when 2
+      put 2 into value
+    otherwise
+      put void into value
+  end case
+end
+""";
+
+        var code = GenerateBehavior(source);
+        Assert.Contains("switch (state)", code);
+        Assert.Contains("case 1:", code);
+        Assert.Contains("case 2:", code);
+        Assert.Contains("default:", code);
+        Assert.Contains("value = null;", code);
+    }
+}

--- a/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerLoopTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerLoopTests.cs
@@ -1,0 +1,63 @@
+using Xunit;
+
+namespace BlingoEngine.Legacy.Lingo.Tests;
+
+public sealed class LegacyHandlerLoopTests : LegacyHandlerTestBase
+{
+    [Fact]
+    public void RepeatWhile_TranslatesToWhileLoop()
+    {
+        const string source = """
+on test
+  repeat while cond
+end repeat
+end
+""";
+
+        var code = GenerateBehavior(source);
+        Assert.Contains("while (cond)", code);
+    }
+
+    [Fact]
+    public void RepeatUntil_TranslatesToDoWhileLoop()
+    {
+        const string source = """
+on test
+  repeat until done
+end repeat
+end
+""";
+
+        var code = GenerateBehavior(source);
+        Assert.Contains("do", code);
+        Assert.Contains("} while (!(done));", code);
+    }
+
+    [Fact]
+    public void RepeatWithIn_TranslatesToForeachLoop()
+    {
+        const string source = """
+on test
+  repeat with item in list
+end repeat
+end
+""";
+
+        var code = GenerateBehavior(source);
+        Assert.Contains("foreach (var item in list)", code);
+    }
+
+    [Fact]
+    public void RepeatWithRange_TranslatesToForLoop()
+    {
+        const string source = """
+on test
+  repeat with i = 1 to count
+end repeat
+end
+""";
+
+        var code = GenerateBehavior(source);
+        Assert.Contains("for (int i = 1; i <= count; i++)", code);
+    }
+}

--- a/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerMemberTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerMemberTests.cs
@@ -1,0 +1,45 @@
+using Xunit;
+
+namespace BlingoEngine.Legacy.Lingo.Tests;
+
+public sealed class LegacyHandlerMemberTests : LegacyHandlerTestBase
+{
+    [Fact]
+    public void SpriteMemberAssignment_UsesSetMember()
+    {
+        const string source = """
+on test
+  sprite(2).member = member("Name")
+end
+""";
+
+        var code = GenerateBehavior(source);
+        Assert.Contains("Sprite(2).SetMember(\"Name\");", code);
+    }
+
+    [Fact]
+    public void SpriteMemberAssignment_WithCastLibKeepsArguments()
+    {
+        const string source = """
+on test
+  sprite(3).member = member("Title", "CastLib")
+end
+""";
+
+        var code = GenerateBehavior(source);
+        Assert.Contains("Sprite(3).SetMember(\"Title\", \"CastLib\");", code);
+    }
+
+    [Fact]
+    public void PutMemberAssignment_UsesSetMember()
+    {
+        const string source = """
+on test
+  put member("Marker") into sprite(4).member
+end
+""";
+
+        var code = GenerateBehavior(source);
+        Assert.Contains("Sprite(4).SetMember(\"Marker\");", code);
+    }
+}

--- a/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerPutTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerPutTests.cs
@@ -1,0 +1,58 @@
+using Xunit;
+
+namespace BlingoEngine.Legacy.Lingo.Tests;
+
+public sealed class LegacyHandlerPutTests : LegacyHandlerTestBase
+{
+    [Fact]
+    public void PutIntoVariable_AssignsValue()
+    {
+        const string source = """
+on test
+  put 42 into answer
+end
+""";
+
+        var code = GenerateBehavior(source);
+        Assert.Contains("answer = 42;", code);
+    }
+
+    [Fact]
+    public void PutIntoField_UsesHelper()
+    {
+        const string source = """
+on test
+  put "Hi" into field "Greeting"
+end
+""";
+
+        var code = GenerateBehavior(source);
+        Assert.Contains("PutTextIntoField(\"Greeting\", \"Hi\");", code);
+    }
+
+    [Fact]
+    public void PutIntoSpriteProperty_AssignsProperty()
+    {
+        const string source = """
+on test
+  put 100 into sprite(3).locH
+end
+""";
+
+        var code = GenerateBehavior(source);
+        Assert.Contains("Sprite(3).LocH = 100;", code);
+    }
+
+    [Fact]
+    public void PutIntoListIndex_UsesSetAt()
+    {
+        const string source = """
+on test
+  put 7 into myList[2]
+end
+""";
+
+        var code = GenerateBehavior(source);
+        Assert.Contains("myList.SetAt(2, 7);", code);
+    }
+}

--- a/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerTestBase.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerTestBase.cs
@@ -1,0 +1,13 @@
+using BlingoEngine.Legacy.Lingo.Analysis;
+using BlingoEngine.Legacy.Lingo.CodeGen;
+
+namespace BlingoEngine.Legacy.Lingo.Tests;
+
+public abstract class LegacyHandlerTestBase
+{
+    protected static string GenerateBehavior(string handlerSource)
+    {
+        var generator = new BlLegacyClassGenerator();
+        return generator.GenerateClass("TestScript", handlerSource, BlLingoScriptKind.Behavior);
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/ActorListAppendVisitor.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/ActorListAppendVisitor.cs
@@ -1,0 +1,43 @@
+using BlingoEngine.Legacy.Lingo.Syntax;
+
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class ActorListAppendVisitor : IHandlerTokenVisitor
+{
+    public bool TryHandle(HandlerTokenEmitContext context)
+    {
+        var tokens = context.Tokens;
+        if (tokens.Count < 6)
+        {
+            return false;
+        }
+
+        if (!BlLegacyHandlerTokenUtilities.IsKeyword(tokens[0], "the") ||
+            !BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[1], "actorList"))
+        {
+            return false;
+        }
+
+        if (tokens[2].Kind != BlSyntaxKind.PeriodToken ||
+            !BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[3], "append"))
+        {
+            return false;
+        }
+
+        if (tokens[4].Kind != BlSyntaxKind.LeftParenthesisToken)
+        {
+            return false;
+        }
+
+        var closeIndex = BlLegacyHandlerTokenUtilities.FindMatchingToken(tokens, 4, BlSyntaxKind.LeftParenthesisToken, BlSyntaxKind.RightParenthesisToken);
+        if (closeIndex < 0)
+        {
+            return false;
+        }
+
+        var argumentTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, 5, closeIndex - 5);
+        var argument = context.ConvertExpression(argumentTokens);
+        context.Writer.WriteLine($"_Movie.ActorList.Add({argument});");
+        return true;
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/ActorListRemoveVisitor.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/ActorListRemoveVisitor.cs
@@ -1,0 +1,48 @@
+using BlingoEngine.Legacy.Lingo.Syntax;
+
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class ActorListRemoveVisitor : IHandlerTokenVisitor
+{
+    public bool TryHandle(HandlerTokenEmitContext context)
+    {
+        var tokens = context.Tokens;
+        if (tokens.Count < 6)
+        {
+            return false;
+        }
+
+        if (!BlLegacyHandlerTokenUtilities.IsKeyword(tokens[0], "the") ||
+            !BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[1], "actorList"))
+        {
+            return false;
+        }
+
+        if (tokens[2].Kind != BlSyntaxKind.PeriodToken)
+        {
+            return false;
+        }
+
+        if (!(BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[3], "deleteOne") ||
+              BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[3], "delete")))
+        {
+            return false;
+        }
+
+        if (tokens[4].Kind != BlSyntaxKind.LeftParenthesisToken)
+        {
+            return false;
+        }
+
+        var closeIndex = BlLegacyHandlerTokenUtilities.FindMatchingToken(tokens, 4, BlSyntaxKind.LeftParenthesisToken, BlSyntaxKind.RightParenthesisToken);
+        if (closeIndex < 0)
+        {
+            return false;
+        }
+
+        var argumentTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, 5, closeIndex - 5);
+        var argument = context.ConvertExpression(argumentTokens);
+        context.Writer.WriteLine($"_Movie.ActorList.Remove({argument});");
+        return true;
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlCSharpCodeWriter.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlCSharpCodeWriter.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+/// <summary>
+/// Provides helpers to generate C# source text with deterministic indentation.
+/// </summary>
+public sealed class BlCSharpCodeWriter
+{
+    private readonly StringBuilder _builder = new();
+    private readonly string _lineEnding;
+    private readonly string _indentation;
+    private int _indentationLevel;
+    private bool _requiresIndentation = true;
+    private int _lineLength;
+
+    /// <summary>
+    /// Gets the number of indentation levels currently applied.
+    /// </summary>
+    public int IndentationLevel => _indentationLevel;
+
+    /// <summary>
+    /// Gets the number of characters written on the current line.
+    /// </summary>
+    public int LineLength => _lineLength;
+
+    /// <summary>
+    /// Gets a value indicating whether the writer is positioned at the beginning of a line.
+    /// </summary>
+    public bool IsAtLineStart => _requiresIndentation;
+
+    /// <summary>
+    /// Gets the total number of characters written to the buffer.
+    /// </summary>
+    public int Length => _builder.Length;
+
+    /// <summary>
+    /// Initializes a new <see cref="BlCSharpCodeWriter"/> instance.
+    /// </summary>
+    /// <param name="lineEnding">The line ending to use when emitting new lines. Defaults to <see cref="Environment.NewLine"/>.</param>
+    /// <param name="indentation">The indentation string used for each indentation level. Defaults to four spaces.</param>
+    public BlCSharpCodeWriter(string? lineEnding = null, string? indentation = null)
+    {
+        _lineEnding = lineEnding ?? Environment.NewLine;
+        _indentation = string.IsNullOrEmpty(indentation) ? "    " : indentation;
+    }
+
+    /// <summary>
+    /// Clears the underlying buffer and resets indentation state.
+    /// </summary>
+    public void Clear()
+    {
+        _builder.Clear();
+        _indentationLevel = 0;
+        _requiresIndentation = true;
+        _lineLength = 0;
+    }
+
+    /// <summary>
+    /// Writes the specified text without appending a trailing newline.
+    /// </summary>
+    public void Write(string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+
+        EnsureIndentation();
+        _builder.Append(text);
+        _lineLength += text.Length;
+    }
+
+    /// <summary>
+    /// Writes a single character without appending a trailing newline.
+    /// </summary>
+    public void Write(char ch)
+    {
+        EnsureIndentation();
+        _builder.Append(ch);
+        _lineLength++;
+    }
+
+    /// <summary>
+    /// Writes the specified text followed by the configured line ending.
+    /// </summary>
+    public void WriteLine(string? text)
+    {
+        if (!string.IsNullOrEmpty(text))
+        {
+            Write(text);
+        }
+
+        _builder.Append(_lineEnding);
+        _requiresIndentation = true;
+        _lineLength = 0;
+    }
+
+    /// <summary>
+    /// Writes an empty line.
+    /// </summary>
+    public void WriteLine() => WriteLine(null);
+
+    /// <summary>
+    /// Writes a delimited list of values using the provided callback for each item.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements to emit.</typeparam>
+    /// <param name="values">The elements to write.</param>
+    /// <param name="writer">Callback invoked for each element.</param>
+    /// <param name="separator">The separator inserted between elements. Defaults to ", ".</param>
+    public void WriteSeparated<T>(IEnumerable<T> values, Action<BlCSharpCodeWriter, T> writer, string separator = ", ")
+    {
+        if (values is null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+
+        if (writer is null)
+        {
+            throw new ArgumentNullException(nameof(writer));
+        }
+
+        using var enumerator = values.GetEnumerator();
+        if (!enumerator.MoveNext())
+        {
+            return;
+        }
+
+        writer(this, enumerator.Current);
+
+        while (enumerator.MoveNext())
+        {
+            Write(separator);
+            writer(this, enumerator.Current);
+        }
+    }
+
+    /// <summary>
+    /// Increases the indentation level for subsequent writes.
+    /// </summary>
+    public void Indent() => _indentationLevel++;
+
+    /// <summary>
+    /// Decreases the indentation level for subsequent writes.
+    /// </summary>
+    public void Unindent()
+    {
+        if (_indentationLevel == 0)
+        {
+            return;
+        }
+
+        _indentationLevel--;
+    }
+
+    /// <summary>
+    /// Creates a scope that increases indentation while the returned object is alive.
+    /// </summary>
+    public IDisposable IndentScope()
+    {
+        Indent();
+        return new IndentationScope(this);
+    }
+
+    /// <summary>
+    /// Writes a code block using braces, indenting the body produced by the provided callback.
+    /// </summary>
+    /// <param name="header">Optional header written before the opening brace.</param>
+    /// <param name="body">Callback responsible for writing the content inside the block.</param>
+    public void WriteBlock(string? header, Action<BlCSharpCodeWriter> body)
+    {
+        if (body is null)
+        {
+            throw new ArgumentNullException(nameof(body));
+        }
+
+        if (!string.IsNullOrEmpty(header))
+        {
+            WriteLine(header);
+        }
+
+        WriteLine("{");
+        using (IndentScope())
+        {
+            body(this);
+        }
+
+        WriteLine("}");
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => _builder.ToString();
+
+    private void EnsureIndentation()
+    {
+        if (!_requiresIndentation)
+        {
+            return;
+        }
+
+        for (var i = 0; i < _indentationLevel; i++)
+        {
+            _builder.Append(_indentation);
+        }
+
+        _requiresIndentation = false;
+        _lineLength = _indentationLevel * _indentation.Length;
+    }
+
+    private sealed class IndentationScope : IDisposable
+    {
+        private readonly BlCSharpCodeWriter _writer;
+        private bool _disposed;
+
+        public IndentationScope(BlCSharpCodeWriter writer)
+        {
+            _writer = writer;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _writer.Unindent();
+            _disposed = true;
+        }
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlCSharpName.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlCSharpName.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Text;
+using BlingoEngine.Legacy.Lingo.Analysis;
+
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+/// <summary>
+/// Provides helper routines for composing valid C# identifiers from Lingo script names.
+/// </summary>
+internal static class BlCSharpName
+{
+    /// <summary>
+    /// Produces a sanitized script name without the common "_ls" suffix.
+    /// </summary>
+    public static string NormalizeScriptName(string name)
+    {
+        var sanitized = SanitizeIdentifier(name);
+        return sanitized.EndsWith("_ls", StringComparison.OrdinalIgnoreCase)
+            ? sanitized[..^3]
+            : sanitized;
+    }
+
+    /// <summary>
+    /// Composes the final class name using the supplied script name and detected script kind.
+    /// </summary>
+    public static string ComposeClassName(string name, BlLingoScriptKind kind, BlLegacyClassGeneratorOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var baseName = NormalizeScriptName(name);
+        var suffix = kind switch
+        {
+            BlLingoScriptKind.Movie => options.MovieScriptSuffix,
+            BlLingoScriptKind.Parent => options.ParentSuffix,
+            BlLingoScriptKind.Behavior => options.BehaviorSuffix,
+            _ => options.ScriptSuffix,
+        };
+        return string.IsNullOrEmpty(suffix) ? baseName : baseName + suffix;
+    }
+
+    internal static string SanitizeIdentifier(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return "Script";
+        }
+
+        var builder = new StringBuilder(name.Length);
+        foreach (var ch in name)
+        {
+            builder.Append(char.IsLetterOrDigit(ch) || ch == '_' ? ch : '_');
+        }
+
+        var index = 0;
+        while (index < builder.Length && !(char.IsLetter(builder[index]) || builder[index] == '_'))
+        {
+            index++;
+        }
+
+        if (index > 0)
+        {
+            builder.Remove(0, index);
+        }
+
+        if (builder.Length == 0)
+        {
+            return "Script";
+        }
+
+        if (char.IsDigit(builder[0]))
+        {
+            builder.Insert(0, 'S');
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyClassGenerator.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyClassGenerator.cs
@@ -1,0 +1,338 @@
+using System;
+using System.Collections.Generic;
+using BlingoEngine.Legacy.Lingo.Analysis;
+using BlingoEngine.Legacy.Lingo.Syntax;
+
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+/// <summary>
+/// Generates C# class skeletons for legacy Lingo scripts using analysis metadata.
+/// </summary>
+public sealed class BlLegacyClassGenerator
+{
+    private static readonly (string Handler, string Interface)[] s_eventInterfaces =
+    [
+        ("blur", "IHasBlurEvent"),
+        ("focus", "IHasFocusEvent"),
+        ("keydown", "IHasKeyDownEvent"),
+        ("keyup", "IHasKeyUpEvent"),
+        ("mousewithin", "IHasMouseWithinEvent"),
+        ("mouseleave", "IHasMouseLeaveEvent"),
+        ("mousedown", "IHasMouseDownEvent"),
+        ("mouseup", "IHasMouseUpEvent"),
+        ("mousemove", "IHasMouseMoveEvent"),
+        ("mousewheel", "IHasMouseWheelEvent"),
+        ("mouseenter", "IHasMouseEnterEvent"),
+        ("mouseexit", "IHasMouseExitEvent"),
+        ("beginsprite", "IHasBeginSpriteEvent"),
+        ("endsprite", "IHasEndSpriteEvent"),
+        ("stepframe", "IHasStepFrameEvent"),
+        ("prepareframe", "IHasPrepareFrameEvent"),
+        ("enterframe", "IHasEnterFrameEvent"),
+        ("exitframe", "IHasExitFrameEvent"),
+    ];
+
+    private readonly BlLingoTokenizer _tokenizer = new();
+    private readonly BlLegacyClassGeneratorOptions _options;
+
+    /// <summary>
+    /// Initializes a generator with default options.
+    /// </summary>
+    public BlLegacyClassGenerator()
+        : this(new BlLegacyClassGeneratorOptions())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a generator with the provided options.
+    /// </summary>
+    /// <param name="options">Naming and formatting options for the generated class.</param>
+    public BlLegacyClassGenerator(BlLegacyClassGeneratorOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _options = options.Clone();
+    }
+
+    /// <summary>
+    /// Generates the class declaration for the provided script source.
+    /// </summary>
+    /// <param name="scriptName">The name of the script being converted.</param>
+    /// <param name="source">The original Lingo source text.</param>
+    /// <param name="declaredKind">Optional explicit script kind metadata.</param>
+    public string GenerateClass(string scriptName, string source, BlLingoScriptKind declaredKind = BlLingoScriptKind.Unknown)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scriptName);
+        source ??= string.Empty;
+
+        var tokens = _tokenizer.Tokenize(source);
+        var analysis = BlLingoAnalyzer.Create(tokens).Run();
+        var classScope = ResolveClassScope(scriptName, analysis);
+        var scriptKind = DetermineScriptKind(declaredKind, classScope);
+
+        var className = BlCSharpName.ComposeClassName(scriptName, scriptKind, _options);
+        var baseType = GetBaseType(scriptKind);
+        var interfaces = CollectInterfaces(classScope);
+
+        var writer = new BlCSharpCodeWriter();
+        var handlerConverter = new BlLegacyHandlerConverter(source, tokens);
+        var interfaceSuffix = interfaces.Count > 0 ? ", " + string.Join(", ", interfaces) : string.Empty;
+
+        writer.WriteLine($"public class {className} : {baseType}{interfaceSuffix}");
+        writer.WriteLine("{");
+
+        using (writer.IndentScope())
+        {
+            var needsGlobal = scriptKind is BlLingoScriptKind.Parent or BlLingoScriptKind.Movie;
+            if (needsGlobal)
+            {
+                writer.WriteLine("private readonly GlobalVars _global;");
+                writer.WriteLine();
+            }
+
+            writer.Write($"public {className}(IBlingoMovieEnvironment env");
+            if (needsGlobal)
+            {
+                writer.Write(", GlobalVars global");
+                writer.WriteLine(") : base(env)");
+                writer.WriteLine("{");
+                using (writer.IndentScope())
+                {
+                    writer.WriteLine("_global = global;");
+                }
+
+                writer.WriteLine("}");
+            }
+            else
+            {
+                writer.WriteLine(") : base(env) { }");
+            }
+
+            if (interfaces.Contains("IBlingoPropertyDescriptionList"))
+            {
+                WritePropertyDescriptionListStubs(writer);
+            }
+
+            WriteHandlers(writer, classScope, handlerConverter);
+        }
+
+        writer.WriteLine("}");
+
+        return writer.ToString();
+    }
+
+    private static BlLingoClassSymbolTable ResolveClassScope(string scriptName, BlLingoAnalysisResult analysis)
+    {
+        if (!string.IsNullOrWhiteSpace(scriptName) && analysis.Symbols.ClassScopes.TryGetValue(scriptName, out var explicitClass))
+        {
+            return explicitClass;
+        }
+
+        return analysis.Symbols.MovieScript;
+    }
+
+    private static BlLingoScriptKind DetermineScriptKind(BlLingoScriptKind declaredKind, BlLingoClassSymbolTable classScope)
+    {
+        if (classScope is null)
+        {
+            return declaredKind == BlLingoScriptKind.Unknown ? BlLingoScriptKind.Behavior : declaredKind;
+        }
+
+        var kind = declaredKind != BlLingoScriptKind.Unknown ? declaredKind : classScope.ScriptKind;
+        if (kind == BlLingoScriptKind.Unknown)
+        {
+            kind = classScope.IsMovieScript ? BlLingoScriptKind.Movie : BlLingoScriptKind.Behavior;
+        }
+
+        if (classScope.Handlers.ContainsKey("getPropertyDescriptionList"))
+        {
+            return BlLingoScriptKind.Behavior;
+        }
+
+        return kind;
+    }
+
+    private static List<string> CollectInterfaces(BlLingoClassSymbolTable classScope)
+    {
+        var result = new List<string>();
+        if (classScope is null)
+        {
+            return result;
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        if (classScope.Handlers.ContainsKey("getPropertyDescriptionList") && seen.Add("IBlingoPropertyDescriptionList"))
+        {
+            result.Add("IBlingoPropertyDescriptionList");
+        }
+
+        foreach (var (handler, iface) in s_eventInterfaces)
+        {
+            if (classScope.Handlers.ContainsKey(handler) && seen.Add(iface))
+            {
+                result.Add(iface);
+            }
+        }
+
+        return result;
+    }
+
+    private static string GetBaseType(BlLingoScriptKind kind)
+    {
+        return kind switch
+        {
+            BlLingoScriptKind.Movie => "BlingoMovieScript",
+            BlLingoScriptKind.Parent => "BlingoParentScript",
+            BlLingoScriptKind.Behavior => "BlingoSpriteBehavior",
+            _ => "BlingoScriptBase",
+        };
+    }
+
+    private static void WritePropertyDescriptionListStubs(BlCSharpCodeWriter writer)
+    {
+        writer.WriteLine();
+        writer.WriteLine("public BehaviorPropertyDescriptionList? GetPropertyDescriptionList()");
+        writer.WriteLine("{");
+        using (writer.IndentScope())
+        {
+            writer.WriteLine("return null;");
+        }
+
+        writer.WriteLine("}");
+        writer.WriteLine();
+        writer.WriteLine("public string? GetBehaviorDescription() => null;");
+        writer.WriteLine();
+        writer.WriteLine("public string? GetBehaviorTooltip() => null;");
+        writer.WriteLine();
+        writer.WriteLine("public bool IsOKToAttach(BlingoSymbol spriteType, int spriteNum) => true;");
+    }
+
+    private static void WriteHandlers(
+        BlCSharpCodeWriter writer,
+        BlLingoClassSymbolTable classScope,
+        BlLegacyHandlerConverter handlerConverter)
+    {
+        if (classScope is null || classScope.Handlers.Count == 0)
+        {
+            return;
+        }
+
+        var handlers = new List<BlLingoHandlerSymbolTable>();
+        foreach (var handler in classScope.Handlers.Values)
+        {
+            if (ShouldSkipHandler(handler))
+            {
+                continue;
+            }
+
+            handlers.Add(handler);
+        }
+
+        if (handlers.Count == 0)
+        {
+            return;
+        }
+
+        handlers.Sort(static (left, right) => string.Compare(left.Symbol.Name, right.Symbol.Name, StringComparison.Ordinal));
+
+        var first = true;
+        foreach (var handler in handlers)
+        {
+            if (!first)
+            {
+                writer.WriteLine();
+            }
+
+            first = false;
+            WriteHandler(writer, handler, handlerConverter);
+        }
+    }
+
+    private static bool ShouldSkipHandler(BlLingoHandlerSymbolTable handler)
+    {
+        if (handler is null)
+        {
+            return true;
+        }
+
+        if (string.Equals(handler.OriginalName, BlLingoHandlerSymbolTable.ImplicitHandlerName, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (IsPropertyDescriptionHandler(handler.OriginalName) || IsPropertyDescriptionHandler(handler.Symbol.Name))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsPropertyDescriptionHandler(string? name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return false;
+        }
+
+        return name.Equals("getPropertyDescriptionList", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("getBehaviorDescription", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("getBehaviorTooltip", StringComparison.OrdinalIgnoreCase)
+            || name.Equals("isOKToAttach", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void WriteHandler(
+        BlCSharpCodeWriter writer,
+        BlLingoHandlerSymbolTable handler,
+        BlLegacyHandlerConverter handlerConverter)
+    {
+        var methodName = BlCSharpName.SanitizeIdentifier(handler.Symbol.Name);
+        if (string.IsNullOrEmpty(methodName))
+        {
+            methodName = "Handler";
+        }
+
+        writer.Write($"public void {methodName}(");
+        var parameters = ComposeHandlerParameters(handler);
+        writer.WriteSeparated(parameters, static (w, parameter) => w.Write(parameter));
+        writer.WriteLine(")");
+        writer.WriteLine("{");
+        writer.Indent();
+        handlerConverter.WriteHandlerBody(writer, handler);
+        writer.Unindent();
+        writer.WriteLine("}");
+    }
+
+    private static List<string> ComposeHandlerParameters(BlLingoHandlerSymbolTable handler)
+    {
+        var parameters = new List<string>();
+        var usedNames = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var symbol in handler.Parameters.Values)
+        {
+            var originalName = symbol.Name;
+            if (string.Equals(originalName, "me", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var sanitized = BlCSharpName.SanitizeIdentifier(originalName);
+            if (string.IsNullOrEmpty(sanitized))
+            {
+                sanitized = "arg";
+            }
+
+            var candidate = sanitized;
+            var suffix = 1;
+            while (!usedNames.Add(candidate))
+            {
+                candidate = sanitized + suffix.ToString();
+                suffix++;
+            }
+
+            parameters.Add($"object? {candidate}");
+        }
+
+        return parameters;
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyClassGeneratorOptions.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyClassGeneratorOptions.cs
@@ -1,0 +1,74 @@
+using System;
+
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+/// <summary>
+/// Configures naming conventions for generated legacy Lingo C# classes.
+/// </summary>
+public sealed class BlLegacyClassGeneratorOptions
+{
+    private string _behaviorSuffix = "Behavior";
+    private string _parentSuffix = "Parent";
+    private string _movieScriptSuffix = "MovieScript";
+    private string _scriptSuffix = "Script";
+
+    /// <summary>
+    /// Gets or sets the suffix appended to generated behavior script classes.
+    /// </summary>
+    public string BehaviorSuffix
+    {
+        get => _behaviorSuffix;
+        set => _behaviorSuffix = ValidateSuffix(value, nameof(BehaviorSuffix));
+    }
+
+    /// <summary>
+    /// Gets or sets the suffix appended to generated parent script classes.
+    /// </summary>
+    public string ParentSuffix
+    {
+        get => _parentSuffix;
+        set => _parentSuffix = ValidateSuffix(value, nameof(ParentSuffix));
+    }
+
+    /// <summary>
+    /// Gets or sets the suffix appended to generated movie script classes.
+    /// </summary>
+    public string MovieScriptSuffix
+    {
+        get => _movieScriptSuffix;
+        set => _movieScriptSuffix = ValidateSuffix(value, nameof(MovieScriptSuffix));
+    }
+
+    /// <summary>
+    /// Gets or sets the suffix appended to generated script classes when the type is unknown.
+    /// </summary>
+    public string ScriptSuffix
+    {
+        get => _scriptSuffix;
+        set => _scriptSuffix = ValidateSuffix(value, nameof(ScriptSuffix));
+    }
+
+    /// <summary>
+    /// Creates a copy of the current options instance.
+    /// </summary>
+    public BlLegacyClassGeneratorOptions Clone()
+    {
+        return new BlLegacyClassGeneratorOptions
+        {
+            BehaviorSuffix = BehaviorSuffix,
+            ParentSuffix = ParentSuffix,
+            MovieScriptSuffix = MovieScriptSuffix,
+            ScriptSuffix = ScriptSuffix,
+        };
+    }
+
+    private static string ValidateSuffix(string? value, string propertyName)
+    {
+        if (value is null)
+        {
+            throw new ArgumentNullException(propertyName);
+        }
+
+        return value;
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyExpressionConverter.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyExpressionConverter.cs
@@ -1,0 +1,507 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using BlingoEngine.Legacy.Lingo.Syntax;
+
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class BlLegacyExpressionConverter
+{
+    private readonly IReadOnlyList<BlSyntaxToken> _tokens;
+    private readonly List<string> _parts = new();
+    private int _index;
+    private bool _afterDot;
+
+    public BlLegacyExpressionConverter(IReadOnlyList<BlSyntaxToken> tokens)
+    {
+        _tokens = tokens ?? Array.Empty<BlSyntaxToken>();
+    }
+
+    public static string Convert(IReadOnlyList<BlSyntaxToken> tokens)
+    {
+        if (tokens is null || tokens.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        return new BlLegacyExpressionConverter(tokens).Build();
+    }
+
+    public string Build()
+    {
+        while (_index < _tokens.Count)
+        {
+            if (TryHandleVoidPredicate() ||
+                TryHandleScriptInstantiation() ||
+                TryHandleMemberTextAccess() ||
+                TryHandleListLiteral() ||
+                TryHandleTheKeywords())
+            {
+                continue;
+            }
+
+            var token = _tokens[_index++];
+            switch (token.Kind)
+            {
+                case BlSyntaxKind.IdentifierToken:
+                case BlSyntaxKind.KeywordToken:
+                    AppendIdentifier(token.ValueText);
+                    break;
+                case BlSyntaxKind.NumberToken:
+                case BlSyntaxKind.StringLiteralToken:
+                    AppendRaw(token.Text);
+                    break;
+                case BlSyntaxKind.OperatorToken:
+                    AppendOperator(token.ValueText);
+                    break;
+                case BlSyntaxKind.PeriodToken:
+                    AppendRaw(".");
+                    _afterDot = true;
+                    break;
+                case BlSyntaxKind.LeftParenthesisToken:
+                    AppendRaw("(");
+                    break;
+                case BlSyntaxKind.RightParenthesisToken:
+                    AppendRaw(")");
+                    _afterDot = false;
+                    break;
+                case BlSyntaxKind.LeftBracketToken:
+                    AppendRaw("[");
+                    break;
+                case BlSyntaxKind.RightBracketToken:
+                    AppendRaw("]");
+                    _afterDot = false;
+                    break;
+                case BlSyntaxKind.CommaToken:
+                    AppendRaw(",");
+                    break;
+                default:
+                    AppendRaw(token.Text);
+                    break;
+            }
+        }
+
+        return NormalizeSpacing(_parts);
+    }
+
+    private bool TryHandleVoidPredicate()
+    {
+        if (_index >= _tokens.Count ||
+            !string.Equals(_tokens[_index].ValueText, "voidp", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (_index + 1 >= _tokens.Count || _tokens[_index + 1].Kind != BlSyntaxKind.LeftParenthesisToken)
+        {
+            return false;
+        }
+
+        var closeIndex = BlLegacyHandlerTokenUtilities.FindMatchingToken(_tokens, _index + 1, BlSyntaxKind.LeftParenthesisToken, BlSyntaxKind.RightParenthesisToken);
+        if (closeIndex < 0)
+        {
+            return false;
+        }
+
+        var innerTokens = BlLegacyHandlerTokenUtilities.SliceTokens(_tokens, _index + 2, closeIndex - (_index + 2));
+        var expression = Convert(innerTokens);
+        AppendRaw(expression);
+        AppendRaw("==");
+        AppendRaw("null");
+        _index = closeIndex + 1;
+        _afterDot = false;
+        return true;
+    }
+
+    private bool TryHandleScriptInstantiation()
+    {
+        if (_index >= _tokens.Count ||
+            !string.Equals(_tokens[_index].ValueText, "script", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (_index + 1 >= _tokens.Count || _tokens[_index + 1].Kind != BlSyntaxKind.LeftParenthesisToken)
+        {
+            return false;
+        }
+
+        var nameClose = BlLegacyHandlerTokenUtilities.FindMatchingToken(_tokens, _index + 1, BlSyntaxKind.LeftParenthesisToken, BlSyntaxKind.RightParenthesisToken);
+        if (nameClose < 0)
+        {
+            return false;
+        }
+
+        var afterName = nameClose + 1;
+        if (afterName + 2 >= _tokens.Count ||
+            _tokens[afterName].Kind != BlSyntaxKind.PeriodToken ||
+            !string.Equals(_tokens[afterName + 1].ValueText, "new", StringComparison.OrdinalIgnoreCase) ||
+            _tokens[afterName + 2].Kind != BlSyntaxKind.LeftParenthesisToken)
+        {
+            return false;
+        }
+
+        var argsClose = BlLegacyHandlerTokenUtilities.FindMatchingToken(_tokens, afterName + 2, BlSyntaxKind.LeftParenthesisToken, BlSyntaxKind.RightParenthesisToken);
+        if (argsClose < 0)
+        {
+            return false;
+        }
+
+        var nameTokens = BlLegacyHandlerTokenUtilities.SliceTokens(_tokens, _index + 2, nameClose - (_index + 2));
+        var argsTokens = BlLegacyHandlerTokenUtilities.SliceTokens(_tokens, afterName + 3, argsClose - (afterName + 3));
+        var className = ResolveClassName(nameTokens);
+        var arguments = ConvertArguments(argsTokens);
+
+        AppendRaw("new");
+        AppendRaw(className);
+        AppendRaw("(");
+        if (!string.IsNullOrEmpty(arguments))
+        {
+            AppendRaw(arguments);
+        }
+
+        AppendRaw(")");
+        _index = argsClose + 1;
+        _afterDot = false;
+        return true;
+    }
+
+    private bool TryHandleMemberTextAccess()
+    {
+        if (_index >= _tokens.Count ||
+            !string.Equals(_tokens[_index].ValueText, "member", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (_index + 1 >= _tokens.Count || _tokens[_index + 1].Kind != BlSyntaxKind.LeftParenthesisToken)
+        {
+            return false;
+        }
+
+        var argsClose = BlLegacyHandlerTokenUtilities.FindMatchingToken(_tokens, _index + 1, BlSyntaxKind.LeftParenthesisToken, BlSyntaxKind.RightParenthesisToken);
+        if (argsClose < 0)
+        {
+            return false;
+        }
+
+        if (argsClose + 2 >= _tokens.Count ||
+            _tokens[argsClose + 1].Kind != BlSyntaxKind.PeriodToken ||
+            !string.Equals(_tokens[argsClose + 2].ValueText, "text", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var argsTokens = BlLegacyHandlerTokenUtilities.SliceTokens(_tokens, _index + 2, argsClose - (_index + 2));
+        var arguments = ConvertArguments(argsTokens);
+
+        AppendRaw("Member<BlingoMemberText>");
+        AppendRaw("(");
+        if (!string.IsNullOrEmpty(arguments))
+        {
+            AppendRaw(arguments);
+        }
+
+        AppendRaw(")");
+        AppendRaw(".");
+        AppendRaw("Text");
+
+        _index = argsClose + 3;
+        _afterDot = false;
+        return true;
+    }
+
+    private bool TryHandleListLiteral()
+    {
+        if (_index >= _tokens.Count || _tokens[_index].Kind != BlSyntaxKind.LeftBracketToken)
+        {
+            return false;
+        }
+
+        var closeIndex = BlLegacyHandlerTokenUtilities.FindMatchingToken(_tokens, _index, BlSyntaxKind.LeftBracketToken, BlSyntaxKind.RightBracketToken);
+        if (closeIndex < 0)
+        {
+            return false;
+        }
+
+        var innerTokens = BlLegacyHandlerTokenUtilities.SliceTokens(_tokens, _index + 1, closeIndex - (_index + 1));
+        var segments = BlLegacyHandlerTokenUtilities.SplitByComma(innerTokens);
+        AppendRaw("new[]");
+        AppendRaw("{");
+        for (var i = 0; i < segments.Count; i++)
+        {
+            var value = Convert(segments[i]);
+            if (value.Length > 0)
+            {
+                AppendRaw(value);
+            }
+
+            if (i < segments.Count - 1)
+            {
+                AppendRaw(",");
+            }
+        }
+
+        AppendRaw("}");
+        _index = closeIndex + 1;
+        _afterDot = false;
+        return true;
+    }
+
+    private bool TryHandleTheKeywords()
+    {
+        if (_index >= _tokens.Count ||
+            !string.Equals(_tokens[_index].ValueText, "the", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (_index + 1 >= _tokens.Count)
+        {
+            return false;
+        }
+
+        var next = _tokens[_index + 1];
+        if (string.Equals(next.ValueText, "mouseH", StringComparison.OrdinalIgnoreCase))
+        {
+            AppendRaw("_Mouse.MouseH");
+            _index += 2;
+            _afterDot = false;
+            return true;
+        }
+
+        if (string.Equals(next.ValueText, "actorList", StringComparison.OrdinalIgnoreCase))
+        {
+            AppendRaw("_Movie.ActorList");
+            _index += 2;
+            _afterDot = false;
+            return true;
+        }
+
+        return false;
+    }
+
+    private void AppendIdentifier(string text)
+    {
+        if (string.Equals(text, "me", StringComparison.OrdinalIgnoreCase))
+        {
+            AppendRaw("this");
+            _afterDot = false;
+            return;
+        }
+
+        if (string.Equals(text, "void", StringComparison.OrdinalIgnoreCase))
+        {
+            AppendRaw("null");
+            _afterDot = false;
+            return;
+        }
+
+        if (string.Equals(text, "sprite", StringComparison.OrdinalIgnoreCase))
+        {
+            AppendRaw("Sprite");
+            _afterDot = false;
+            return;
+        }
+
+        if (_afterDot)
+        {
+            AppendRaw(BlLegacyHandlerTokenUtilities.ToPascalCase(text));
+            _afterDot = false;
+            return;
+        }
+
+        AppendRaw(text);
+        _afterDot = false;
+    }
+
+    private void AppendOperator(string op)
+    {
+        if (string.Equals(op, "<>", StringComparison.Ordinal))
+        {
+            AppendRaw("!=");
+            return;
+        }
+
+        if (string.Equals(op, "&", StringComparison.Ordinal))
+        {
+            AppendRaw("+");
+            return;
+        }
+
+        AppendRaw(op);
+    }
+
+    private void AppendRaw(string text)
+    {
+        if (!string.IsNullOrEmpty(text))
+        {
+            _parts.Add(text);
+        }
+    }
+
+    private static string NormalizeSpacing(List<string> parts)
+    {
+        if (parts.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var raw = string.Join(' ', parts);
+        var builder = new StringBuilder(raw.Length * 2);
+        var insideArrayLiteral = false;
+        var arrayDepth = 0;
+
+        for (var index = 0; index < raw.Length; index++)
+        {
+            var ch = raw[index];
+
+            if (ch == '{')
+            {
+                var startsArray = !insideArrayLiteral && EndsWithNewArray(builder);
+                builder.Append('{');
+
+                if (startsArray)
+                {
+                    insideArrayLiteral = true;
+                    arrayDepth = 1;
+                }
+                else if (insideArrayLiteral)
+                {
+                    arrayDepth++;
+                }
+
+                continue;
+            }
+
+            if (ch == '}')
+            {
+                if (insideArrayLiteral && arrayDepth > 0)
+                {
+                    arrayDepth--;
+                    if (arrayDepth == 0)
+                    {
+                        insideArrayLiteral = false;
+                    }
+                }
+
+                builder.Append('}');
+                continue;
+            }
+
+            if (ch == ' ')
+            {
+                var next = index + 1 < raw.Length ? raw[index + 1] : '\0';
+                var previous = builder.Length > 0 ? builder[^1] : '\0';
+
+                if (insideArrayLiteral && arrayDepth <= 1 && previous == ',')
+                {
+                    continue;
+                }
+
+                if (previous == ' ' || previous == '.' || next == '\0' || next is '.' or ',' or ')' or ']' ||
+                    previous is '(' or '[' or '<')
+                {
+                    continue;
+                }
+            }
+
+            if (builder.Length > 0 && builder[^1] == ' ' && (ch is '(' or '['))
+            {
+                builder.Length--;
+            }
+
+            if (ch == ',')
+            {
+                builder.Append(',');
+                if (!insideArrayLiteral || arrayDepth > 1)
+                {
+                    if (index + 1 < raw.Length && raw[index + 1] != ' ')
+                    {
+                        builder.Append(' ');
+                    }
+                }
+
+                continue;
+            }
+
+            if (builder.Length > 0 && builder[^1] == ' ' && (ch is '.' or ')' or ']' or ';' or ':'))
+            {
+                builder.Length--;
+            }
+
+            builder.Append(ch);
+        }
+
+        return builder.ToString().Trim();
+    }
+
+    private static bool EndsWithNewArray(StringBuilder builder)
+    {
+        const string pattern = "new[]";
+        var index = builder.Length - 1;
+
+        while (index >= 0 && char.IsWhiteSpace(builder[index]))
+        {
+            index--;
+        }
+
+        if (index < pattern.Length - 1)
+        {
+            return false;
+        }
+
+        for (var patternIndex = pattern.Length - 1; patternIndex >= 0; patternIndex--, index--)
+        {
+            if (index < 0 || builder[index] != pattern[patternIndex])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string ResolveClassName(IReadOnlyList<BlSyntaxToken> tokens)
+    {
+        if (tokens.Count == 0)
+        {
+            return "Script";
+        }
+
+        var token = tokens[0];
+        if (token.Kind == BlSyntaxKind.StringLiteralToken)
+        {
+            return BlCSharpName.SanitizeIdentifier(token.ValueText);
+        }
+
+        return BlCSharpName.SanitizeIdentifier(token.ValueText);
+    }
+
+    private static string ConvertArguments(IReadOnlyList<BlSyntaxToken> tokens)
+    {
+        if (tokens.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var segments = BlLegacyHandlerTokenUtilities.SplitByComma(tokens);
+        var builder = new StringBuilder();
+        for (var index = 0; index < segments.Count; index++)
+        {
+            var expression = Convert(segments[index]);
+            if (expression.Length > 0)
+            {
+                if (builder.Length > 0)
+                {
+                    builder.Append(", ");
+                }
+
+                builder.Append(expression);
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyHandlerBodyEmitter.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyHandlerBodyEmitter.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using BlingoEngine.Legacy.Lingo.Syntax;
+
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class BlLegacyHandlerBodyEmitter
+{
+    private readonly BlCSharpCodeWriter _writer;
+    private readonly IReadOnlyList<BlSyntaxToken> _tokens;
+    private readonly IReadOnlyList<BlSyntaxTrivia> _endTrivia;
+    private readonly HandlerBlockManager _blocks;
+    private readonly IReadOnlyList<IHandlerTokenVisitor> _visitors;
+
+    public BlLegacyHandlerBodyEmitter(
+        BlCSharpCodeWriter writer,
+        IReadOnlyList<BlSyntaxToken> tokens,
+        IReadOnlyList<BlSyntaxTrivia> endTrivia)
+        : this(writer, tokens, endTrivia, null)
+    {
+    }
+
+    public BlLegacyHandlerBodyEmitter(
+        BlCSharpCodeWriter writer,
+        IReadOnlyList<BlSyntaxToken> tokens,
+        IReadOnlyList<BlSyntaxTrivia> endTrivia,
+        IReadOnlyList<IHandlerTokenVisitor>? visitors)
+    {
+        _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+        _tokens = tokens ?? Array.Empty<BlSyntaxToken>();
+        _endTrivia = endTrivia ?? Array.Empty<BlSyntaxTrivia>();
+        _blocks = new HandlerBlockManager(_writer);
+        _visitors = visitors ?? CreateDefaultVisitors();
+    }
+
+    public void Emit()
+    {
+        var lines = HandlerLine.Split(_tokens, _endTrivia);
+        if (lines.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var line in lines)
+        {
+            switch (line.Kind)
+            {
+                case HandlerLineKind.Blank:
+                    _writer.WriteLine();
+                    break;
+                case HandlerLineKind.Comment:
+                    WriteComment(line.CommentText);
+                    break;
+                case HandlerLineKind.Tokens:
+                    EmitTokens(line.Tokens);
+                    break;
+            }
+        }
+
+        _blocks.CloseAll();
+    }
+
+    private void EmitTokens(IReadOnlyList<BlSyntaxToken> tokens)
+    {
+        if (tokens.Count == 0)
+        {
+            return;
+        }
+
+        var context = new HandlerTokenEmitContext(_writer, tokens, _blocks);
+        foreach (var visitor in _visitors)
+        {
+            if (visitor.TryHandle(context))
+            {
+                return;
+            }
+        }
+    }
+
+    private void WriteComment(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            _writer.WriteLine("//");
+        }
+        else
+        {
+            _writer.WriteLine("// " + text);
+        }
+    }
+
+    private static IReadOnlyList<IHandlerTokenVisitor> CreateDefaultVisitors()
+    {
+        return new IHandlerTokenVisitor[]
+        {
+            new EndTokenVisitor(),
+            new ElseTokenVisitor(),
+            new RepeatTokenVisitor(),
+            new CaseTokenVisitor(),
+            new PutTokenVisitor(),
+            new SpriteMemberAssignmentVisitor(),
+            new ActorListAppendVisitor(),
+            new ActorListRemoveVisitor(),
+            new SendSpriteVisitor(),
+            new IfTokenVisitor(),
+            new ExitNextTokenVisitor(),
+            new MovieCallVisitor(),
+            new ExpressionStatementVisitor(),
+        };
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyHandlerConverter.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyHandlerConverter.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using BlingoEngine.Legacy.Lingo.Analysis;
+using BlingoEngine.Legacy.Lingo.Syntax;
+
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+/// <summary>
+/// Translates legacy Lingo handler bodies into C# statements following the
+/// conversion tables outlined in docs/design/Blingo_vs_CSharp.md.
+/// </summary>
+public sealed class BlLegacyHandlerConverter
+{
+    private readonly IReadOnlyList<BlSyntaxToken> _tokens;
+
+    public BlLegacyHandlerConverter(string source, IReadOnlyList<BlSyntaxToken> tokens)
+    {
+        _ = source;
+        _tokens = tokens ?? Array.Empty<BlSyntaxToken>();
+    }
+
+    /// <summary>
+    /// Writes the translated body for the supplied handler.
+    /// </summary>
+    public void WriteHandlerBody(BlCSharpCodeWriter writer, BlLingoHandlerSymbolTable handler)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(handler);
+
+        var body = ExtractHandlerBody(handler);
+        if (body.Tokens.Count == 0 && body.EndLeadingTrivia.Count == 0)
+        {
+            return;
+        }
+
+        var emitter = new BlLegacyHandlerBodyEmitter(writer, body.Tokens, body.EndLeadingTrivia);
+        emitter.Emit();
+    }
+
+    private HandlerBody ExtractHandlerBody(BlLingoHandlerSymbolTable handler)
+    {
+        if (handler.Symbol.Declarations.Count == 0)
+        {
+            return HandlerBody.Empty;
+        }
+
+        var declaration = handler.Symbol.Declarations[0];
+        var declarationIndex = IndexOfToken(declaration);
+        if (declarationIndex < 0)
+        {
+            return HandlerBody.Empty;
+        }
+
+        var bodyStartIndex = declarationIndex + 1;
+        while (bodyStartIndex < _tokens.Count)
+        {
+            var token = _tokens[bodyStartIndex];
+            if (ContainsNewLine(token.LeadingTrivia))
+            {
+                break;
+            }
+
+            bodyStartIndex++;
+        }
+
+        if (bodyStartIndex >= _tokens.Count)
+        {
+            return HandlerBody.Empty;
+        }
+
+        var endIndex = FindHandlerEndIndex(bodyStartIndex);
+        if (endIndex < 0 || endIndex <= bodyStartIndex)
+        {
+            return HandlerBody.Empty;
+        }
+
+        var bodyTokens = new List<BlSyntaxToken>(endIndex - bodyStartIndex);
+        for (var index = bodyStartIndex; index < endIndex; index++)
+        {
+            bodyTokens.Add(_tokens[index]);
+        }
+
+        return new HandlerBody(bodyTokens, _tokens[endIndex].LeadingTrivia);
+    }
+
+    private int IndexOfToken(BlSyntaxToken target)
+    {
+        for (var index = 0; index < _tokens.Count; index++)
+        {
+            if (ReferenceEquals(_tokens[index], target))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private int FindHandlerEndIndex(int startIndex)
+    {
+        for (var index = Math.Max(startIndex, 0); index < _tokens.Count; index++)
+        {
+            var token = _tokens[index];
+            if (token.Kind != BlSyntaxKind.KeywordToken)
+            {
+                continue;
+            }
+
+            if (!string.Equals(token.ValueText, "end", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (IsHandlerTerminator(index))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private bool IsHandlerTerminator(int index)
+    {
+        var nextIndex = index + 1;
+        if (nextIndex >= _tokens.Count)
+        {
+            return true;
+        }
+
+        var next = _tokens[nextIndex];
+        if (next.Kind == BlSyntaxKind.EndOfFileToken)
+        {
+            return true;
+        }
+
+        return ContainsNewLine(next.LeadingTrivia);
+    }
+
+    private static bool ContainsNewLine(IReadOnlyList<BlSyntaxTrivia> trivia)
+    {
+        if (trivia is null)
+        {
+            return false;
+        }
+
+        for (var index = 0; index < trivia.Count; index++)
+        {
+            if (trivia[index].Kind == BlSyntaxKind.NewLineTrivia)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private readonly record struct HandlerBody(
+        IReadOnlyList<BlSyntaxToken> Tokens,
+        IReadOnlyList<BlSyntaxTrivia> EndLeadingTrivia)
+    {
+        public static HandlerBody Empty { get; } = new(Array.Empty<BlSyntaxToken>(), Array.Empty<BlSyntaxTrivia>());
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyHandlerTokenUtilities.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyHandlerTokenUtilities.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using BlingoEngine.Legacy.Lingo.Syntax;
+
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public static class BlLegacyHandlerTokenUtilities
+{
+    public static IReadOnlyList<BlSyntaxToken> SliceTokens(IReadOnlyList<BlSyntaxToken> tokens, int start, int length)
+    {
+        if (tokens is null || length <= 0)
+        {
+            return Array.Empty<BlSyntaxToken>();
+        }
+
+        var list = new List<BlSyntaxToken>(Math.Max(length, 0));
+        for (var index = 0; index < length && start + index < tokens.Count; index++)
+        {
+            list.Add(tokens[start + index]);
+        }
+
+        return list;
+    }
+
+    public static int FindKeyword(IReadOnlyList<BlSyntaxToken> tokens, string keyword)
+    {
+        for (var index = 0; index < tokens.Count; index++)
+        {
+            if (IsIdentifier(tokens[index], keyword))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    public static int FindOperator(IReadOnlyList<BlSyntaxToken> tokens, string op)
+    {
+        for (var index = 0; index < tokens.Count; index++)
+        {
+            if (tokens[index].Kind == BlSyntaxKind.OperatorToken &&
+                string.Equals(tokens[index].ValueText, op, StringComparison.Ordinal))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    public static int FindToken(IReadOnlyList<BlSyntaxToken> tokens, BlSyntaxKind kind)
+    {
+        for (var index = 0; index < tokens.Count; index++)
+        {
+            if (tokens[index].Kind == kind)
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    public static int FindMatchingToken(
+        IReadOnlyList<BlSyntaxToken> tokens,
+        int startIndex,
+        BlSyntaxKind openKind,
+        BlSyntaxKind closeKind)
+    {
+        var depth = 0;
+        for (var index = startIndex; index < tokens.Count; index++)
+        {
+            var token = tokens[index];
+            if (token.Kind == openKind)
+            {
+                depth++;
+            }
+            else if (token.Kind == closeKind)
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return index;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    public static bool IsKeyword(BlSyntaxToken token, string keyword)
+    {
+        return token.Kind == BlSyntaxKind.KeywordToken &&
+            string.Equals(token.ValueText, keyword, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static bool IsIdentifier(BlSyntaxToken token, string identifier)
+    {
+        return token.Kind is BlSyntaxKind.IdentifierToken or BlSyntaxKind.KeywordToken &&
+            string.Equals(token.ValueText, identifier, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static bool TryGetSpritePropertyTarget(
+        IReadOnlyList<BlSyntaxToken> tokens,
+        out string spriteIndex,
+        out string propertyName)
+    {
+        spriteIndex = string.Empty;
+        propertyName = string.Empty;
+
+        if (tokens.Count < 5 || !IsIdentifier(tokens[0], "sprite"))
+        {
+            return false;
+        }
+
+        if (tokens[1].Kind != BlSyntaxKind.LeftParenthesisToken)
+        {
+            return false;
+        }
+
+        var closeIndex = FindMatchingToken(tokens, 1, BlSyntaxKind.LeftParenthesisToken, BlSyntaxKind.RightParenthesisToken);
+        if (closeIndex < 0 || closeIndex + 2 >= tokens.Count)
+        {
+            return false;
+        }
+
+        if (tokens[closeIndex + 1].Kind != BlSyntaxKind.PeriodToken)
+        {
+            return false;
+        }
+
+        var propertyToken = tokens[closeIndex + 2];
+        if (propertyToken.Kind != BlSyntaxKind.IdentifierToken)
+        {
+            return false;
+        }
+
+        var indexTokens = SliceTokens(tokens, 2, closeIndex - 2);
+        spriteIndex = BlLegacyExpressionConverter.Convert(indexTokens);
+        propertyName = ToPascalCase(propertyToken.ValueText);
+        return true;
+    }
+
+    public static bool TryGetListTarget(
+        IReadOnlyList<BlSyntaxToken> tokens,
+        out string listExpression,
+        out string indexExpression)
+    {
+        listExpression = string.Empty;
+        indexExpression = string.Empty;
+
+        var bracketIndex = FindToken(tokens, BlSyntaxKind.LeftBracketToken);
+        if (bracketIndex <= 0)
+        {
+            return false;
+        }
+
+        var closeIndex = FindMatchingToken(tokens, bracketIndex, BlSyntaxKind.LeftBracketToken, BlSyntaxKind.RightBracketToken);
+        if (closeIndex < 0)
+        {
+            return false;
+        }
+
+        var listTokens = SliceTokens(tokens, 0, bracketIndex);
+        var indexTokens = SliceTokens(tokens, bracketIndex + 1, closeIndex - bracketIndex - 1);
+        listExpression = BlLegacyExpressionConverter.Convert(listTokens);
+        indexExpression = BlLegacyExpressionConverter.Convert(indexTokens);
+        return listExpression.Length > 0 && indexExpression.Length > 0;
+    }
+
+    public static List<IReadOnlyList<BlSyntaxToken>> SplitByComma(IReadOnlyList<BlSyntaxToken> tokens)
+    {
+        var result = new List<IReadOnlyList<BlSyntaxToken>>();
+        var start = 0;
+        var depthParenthesis = 0;
+        var depthBracket = 0;
+        var depthBrace = 0;
+
+        for (var index = 0; index < tokens.Count; index++)
+        {
+            var token = tokens[index];
+            switch (token.Kind)
+            {
+                case BlSyntaxKind.LeftParenthesisToken:
+                    depthParenthesis++;
+                    break;
+                case BlSyntaxKind.RightParenthesisToken:
+                    depthParenthesis--;
+                    break;
+                case BlSyntaxKind.LeftBracketToken:
+                    depthBracket++;
+                    break;
+                case BlSyntaxKind.RightBracketToken:
+                    depthBracket--;
+                    break;
+                case BlSyntaxKind.LeftBraceToken:
+                    depthBrace++;
+                    break;
+                case BlSyntaxKind.RightBraceToken:
+                    depthBrace--;
+                    break;
+                case BlSyntaxKind.CommaToken when depthParenthesis == 0 && depthBracket == 0 && depthBrace == 0:
+                    result.Add(SliceTokens(tokens, start, index - start));
+                    start = index + 1;
+                    break;
+            }
+        }
+
+        if (start < tokens.Count)
+        {
+            result.Add(SliceTokens(tokens, start, tokens.Count - start));
+        }
+
+        return result;
+    }
+
+    public static string ToPascalCase(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return name;
+        }
+
+        if (name.Length == 1)
+        {
+            return name.ToUpper(CultureInfo.InvariantCulture);
+        }
+
+        return char.ToUpper(name[0], CultureInfo.InvariantCulture) + name[1..];
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlockKind.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlockKind.cs
@@ -1,0 +1,9 @@
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public enum BlockKind
+{
+    If,
+    Loop,
+    RepeatUntil,
+    Switch,
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/CaseTokenVisitor.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/CaseTokenVisitor.cs
@@ -1,0 +1,51 @@
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class CaseTokenVisitor : IHandlerTokenVisitor
+{
+    public bool TryHandle(HandlerTokenEmitContext context)
+    {
+        var tokens = context.Tokens;
+        if (tokens.Count == 0)
+        {
+            return false;
+        }
+
+        if (BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[0], "case"))
+        {
+            var ofIndex = BlLegacyHandlerTokenUtilities.FindKeyword(tokens, "of");
+            if (ofIndex < 0)
+            {
+                return false;
+            }
+
+            var expressionTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, 1, ofIndex - 1);
+            var expression = context.ConvertExpression(expressionTokens);
+            context.Writer.WriteLine($"switch ({expression})");
+            context.Blocks.OpenBlock(BlockKind.Switch);
+            return true;
+        }
+
+        if (!context.Blocks.IsCurrent(BlockKind.Switch))
+        {
+            return false;
+        }
+
+        if (BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[0], "when"))
+        {
+            var expressionTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, 1, tokens.Count - 1);
+            var expression = context.ConvertExpression(expressionTokens);
+            context.Writer.WriteLine($"case {expression}:");
+            context.Blocks.StartSwitchSection();
+            return true;
+        }
+
+        if (tokens.Count == 1 && BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[0], "otherwise"))
+        {
+            context.Writer.WriteLine("default:");
+            context.Blocks.StartSwitchSection();
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/ElseTokenVisitor.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/ElseTokenVisitor.cs
@@ -1,0 +1,34 @@
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class ElseTokenVisitor : IHandlerTokenVisitor
+{
+    public bool TryHandle(HandlerTokenEmitContext context)
+    {
+        var tokens = context.Tokens;
+        if (tokens.Count == 0 || !BlLegacyHandlerTokenUtilities.IsKeyword(tokens[0], "else"))
+        {
+            return false;
+        }
+
+        if (tokens.Count > 1 && BlLegacyHandlerTokenUtilities.IsKeyword(tokens[1], "if"))
+        {
+            var thenIndex = BlLegacyHandlerTokenUtilities.FindKeyword(tokens, "then");
+            if (thenIndex < 0)
+            {
+                return false;
+            }
+
+            var conditionTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, 2, thenIndex - 2);
+            var condition = context.ConvertExpression(conditionTokens);
+            context.Blocks.CloseBlock(leaveOnStack: true);
+            context.Writer.WriteLine($"else if ({condition})");
+            context.Blocks.OpenBlock(BlockKind.If, reopenExisting: true);
+            return true;
+        }
+
+        context.Blocks.CloseBlock(leaveOnStack: true);
+        context.Writer.WriteLine("else");
+        context.Blocks.OpenBlock(BlockKind.If, reopenExisting: true);
+        return true;
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/EndTokenVisitor.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/EndTokenVisitor.cs
@@ -1,0 +1,16 @@
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class EndTokenVisitor : IHandlerTokenVisitor
+{
+    public bool TryHandle(HandlerTokenEmitContext context)
+    {
+        if (context.Tokens.Count == 0 ||
+            !BlLegacyHandlerTokenUtilities.IsKeyword(context.Tokens[0], "end"))
+        {
+            return false;
+        }
+
+        context.Blocks.CloseBlock();
+        return true;
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/ExitNextTokenVisitor.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/ExitNextTokenVisitor.cs
@@ -1,0 +1,56 @@
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class ExitNextTokenVisitor : IHandlerTokenVisitor
+{
+    public bool TryHandle(HandlerTokenEmitContext context)
+    {
+        var tokens = context.Tokens;
+        if (tokens.Count == 0)
+        {
+            return false;
+        }
+
+        if (BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[0], "exit"))
+        {
+            if (tokens.Count >= 3 &&
+                BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[1], "repeat") &&
+                BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[2], "if"))
+            {
+                var conditionTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, 3, tokens.Count - 3);
+                var condition = context.ConvertExpression(conditionTokens);
+                context.Writer.WriteLine($"if ({condition}) break;");
+                return true;
+            }
+
+            if (tokens.Count >= 2 && BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[1], "repeat"))
+            {
+                context.Writer.WriteLine("break;");
+                return true;
+            }
+
+            if (tokens.Count == 1)
+            {
+                context.Writer.WriteLine("return;");
+                return true;
+            }
+        }
+
+        if (BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[0], "next") &&
+            tokens.Count >= 2 &&
+            BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[1], "repeat"))
+        {
+            if (tokens.Count >= 3 && BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[2], "if"))
+            {
+                var conditionTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, 3, tokens.Count - 3);
+                var condition = context.ConvertExpression(conditionTokens);
+                context.Writer.WriteLine($"if ({condition}) continue;");
+                return true;
+            }
+
+            context.Writer.WriteLine("continue;");
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/ExpressionStatementVisitor.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/ExpressionStatementVisitor.cs
@@ -1,0 +1,16 @@
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class ExpressionStatementVisitor : IHandlerTokenVisitor
+{
+    public bool TryHandle(HandlerTokenEmitContext context)
+    {
+        var expression = context.ConvertExpression(context.Tokens);
+        if (expression.Length == 0)
+        {
+            return false;
+        }
+
+        context.Writer.WriteLine(expression + ";");
+        return true;
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/HandlerBlockFrame.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/HandlerBlockFrame.cs
@@ -1,0 +1,16 @@
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class HandlerBlockFrame
+{
+    public HandlerBlockFrame(BlockKind kind, string? condition)
+    {
+        Kind = kind;
+        Condition = condition;
+    }
+
+    public BlockKind Kind { get; }
+
+    public string? Condition { get; set; }
+
+    public bool CaseOpen { get; set; }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/HandlerBlockManager.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/HandlerBlockManager.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class HandlerBlockManager
+{
+    private readonly BlCSharpCodeWriter _writer;
+    private readonly Stack<HandlerBlockFrame> _frames = new();
+
+    public HandlerBlockManager(BlCSharpCodeWriter writer)
+    {
+        _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+    }
+
+    public HandlerBlockFrame? Current => _frames.Count > 0 ? _frames.Peek() : null;
+
+    public bool IsCurrent(BlockKind kind) => _frames.Count > 0 && _frames.Peek().Kind == kind;
+
+    public void OpenBlock(BlockKind kind, string? condition = null, bool reopenExisting = false)
+    {
+        if (reopenExisting && _frames.Count > 0)
+        {
+            _writer.WriteLine("{");
+            _writer.Indent();
+            return;
+        }
+
+        _writer.WriteLine("{");
+        _writer.Indent();
+        _frames.Push(new HandlerBlockFrame(kind, condition));
+    }
+
+    public void CloseBlock(bool leaveOnStack = false)
+    {
+        if (_frames.Count == 0)
+        {
+            return;
+        }
+
+        var frame = _frames.Peek();
+        if (frame.Kind == BlockKind.Switch)
+        {
+            CloseActiveCase();
+        }
+
+        _writer.Unindent();
+        if (frame.Kind == BlockKind.RepeatUntil)
+        {
+            var condition = frame.Condition ?? "false";
+            _writer.WriteLine($"}} while (!({condition}));");
+        }
+        else
+        {
+            _writer.WriteLine("}");
+        }
+
+        if (!leaveOnStack)
+        {
+            _frames.Pop();
+        }
+    }
+
+    public void CloseAll()
+    {
+        while (_frames.Count > 0)
+        {
+            CloseBlock();
+        }
+    }
+
+    public void CloseActiveCase()
+    {
+        if (_frames.Count == 0)
+        {
+            return;
+        }
+
+        var frame = _frames.Peek();
+        if (!frame.CaseOpen)
+        {
+            return;
+        }
+
+        frame.CaseOpen = false;
+        _writer.WriteLine("break;");
+        _writer.Unindent();
+    }
+
+    public void StartSwitchSection()
+    {
+        if (!IsCurrent(BlockKind.Switch))
+        {
+            return;
+        }
+
+        CloseActiveCase();
+        var frame = _frames.Peek();
+        _writer.Indent();
+        frame.CaseOpen = true;
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/HandlerLine.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/HandlerLine.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using BlingoEngine.Legacy.Lingo.Syntax;
+
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class HandlerLine
+{
+    private HandlerLine(HandlerLineKind kind, IReadOnlyList<BlSyntaxToken> tokens, string? commentText)
+    {
+        Kind = kind;
+        Tokens = tokens;
+        CommentText = commentText;
+    }
+
+    public HandlerLineKind Kind { get; }
+
+    public IReadOnlyList<BlSyntaxToken> Tokens { get; }
+
+    public string? CommentText { get; }
+
+    public static List<HandlerLine> Split(IReadOnlyList<BlSyntaxToken> tokens, IReadOnlyList<BlSyntaxTrivia> endTrivia)
+    {
+        var result = new List<HandlerLine>();
+        var currentTokens = new List<BlSyntaxToken>();
+        var lastWasBlank = false;
+
+        foreach (var token in tokens)
+        {
+            ProcessTrivia(token.LeadingTrivia, result, currentTokens, ref lastWasBlank);
+            currentTokens.Add(token);
+            lastWasBlank = false;
+            ProcessTrivia(token.TrailingTrivia, result, currentTokens, ref lastWasBlank);
+        }
+
+        ProcessTrivia(endTrivia, result, currentTokens, ref lastWasBlank);
+        AddTokenLine(result, currentTokens, ref lastWasBlank);
+
+        for (var index = result.Count - 1; index >= 0; index--)
+        {
+            if (result[index].Kind == HandlerLineKind.Blank)
+            {
+                result.RemoveAt(index);
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    private static void ProcessTrivia(
+        IReadOnlyList<BlSyntaxTrivia> trivia,
+        List<HandlerLine> result,
+        List<BlSyntaxToken> currentTokens,
+        ref bool lastWasBlank)
+    {
+        if (trivia is null)
+        {
+            return;
+        }
+
+        foreach (var item in trivia)
+        {
+            if (item.Kind == BlSyntaxKind.CommentTrivia)
+            {
+                AddTokenLine(result, currentTokens, ref lastWasBlank);
+                AddCommentLine(result, ExtractCommentText(item), ref lastWasBlank);
+                continue;
+            }
+
+            if (item.Kind == BlSyntaxKind.NewLineTrivia)
+            {
+                AddTokenLine(result, currentTokens, ref lastWasBlank);
+                AddBlankLine(result, ref lastWasBlank);
+            }
+        }
+    }
+
+    private static void AddTokenLine(
+        List<HandlerLine> result,
+        List<BlSyntaxToken> currentTokens,
+        ref bool lastWasBlank)
+    {
+        if (currentTokens.Count == 0)
+        {
+            return;
+        }
+
+        result.Add(new HandlerLine(HandlerLineKind.Tokens, currentTokens.ToArray(), null));
+        currentTokens.Clear();
+        lastWasBlank = false;
+    }
+
+    private static void AddBlankLine(List<HandlerLine> result, ref bool lastWasBlank)
+    {
+        if (lastWasBlank)
+        {
+            return;
+        }
+
+        result.Add(new HandlerLine(HandlerLineKind.Blank, Array.Empty<BlSyntaxToken>(), null));
+        lastWasBlank = true;
+    }
+
+    private static void AddCommentLine(List<HandlerLine> result, string text, ref bool lastWasBlank)
+    {
+        result.Add(new HandlerLine(HandlerLineKind.Comment, Array.Empty<BlSyntaxToken>(), text));
+        lastWasBlank = false;
+    }
+
+    private static string ExtractCommentText(BlSyntaxTrivia trivia)
+    {
+        var text = trivia.Text.Trim();
+        if (text.StartsWith("--", StringComparison.Ordinal))
+        {
+            text = text[2..];
+        }
+
+        return text.Trim();
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/HandlerLineKind.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/HandlerLineKind.cs
@@ -1,0 +1,8 @@
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public enum HandlerLineKind
+{
+    Blank,
+    Comment,
+    Tokens,
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/HandlerTokenEmitContext.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/HandlerTokenEmitContext.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using BlingoEngine.Legacy.Lingo.Syntax;
+
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class HandlerTokenEmitContext
+{
+    public HandlerTokenEmitContext(BlCSharpCodeWriter writer, IReadOnlyList<BlSyntaxToken> tokens, HandlerBlockManager blocks)
+    {
+        Writer = writer ?? throw new ArgumentNullException(nameof(writer));
+        Tokens = tokens ?? Array.Empty<BlSyntaxToken>();
+        Blocks = blocks ?? throw new ArgumentNullException(nameof(blocks));
+    }
+
+    public BlCSharpCodeWriter Writer { get; }
+
+    public IReadOnlyList<BlSyntaxToken> Tokens { get; }
+
+    public HandlerBlockManager Blocks { get; }
+
+    public string ConvertExpression(IReadOnlyList<BlSyntaxToken> tokens)
+    {
+        return BlLegacyExpressionConverter.Convert(tokens);
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/IHandlerTokenVisitor.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/IHandlerTokenVisitor.cs
@@ -1,0 +1,6 @@
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public interface IHandlerTokenVisitor
+{
+    bool TryHandle(HandlerTokenEmitContext context);
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/IfTokenVisitor.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/IfTokenVisitor.cs
@@ -1,0 +1,25 @@
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class IfTokenVisitor : IHandlerTokenVisitor
+{
+    public bool TryHandle(HandlerTokenEmitContext context)
+    {
+        var tokens = context.Tokens;
+        if (tokens.Count == 0 || !BlLegacyHandlerTokenUtilities.IsKeyword(tokens[0], "if"))
+        {
+            return false;
+        }
+
+        var thenIndex = BlLegacyHandlerTokenUtilities.FindKeyword(tokens, "then");
+        if (thenIndex < 0)
+        {
+            return false;
+        }
+
+        var conditionTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, 1, thenIndex - 1);
+        var condition = context.ConvertExpression(conditionTokens);
+        context.Writer.WriteLine($"if ({condition})");
+        context.Blocks.OpenBlock(BlockKind.If);
+        return true;
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/MovieCallVisitor.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/MovieCallVisitor.cs
@@ -1,0 +1,19 @@
+using BlingoEngine.Legacy.Lingo.Syntax;
+
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class MovieCallVisitor : IHandlerTokenVisitor
+{
+    public bool TryHandle(HandlerTokenEmitContext context)
+    {
+        var tokens = context.Tokens;
+        if (tokens.Count != 1 || tokens[0].Kind != BlSyntaxKind.IdentifierToken)
+        {
+            return false;
+        }
+
+        var handlerName = BlCSharpName.SanitizeIdentifier(tokens[0].ValueText);
+        context.Writer.WriteLine($"CallMovieScript(movie => movie.{handlerName}());");
+        return true;
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/PutTokenVisitor.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/PutTokenVisitor.cs
@@ -1,0 +1,75 @@
+using System;
+using BlingoEngine.Legacy.Lingo.Syntax;
+
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class PutTokenVisitor : IHandlerTokenVisitor
+{
+    public bool TryHandle(HandlerTokenEmitContext context)
+    {
+        var tokens = context.Tokens;
+        if (tokens.Count == 0 || !BlLegacyHandlerTokenUtilities.IsKeyword(tokens[0], "put"))
+        {
+            return false;
+        }
+
+        var intoIndex = BlLegacyHandlerTokenUtilities.FindKeyword(tokens, "into");
+        if (intoIndex < 0)
+        {
+            return false;
+        }
+
+        var valueTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, 1, intoIndex - 1);
+        var targetTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, intoIndex + 1, tokens.Count - (intoIndex + 1));
+        var valueExpression = context.ConvertExpression(valueTokens);
+
+        if (targetTokens.Count >= 2 && BlLegacyHandlerTokenUtilities.IsIdentifier(targetTokens[0], "field"))
+        {
+            var fieldTokens = BlLegacyHandlerTokenUtilities.SliceTokens(targetTokens, 1, targetTokens.Count - 1);
+            var fieldName = context.ConvertExpression(fieldTokens);
+            context.Writer.WriteLine($"PutTextIntoField({fieldName}, {valueExpression});");
+            return true;
+        }
+
+        if (BlLegacyHandlerTokenUtilities.TryGetSpritePropertyTarget(targetTokens, out var spriteIndex, out var propertyName))
+        {
+            if (string.Equals(propertyName, "Member", StringComparison.Ordinal))
+            {
+                if (valueTokens.Count > 1 &&
+                    BlLegacyHandlerTokenUtilities.IsIdentifier(valueTokens[0], "member") &&
+                    valueTokens[1].Kind == BlSyntaxKind.LeftParenthesisToken)
+                {
+                    var closeIndex = BlLegacyHandlerTokenUtilities.FindMatchingToken(valueTokens, 1, BlSyntaxKind.LeftParenthesisToken, BlSyntaxKind.RightParenthesisToken);
+                    if (closeIndex == valueTokens.Count - 1)
+                    {
+                        var memberTokens = BlLegacyHandlerTokenUtilities.SliceTokens(valueTokens, 2, closeIndex - 2);
+                        var memberArgs = context.ConvertExpression(memberTokens);
+                        context.Writer.WriteLine($"Sprite({spriteIndex}).SetMember({memberArgs});");
+                        return true;
+                    }
+                }
+
+                context.Writer.WriteLine($"Sprite({spriteIndex}).Member = {valueExpression};");
+                return true;
+            }
+
+            context.Writer.WriteLine($"Sprite({spriteIndex}).{propertyName} = {valueExpression};");
+            return true;
+        }
+
+        if (BlLegacyHandlerTokenUtilities.TryGetListTarget(targetTokens, out var listExpression, out var listIndex))
+        {
+            context.Writer.WriteLine($"{listExpression}.SetAt({listIndex}, {valueExpression});");
+            return true;
+        }
+
+        var targetExpression = context.ConvertExpression(targetTokens);
+        if (targetExpression.Length == 0)
+        {
+            return false;
+        }
+
+        context.Writer.WriteLine($"{targetExpression} = {valueExpression};");
+        return true;
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/RepeatTokenVisitor.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/RepeatTokenVisitor.cs
@@ -1,0 +1,70 @@
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class RepeatTokenVisitor : IHandlerTokenVisitor
+{
+    public bool TryHandle(HandlerTokenEmitContext context)
+    {
+        var tokens = context.Tokens;
+        if (tokens.Count == 0 || !BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[0], "repeat"))
+        {
+            return false;
+        }
+
+        if (tokens.Count >= 4 && BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[1], "with"))
+        {
+            var variableToken = tokens[2];
+            var variableName = BlCSharpName.SanitizeIdentifier(variableToken.ValueText);
+            var inIndex = BlLegacyHandlerTokenUtilities.FindKeyword(tokens, "in");
+            if (inIndex > 0)
+            {
+                var sourceTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, inIndex + 1, tokens.Count - (inIndex + 1));
+                var source = context.ConvertExpression(sourceTokens);
+                context.Writer.WriteLine($"foreach (var {variableName} in {source})");
+                context.Blocks.OpenBlock(BlockKind.Loop);
+                return true;
+            }
+
+            var toIndex = BlLegacyHandlerTokenUtilities.FindKeyword(tokens, "to");
+            var equalsIndex = BlLegacyHandlerTokenUtilities.FindOperator(tokens, "=");
+            if (equalsIndex > 0 && toIndex > equalsIndex)
+            {
+                var startTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, equalsIndex + 1, toIndex - equalsIndex - 1);
+                var endTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, toIndex + 1, tokens.Count - (toIndex + 1));
+                var start = context.ConvertExpression(startTokens);
+                var end = context.ConvertExpression(endTokens);
+                context.Writer.WriteLine($"for (int {variableName} = {start}; {variableName} <= {end}; {variableName}++)");
+                context.Blocks.OpenBlock(BlockKind.Loop);
+                return true;
+            }
+
+            return false;
+        }
+
+        if (tokens.Count >= 3 && BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[1], "while"))
+        {
+            var conditionTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, 2, tokens.Count - 2);
+            var condition = context.ConvertExpression(conditionTokens);
+            context.Writer.WriteLine($"while ({condition})");
+            context.Blocks.OpenBlock(BlockKind.Loop);
+            return true;
+        }
+
+        if (tokens.Count >= 3 && BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[1], "until"))
+        {
+            var conditionTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, 2, tokens.Count - 2);
+            var condition = context.ConvertExpression(conditionTokens);
+            context.Writer.WriteLine("do");
+            context.Blocks.OpenBlock(BlockKind.RepeatUntil, condition);
+            return true;
+        }
+
+        if (tokens.Count >= 2 && BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[1], "forever"))
+        {
+            context.Writer.WriteLine("while (true)");
+            context.Blocks.OpenBlock(BlockKind.Loop);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/SendSpriteVisitor.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/SendSpriteVisitor.cs
@@ -1,0 +1,61 @@
+using BlingoEngine.Legacy.Lingo.Syntax;
+
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class SendSpriteVisitor : IHandlerTokenVisitor
+{
+    public bool TryHandle(HandlerTokenEmitContext context)
+    {
+        var tokens = context.Tokens;
+        if (tokens.Count == 0 || !BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[0], "sendSprite"))
+        {
+            return false;
+        }
+
+        var commaIndex = BlLegacyHandlerTokenUtilities.FindToken(tokens, BlSyntaxKind.CommaToken);
+        if (commaIndex < 0)
+        {
+            return false;
+        }
+
+        var channelTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, 1, commaIndex - 1);
+        if (commaIndex + 1 >= tokens.Count)
+        {
+            return false;
+        }
+
+        var handlerToken = tokens[commaIndex + 1];
+        if (handlerToken.Kind != BlSyntaxKind.SymbolToken)
+        {
+            return false;
+        }
+
+        var channelExpression = context.ConvertExpression(channelTokens);
+        var handlerName = BlCSharpName.SanitizeIdentifier(handlerToken.ValueText);
+        string? typeName = null;
+        string parameterName;
+
+        if (channelTokens.Count == 1 && tokens[1].Kind == BlSyntaxKind.NumberToken &&
+            int.TryParse(tokens[1].ValueText, out var channelNumber))
+        {
+            typeName = $"B{channelNumber}";
+            parameterName = $"b{channelNumber}";
+        }
+        else
+        {
+            parameterName = "sprite";
+        }
+
+        var lambdaCall = $"{parameterName}.{handlerName}()";
+        if (typeName is null)
+        {
+            context.Writer.WriteLine($"SendSprite({channelExpression}, {parameterName} => {lambdaCall});");
+        }
+        else
+        {
+            context.Writer.WriteLine($"SendSprite<{typeName}>({channelExpression}, {parameterName} => {lambdaCall});");
+        }
+
+        return true;
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/SpriteMemberAssignmentVisitor.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/SpriteMemberAssignmentVisitor.cs
@@ -1,0 +1,65 @@
+using BlingoEngine.Legacy.Lingo.Syntax;
+
+namespace BlingoEngine.Legacy.Lingo.CodeGen;
+
+public sealed class SpriteMemberAssignmentVisitor : IHandlerTokenVisitor
+{
+    public bool TryHandle(HandlerTokenEmitContext context)
+    {
+        var tokens = context.Tokens;
+        if (tokens.Count == 0 || !BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[0], "sprite"))
+        {
+            return false;
+        }
+
+        var openIndex = 1;
+        if (openIndex >= tokens.Count || tokens[openIndex].Kind != BlSyntaxKind.LeftParenthesisToken)
+        {
+            return false;
+        }
+
+        var closeIndex = BlLegacyHandlerTokenUtilities.FindMatchingToken(tokens, openIndex, BlSyntaxKind.LeftParenthesisToken, BlSyntaxKind.RightParenthesisToken);
+        if (closeIndex < 0 || closeIndex + 3 >= tokens.Count)
+        {
+            return false;
+        }
+
+        if (tokens[closeIndex + 1].Kind != BlSyntaxKind.PeriodToken ||
+            !BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[closeIndex + 2], "member"))
+        {
+            return false;
+        }
+
+        if (tokens[closeIndex + 3].Kind != BlSyntaxKind.OperatorToken ||
+            tokens[closeIndex + 3].ValueText != "=")
+        {
+            return false;
+        }
+
+        var valueIndex = closeIndex + 4;
+        if (valueIndex >= tokens.Count ||
+            !BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[valueIndex], "member"))
+        {
+            return false;
+        }
+
+        if (valueIndex + 1 >= tokens.Count ||
+            tokens[valueIndex + 1].Kind != BlSyntaxKind.LeftParenthesisToken)
+        {
+            return false;
+        }
+
+        var valueClose = BlLegacyHandlerTokenUtilities.FindMatchingToken(tokens, valueIndex + 1, BlSyntaxKind.LeftParenthesisToken, BlSyntaxKind.RightParenthesisToken);
+        if (valueClose < 0)
+        {
+            return false;
+        }
+
+        var indexTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, openIndex + 1, closeIndex - (openIndex + 1));
+        var memberTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, valueIndex + 2, valueClose - (valueIndex + 2));
+        var indexExpression = context.ConvertExpression(indexTokens);
+        var memberExpression = context.ConvertExpression(memberTokens);
+        context.Writer.WriteLine($"Sprite({indexExpression}).SetMember({memberExpression});");
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- extract the legacy handler converter helpers into dedicated source files and keep the converter focused on body extraction
- add an actor-list removal visitor and teach the put visitor to map sprite member targets to SetMember calls
- replace the single large generator assertion with focused loop, member, actor-list, put, and conditional handler conversion tests that share a helper base

## Testing
- dotnet test Test/BlingoEngine.Legacy.Lingo.Tests/BlingoEngine.Legacy.Lingo.Tests.csproj -v minimal

------
https://chatgpt.com/codex/tasks/task_e_68d15d7bc178833292b3e06b8499d107