### PR TITLE
Normalize newline comparisons in legacy IO tests

### DIFF
--- a/Test/BlingoEngine.IO.Legacy.Tests/Helpers/ResultTestHelper.cs
+++ b/Test/BlingoEngine.IO.Legacy.Tests/Helpers/ResultTestHelper.cs
@@ -1,0 +1,22 @@
+using System;
+using FluentAssertions;
+
+#nullable enable
+
+namespace BlingoEngine.IO.Legacy.Tests.Helpers;
+
+internal static class ResultTestHelper
+{
+    public static void ShouldMatchNormalized(this string? actual, string expected)
+    {
+        NormalizeLineEndings(actual).Should().Be(NormalizeLineEndings(expected));
+    }
+
+    public static string NormalizeLineEndings(string? value)
+    {
+        return (value ?? string.Empty)
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace("\r", "\n", StringComparison.Ordinal)
+            .Trim();
+    }
+}

--- a/Test/BlingoEngine.IO.Legacy.Tests/Scripts/BlLegacyScriptReaderTests.cs
+++ b/Test/BlingoEngine.IO.Legacy.Tests/Scripts/BlLegacyScriptReaderTests.cs
@@ -34,7 +34,7 @@ public class BlLegacyScriptReaderTests
         var singleScripts = TestContextHarness.LoadScripts("Behaviors/5spritesTest_With_Behavior.dir");
 
         var singleScript = singleScripts.Should().ContainSingle(s => s.ResourceId == 5).Subject;
-        singleScript.Text.Should().Be("on beginsprite\r  put 12\rend");
+        singleScript.Text.ShouldMatchNormalized("on beginsprite\r  put 12\rend");
         singleScript.Name.Should().Be("MyTestBe");
 
         var multiScripts = TestContextHarness.LoadScripts("Behaviors/Two_Behaviors.dir");
@@ -42,27 +42,29 @@ public class BlLegacyScriptReaderTests
         multiScripts.Should().HaveCount(2);
         multiScripts.Should().OnlyContain(s => s.Text != null && s.Name != null);
 
-        var expectedContents = new[]
-        {
-            "on exitFrame me\r  put 20\r    put \"I'm in cast slot 1\"\rend",
-            "on exitFrame me\r  put \"hallo\"\r  put \"I'm in cast slot 3\"\rend"
-        };
-
-        var expectedNamesByText = new Dictionary<string, string>
+        var expectedScripts = new Dictionary<string, string>
         {
             ["on exitFrame me\r  put 20\r    put \"I'm in cast slot 1\"\rend"] = "MyFirstBehaviorOnFrame10",
             ["on exitFrame me\r  put \"hallo\"\r  put \"I'm in cast slot 3\"\rend"] = "MeSecondBehaviorOnFrame20"
         };
 
-        multiScripts
-            .Select(script => script.Text!)
-            .Should()
-            .BeEquivalentTo(expectedContents);
+        var normalizedExpectations = expectedScripts.ToDictionary(
+            pair => ResultTestHelper.NormalizeLineEndings(pair.Key),
+            pair => pair);
 
         foreach (var script in multiScripts)
         {
-            script.Name.Should().Be(expectedNamesByText[script.Text!]);
+            var normalizedText = ResultTestHelper.NormalizeLineEndings(script.Text);
+            normalizedExpectations.Should().ContainKey(normalizedText);
+
+            var expected = normalizedExpectations[normalizedText];
+            script.Text.ShouldMatchNormalized(expected.Key);
+            script.Name.Should().Be(expected.Value);
+
+            normalizedExpectations.Remove(normalizedText);
         }
+
+        normalizedExpectations.Should().BeEmpty();
     }
 
     [Fact]
@@ -153,7 +155,7 @@ public class BlLegacyScriptReaderTests
 
         var script = scripts.Should().ContainSingle(s => s.ResourceId == scriptId).Subject;
         script.Format.Should().Be(BlLegacyScriptFormatKind.Behavior);
-        script.Text.Should().Be(scriptText);
+        script.Text.ShouldMatchNormalized(scriptText);
         script.Name.Should().Be(scriptName);
     }
 
@@ -189,7 +191,7 @@ public class BlLegacyScriptReaderTests
 
         var script = scripts.Should().ContainSingle(s => s.ResourceId == scriptId).Subject;
         script.Format.Should().Be(BlLegacyScriptFormatKind.Movie);
-        script.Text.Should().Be(scriptText);
+        script.Text.ShouldMatchNormalized(scriptText);
         script.Name.Should().Be(scriptName);
     }
 

--- a/Test/BlingoEngine.IO.Legacy.Tests/Texts/XmedFileTest.cs
+++ b/Test/BlingoEngine.IO.Legacy.Tests/Texts/XmedFileTest.cs
@@ -17,7 +17,7 @@ public class XmedFileTest
         var document = ReadDocument("Text_Hallo_tab_true_13.xmed.bin");
 
         string textFromRuns = string.Concat(document.Runs.Select(run => run.Text));
-        textFromRuns.Should().Be("Hallo");
+        textFromRuns.ShouldMatchNormalized("Hallo");
         document.Runs.Should().HaveCount(1);
     }
 
@@ -27,7 +27,7 @@ public class XmedFileTest
         var document = ReadDocument("Text_Hallo_multifont_13.xmed.bin");
 
         string textFromRuns = string.Concat(document.Runs.Select(run => run.Text));
-        textFromRuns.Should().Be("Hallo");
+        textFromRuns.ShouldMatchNormalized("Hallo");
         document.Runs.Should().HaveCount(1);
     }
 
@@ -37,7 +37,7 @@ public class XmedFileTest
         var document = ReadDocument("Text_Hallo_multiLine_13.xmed.bin");
 
         string textFromRuns = string.Concat(document.Runs.Select(run => run.Text));
-        textFromRuns.Should().Be("Hallo\rmulti line\ris longer\rYES!");
+        textFromRuns.ShouldMatchNormalized("Hallo\rmulti line\ris longer\rYES!");
     }
 
     [Fact]
@@ -46,7 +46,7 @@ public class XmedFileTest
         var document = ReadDocument("Text_Single_Line_Multi_Style_13.xmed.bin");
 
         string textFromRuns = string.Concat(document.Runs.Select(run => run.Text));
-        textFromRuns.Should().Be("This text is red, Arial,12px,  The text is yellow, Tahoma, 9px, , bold, italic, underline The text is green, font Terminal, 18px, with spacing of 39 The text is orange, Tahoma, 9px, bold, italic, underline This text is red, Arial,12px, again");
+        textFromRuns.ShouldMatchNormalized("This text is red, Arial,12px,  The text is yellow, Tahoma, 9px, , bold, italic, underline The text is green, font Terminal, 18px, with spacing of 39 The text is orange, Tahoma, 9px, bold, italic, underline This text is red, Arial,12px, again");
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public class XmedFileTest
         var document = ReadDocument("Text_Hallo_text_transform_all_on_13.xmed.bin");
 
         string textFromRuns = string.Concat(document.Runs.Select(run => run.Text));
-        textFromRuns.Should().Be("Hallo");
+        textFromRuns.ShouldMatchNormalized("Hallo");
     }
 
     private static XmedDocument ReadDocument(string fileName)


### PR DESCRIPTION
## Summary
- add a helper to normalize line endings in BlingoEngine.IO.Legacy tests
- compare legacy script and XMED text expectations using the normalized helper

## Testing
- `dotnet test Test/BlingoEngine.IO.Legacy.Tests/BlingoEngine.IO.Legacy.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68d19455cc608332a6762de48e9bdb72