### PR TITLE
Align SDL menu styling and menu registration

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Buttons/AbstSdlButton.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Buttons/AbstSdlButton.cs
@@ -11,7 +11,7 @@ using AbstUI.FrameworkCommunication;
 
 namespace AbstUI.SDL2.Components.Buttons
 {
-    internal class AbstSdlButton : AbstSdlComponent, IAbstFrameworkButton, IFrameworkFor<AbstButton>, IHandleSdlEvent, ISdlFocusable, IDisposable
+    internal class AbstSdlButton : AbstSdlComponent, IAbstFrameworkButton, IFrameworkFor<AbstButton>, IHandleSdlEvent, ISdlFocusable, IDisposable, IHasButtonBorderStates
     {
         private ISdlFontLoadedByUser? _font;
         private nint _texture;
@@ -270,6 +270,14 @@ namespace AbstUI.SDL2.Components.Buttons
             _iconTextureSub?.Release();
             _font?.Release();
             base.Dispose();
+        }
+
+        public void SetBorderStateColors(AColor normal, AColor hover, AColor pressed)
+        {
+            _borderColor = normal;
+            _borderHoverColor = hover;
+            _borderPressedColor = pressed;
+            RequestRedraw();
         }
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Menus/AbstSdlMenu.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Menus/AbstSdlMenu.cs
@@ -24,6 +24,8 @@ namespace AbstUI.SDL2.Components.Menus
         private int _texW;
         private int _texH;
         private int _hoverIndex = -1;
+        private bool _suppressNextRelease;
+        private bool _dragSelecting;
 
         private const int ItemHeight = 18;
 
@@ -62,8 +64,11 @@ namespace AbstUI.SDL2.Components.Menus
         {
             if (button is AbstSdlButton sdlBtn)
             {
-                X = sdlBtn.X;
-                Y = sdlBtn.Y + sdlBtn.Height;
+                var buttonPos = GetAbsolutePosition(sdlBtn.ComponentContext);
+                var parentCtx = ComponentContext.VisualParent ?? ComponentContext;
+                var parentPos = GetAbsolutePosition(parentCtx);
+                X = buttonPos.X - parentPos.X;
+                Y = buttonPos.Y - parentPos.Y + sdlBtn.Height;
             }
         }
 
@@ -73,6 +78,8 @@ namespace AbstUI.SDL2.Components.Menus
             Factory.RootContext.ComponentContainer.Activate(ComponentContext);
             _isDirty = true;
             ComponentContext.QueueRedraw(this);
+            _suppressNextRelease = true;
+            _dragSelecting = false;
         }
 
         public void HandleEvent(AbstSDLEvent e)
@@ -100,13 +107,29 @@ namespace AbstUI.SDL2.Components.Menus
                             _isDirty = true;
                             ComponentContext.QueueRedraw(this);
                         }
+                        _dragSelecting = (ev.motion.state & SDL.SDL_BUTTON_LMASK) != 0;
                         break;
                     }
