### PR TITLE
Deduplicate property list entries when generating behavior code

### DIFF
--- a/Test/BlingoEngine.Lingo.Core.Tests/BlingoToCSharpConverterTests.cs
+++ b/Test/BlingoEngine.Lingo.Core.Tests/BlingoToCSharpConverterTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace BlingoEngine.Lingo.Core.Tests;
@@ -194,6 +195,28 @@ end";
             "        .Add(this, x => x.myFunction, \"function to execute:\", \"70\");",
             "}");
         Assert.Equal(expected.Trim(), result.Replace("\r", "").Trim());
+    }
+
+    [Fact]
+    public void DuplicatePropertyDescriptionEntriesAreOverwritten()
+    {
+        var lingo = string.Join('\n',
+            "on getPropertyDescriptionList",
+            "  description = [:]",
+            "  addProp description,#myValue, [#default:1, #format:#integer, #comment:\"Value:\"]",
+            "  addProp description,#myVar1, [#default:0, #format:#integer, #comment:\"Var 1:\"]",
+            "  addProp description,#myValue, [#default:5, #format:#integer, #comment:\"Value Updated:\"]",
+            "  return description",
+            "end");
+        var result = _converter.Convert(lingo);
+        var addMatches = Regex.Matches(result, @"\.Add\(this,\s*x => x\.(?<name>\w+)");
+        var propertyNames = addMatches.Cast<Match>().Select(m => m.Groups["name"].Value).ToList();
+        Assert.Equal(propertyNames.Count, propertyNames.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+
+        var valueMatch = Regex.Match(result, @"\.Add\(this,\s*x => x\.myValue,\s*""(?<comment>[^""]*)"",\s*(?<default>[^\)]+)\)");
+        Assert.True(valueMatch.Success);
+        Assert.Equal("Value Updated:", valueMatch.Groups["comment"].Value);
+        Assert.Equal("5", valueMatch.Groups["default"].Value.Trim());
     }
 
     [Fact]

--- a/Test/BlingoEngine.Lingo.Core.Tests/ClassGenerationTests.cs
+++ b/Test/BlingoEngine.Lingo.Core.Tests/ClassGenerationTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Linq;
 using FluentAssertions;
+using System;
+using System.Text.RegularExpressions;
 using BlingoEngine.Lingo.Core;
 using Xunit;
 
@@ -77,7 +79,6 @@ public class MyParentParent : BlingoParentScript
     public MyParentParent(IBlingoMovieEnvironment env, GlobalVars global, object x) : base(env)
     {
         _global = global;
-        
         myVar = x;
     }
 }";
@@ -216,6 +217,38 @@ end",
         Assert.Contains(".Add(this, x => x.myFunction, \"function to execute:\", \"70\")", result);
         Assert.Contains("public int myStartMembernum = 0;", result);
         Assert.Contains("public string myFunction = \"70\";", result);
+
+        var addMatches = Regex.Matches(result, @"\.Add\(this,\s*x => x\.(?<name>\w+)");
+        var propertyNames = addMatches.Cast<Match>().Select(m => m.Groups["name"].Value).ToList();
+        Assert.Equal(8, propertyNames.Count);
+        Assert.Equal(propertyNames.Count, propertyNames.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+    }
+
+    [Fact]
+    public void DuplicatePropertyDescriptionEntriesAreOverwrittenInClassGeneration()
+    {
+        var file = new BlingoScriptFile
+        {
+            Name = "DupScript",
+            Source = @"on getPropertyDescriptionList
+  description = [:]
+  addProp description,#myValue, [#default:1, #format:#integer, #comment:""First:""]
+  addProp description,#myValue, [#default:2, #format:#integer, #comment:""Second:""]
+  return description
+end",
+            Type = BlingoScriptType.Behavior
+        };
+
+        var result = _converter.ConvertClass(file);
+
+        var matches = Regex.Matches(result, @"\.Add\(this,\s*x => x\.(?<name>\w+)");
+        var propertyNames = matches.Cast<Match>().Select(m => m.Groups["name"].Value).ToList();
+        Assert.Single(propertyNames);
+
+        var valueMatch = Regex.Match(result, @"\.Add\(this,\s*x => x\.myValue,\s*""(?<comment>[^""]*)"",\s*(?<default>[^\)]+)\)");
+        Assert.True(valueMatch.Success);
+        Assert.Equal("Second:", valueMatch.Groups["comment"].Value);
+        Assert.Equal("2", valueMatch.Groups["default"].Value.Trim());
     }
 
     [Fact]

--- a/src/BlingoEngine.Lingo.Core/BlingoToCSharpConverter.cs
+++ b/src/BlingoEngine.Lingo.Core/BlingoToCSharpConverter.cs
@@ -587,7 +587,7 @@ public class BlingoToCSharpConverter
 
     private static List<(string Name, string Default, string Comment, string Format)> ExtractPropertyDescriptions(string source)
     {
-        var list = new List<(string Name, string Default, string Comment, string Format)>();
+        var builder = new OrderedPropertyListBuilder<string, (string Name, string Default, string Comment, string Format)>(StringComparer.OrdinalIgnoreCase);
         var regex = new Regex(@"addProp\s+description,#(?<name>\w+),\s*\[(?<body>[^\]]*)\]", RegexOptions.IgnoreCase | RegexOptions.Singleline);
         foreach (Match m in regex.Matches(source))
         {
@@ -605,9 +605,10 @@ public class BlingoToCSharpConverter
             else if (fmt == "color" && Regex.IsMatch(def, @"^\d+$"))
                 def = $"AColor.FromCode({def})";
             var comment = commentMatch.Success ? Escape(commentMatch.Groups[1].Value) : string.Empty;
-            list.Add((name, def, comment, fmt));
+            var entry = (name, def, comment, fmt);
+            builder.AddOrUpdate(name, entry);
         }
-        return list;
+        return builder.ToList();
     }
 
     private static List<string> ExtractPropertyDeclarations(string source)

--- a/src/BlingoEngine.Lingo.Core/CSharpWriter.HandlerWriter.cs
+++ b/src/BlingoEngine.Lingo.Core/CSharpWriter.HandlerWriter.cs
@@ -53,7 +53,7 @@ public partial class CSharpWriter
         AppendLine("{");
         Indent();
 
-        var props = new List<PropDesc>();
+        var propBuilder = new OrderedPropertyListBuilder<string, PropDesc>(StringComparer.OrdinalIgnoreCase);
         foreach (var child in node.Block.Children)
         {
             if (child is BlingoCallNode call &&
@@ -97,11 +97,12 @@ public partial class CSharpWriter
                 if (propName != null && comment != null && defDatum != null)
                 {
                     var defVal = FormatDefault(defDatum, format);
-                    props.Add(new PropDesc(propName, EscapeString(comment), defVal));
+                    propBuilder.AddOrUpdate(propName, new PropDesc(propName, EscapeString(comment), defVal));
                 }
             }
         }
 
+        var props = propBuilder.Items;
         if (props.Count > 0)
         {
             AppendLine("return new BehaviorPropertyDescriptionList()");

--- a/src/BlingoEngine.Lingo.Core/OrderedPropertyListBuilder.cs
+++ b/src/BlingoEngine.Lingo.Core/OrderedPropertyListBuilder.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace BlingoEngine.Lingo.Core;
+
+internal sealed class OrderedPropertyListBuilder<TKey, TValue>
+    where TKey : notnull
+{
+    private readonly Dictionary<TKey, int> _indices;
+    private readonly List<TValue> _items = new();
+
+    public OrderedPropertyListBuilder(IEqualityComparer<TKey>? comparer = null)
+    {
+        _indices = new Dictionary<TKey, int>(comparer ?? EqualityComparer<TKey>.Default);
+    }
+
+    public void AddOrUpdate(TKey key, TValue value)
+    {
+        if (_indices.TryGetValue(key, out var index))
+        {
+            _items[index] = value;
+        }
+        else
+        {
+            _indices[key] = _items.Count;
+            _items.Add(value);
+        }
+    }
+
+    public IReadOnlyList<TValue> Items => _items;
+
+    public List<TValue> ToList() => new(_items);
+}


### PR DESCRIPTION
## Summary
- add an ordered property list builder that replaces prior entries when the same key is added again
- use the ordered builder when extracting property descriptions and when emitting getPropertyDescriptionList handlers
- add regression tests ensuring duplicate property description entries are overwritten in both converter paths

## Testing
- dotnet test Test/BlingoEngine.Lingo.Core.Tests/BlingoEngine.Lingo.Core.Tests.csproj -c Release

------
https://chatgpt.com/codex/tasks/task_e_68d38117b4cc8332bdb0c1c0586ba7de