+                case SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN:
+                    if (ev.button.button == SDL.SDL_BUTTON_LEFT)
+                    {
+                        _dragSelecting = true;
+                        _suppressNextRelease = false;
+                    }
+                    break;
                 case SDL.SDL_EventType.SDL_MOUSEBUTTONUP:
                     if (ev.button.button == SDL.SDL_BUTTON_LEFT)
                     {
+                        if (_suppressNextRelease && !_dragSelecting)
+                        {
+                            _suppressNextRelease = false;
+                            _dragSelecting = false;
+                            break;
+                        }
+                        _suppressNextRelease = false;
                         int localY = ev.button.y - (int)Y;
                         int idx = localY / ItemHeight;
+                        _dragSelecting = false;
                         if (idx >= 0 && idx < _items.Count)
                         {
                             var item = _items[idx];
@@ -126,6 +149,20 @@ namespace AbstUI.SDL2.Components.Menus
         {
             if (_font == null)
                 _font = _fontManager.GetDefaultFont<IAbstSdlFont>().Get(this, 12);
+        }
+
+        private static (float X, float Y) GetAbsolutePosition(AbstSDLComponentContext context)
+        {
+            float x = context.X;
+            float y = context.Y;
+            var parent = context.VisualParent;
+            while (parent != null)
+            {
+                x += parent.X;
+                y += parent.Y;
+                parent = parent.VisualParent;
+            }
+            return (x, y);
         }
 
         public override AbstSDLRenderResult Render(AbstSDLRenderContext context)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Buttons/IHasButtonBorderStates.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Buttons/IHasButtonBorderStates.cs
@@ -1,0 +1,16 @@
+using AbstUI.Primitives;
+
+namespace AbstUI.Components.Buttons;
+
+public interface IHasButtonBorderStates
+{
+    void SetBorderStateColors(AColor normal, AColor hover, AColor pressed);
+}
+
+public static class ButtonBorderStateExtensions
+{
+    public static void SetUniformBorderColor(this IHasButtonBorderStates button, AColor color)
+    {
+        button.SetBorderStateColors(color, color, color);
+    }
+}

--- a/src/Director/BlingoEngine.Director.Core/UI/DirectorMainMenu.cs
+++ b/src/Director/BlingoEngine.Director.Core/UI/DirectorMainMenu.cs
@@ -482,6 +482,12 @@ namespace BlingoEngine.Director.Core.UI
             _redoItem.Enabled = _historyManager.CanRedo;
         }
 
+        protected override void OnInit(IAbstFrameworkWindow frameworkWindow)
+        {
+            base.OnInit(frameworkWindow);
+            CallOnAllTopMenus(menu => Framework.RegisterTopMenu(menu));
+        }
+
 
 
         protected override void OnDispose()

--- a/src/Director/BlingoEngine.Director.Core/UI/IDirFrameworkMainMenuWindow.cs
+++ b/src/Director/BlingoEngine.Director.Core/UI/IDirFrameworkMainMenuWindow.cs
@@ -1,11 +1,11 @@
-﻿using AbstUI.Windowing;
+using AbstUI.Components.Menus;
+using AbstUI.Windowing;
 using BlingoEngine.Director.Core.Windowing;
 
 namespace BlingoEngine.Director.Core.UI
 {
     public interface IDirFrameworkMainMenuWindow : IAbstFrameworkWindow
     {
-
+        void RegisterTopMenu(AbstMenu menu);
     }
 }
-

--- a/src/Director/BlingoEngine.Director.LGodot/UI/DirGodotMainMenu.cs
+++ b/src/Director/BlingoEngine.Director.LGodot/UI/DirGodotMainMenu.cs
@@ -1,5 +1,6 @@
 ﻿using AbstUI.Commands;
 using AbstUI.Components;
+using AbstUI.Components.Menus;
 using AbstUI.FrameworkCommunication;
 using AbstUI.Inputs;
 using AbstUI.LGodot.Components;
@@ -85,11 +86,6 @@ internal partial class DirGodotMainMenu : Control , IDirFrameworkMainMenuWindow,
         _menuBar.Position = new Vector2(10, 1);
         _iconBar.Position = new Vector2(400, 1);
 
-        directorMainMenu.CallOnAllTopMenus(btn =>
-        {
-            AddChild(btn.Framework<AbstGodotMenu>());
-        });
-
         StyleTopMenu(directorMainMenu);
         foreach (var childItem in _iconBar.GetChild(0).GetChildren())
         {
@@ -102,7 +98,12 @@ internal partial class DirGodotMainMenu : Control , IDirFrameworkMainMenuWindow,
     }
     public void Init(IAbstWindow instance)
     {
-        
+
+    }
+
+    public void RegisterTopMenu(AbstMenu menu)
+    {
+        AddChild(menu.Framework<AbstGodotMenu>());
     }
 
     private static void StyleIconButton(Button btn)

--- a/src/Director/BlingoEngine.Director.SDL2/UI/DirSDLMainMenu.cs
+++ b/src/Director/BlingoEngine.Director.SDL2/UI/DirSDLMainMenu.cs
@@ -1,13 +1,19 @@
-﻿using AbstUI.Commands;
+using System;
+using AbstUI.Commands;
 using AbstUI.Components;
+using AbstUI.Components.Buttons;
 using AbstUI.Components.Containers;
+using AbstUI.Components.Menus;
 using AbstUI.FrameworkCommunication;
 using AbstUI.Inputs;
 using AbstUI.SDL2.Components;
+using AbstUI.SDL2.Components.Buttons;
 using AbstUI.SDL2.Components.Containers;
+using AbstUI.SDL2.Styles;
 using AbstUI.SDL2.Windowing;
 using AbstUI.Tools;
 using AbstUI.Windowing;
+using AbstUI.Primitives;
 using BlingoEngine.Core;
 using BlingoEngine.Director.Core.Projects;
 using BlingoEngine.Director.Core.Styles;
@@ -62,6 +68,7 @@ internal partial class DirSDLMainMenu : AbstSdlWindow, IDirFrameworkMainMenuWind
         _root.BackgroundColor = DirectorColors.BG_TopMenu;
         _root.AddItem(directorMainMenu.MenuBar, _menuBar.X, _menuBar.Y);
         _root.AddItem(directorMainMenu.IconBar, _iconBar.X, _iconBar.Y);
+        StyleTopMenuButtons();
         //_root.Compose(Factory).NextRow().Finalize();
         //_root.Compose(Factory).NextRow().AddButton("hallo", "Halo", () => { }).AddLabel("rzer", "tedft").Finalize();
         //directorMainMenu.CallOnAllTopMenus(btn =>
@@ -83,6 +90,36 @@ internal partial class DirSDLMainMenu : AbstSdlWindow, IDirFrameworkMainMenuWind
     {
         base.Init(instance);
         Content = _root.FrameworkObj;
+    }
+
+    public void RegisterTopMenu(AbstMenu menu)
+    {
+        _root.AddItem(menu);
+    }
+
+    private void StyleTopMenuButtons()
+    {
+        var baseColor = DirectorColors.BG_TopMenu;
+        var hoverColor = baseColor.Lighten(0.1f);
+        var fontManager = _componentFactory.FontManagerTyped;
+
+        _directorMainMenu.CallOnAllTopMenuButtons(btn =>
+        {
+            btn.Margin = AMargin.Zero;
+            btn.BackgroundColor = baseColor;
+            btn.BackgroundHoverColor = hoverColor;
+            btn.BorderColor = AColor.Transparent();
+            if (btn.FrameworkObj is IHasButtonBorderStates borderStates)
+            {
+                borderStates.SetUniformBorderColor(AColor.Transparent());
+            }
+            btn.TextColor = DirectorColors.TextColorLabels;
+
+            var text = btn.Text ?? string.Empty;
+            var textWidth = fontManager.MeasureTextWidth(text, SdlFontManager.DefaultFontName, 12);
+            const float horizontalPadding = 12f;
+            btn.Width = MathF.Ceiling(textWidth + horizontalPadding);
+        });
     }
 
     //private static void StyleIconButton(Button btn)


### PR DESCRIPTION
## Summary
- expose a `RegisterTopMenu` hook on `IDirFrameworkMainMenuWindow` and register all top menus during `DirectorMainMenu` initialisation
- update the SDL main menu window to register popups, size buttons to their text and remove borders for the top menu bar
- add `IHasButtonBorderStates` so frameworks can align hover/pressed border colours explicitly and use it from the SDL main menu instead of changing the base setter

## Testing
- `dotnet build WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/AbstUI.SDL2.csproj`
- `dotnet build src/Director/BlingoEngine.Director.SDL2/BlingoEngine.Director.SDL2.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68d189a2f6648332a43a278a425ae287