### PR TITLE
Fix SignalR command binding for RNet commands

### DIFF
--- a/Test/BlingoEngine.Net.RNetPipe.Tests/RNetCommandSerializationTests.cs
+++ b/Test/BlingoEngine.Net.RNetPipe.Tests/RNetCommandSerializationTests.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using BlingoEngine.Net.RNetContracts;
+
+namespace BlingoEngine.Net.RNetPipe.Tests;
+
+public class RNetCommandSerializationTests
+{
+    public static TheoryData<RNetCommand> CommandData => new()
+    {
+        new SetSpritePropCmd(1, 2, RNetSpriteTypeDto.Sprite2D, "LocH", "42"),
+        new SetMemberPropCmd(3, 4, RNetMemberTypeDto.Bitmap, "Name", "Sprite"),
+        new SetCastPropCmd(5, "Label", "Cast"),
+        new GoToFrameCmd(123),
+        new RewindCmd(),
+        new PauseCmd(),
+        new ResumeCmd(),
+    };
+
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
+
+    [Theory]
+    [MemberData(nameof(CommandData))]
+    public void SerializeAsRNetCommand_RoundTrips(RNetCommand command)
+    {
+        var json = JsonSerializer.Serialize(command, Options);
+        var result = JsonSerializer.Deserialize<RNetCommand>(json, Options);
+
+        Assert.NotNull(result);
+        Assert.IsType(command.GetType(), result);
+        Assert.Equal(command, result);
+    }
+
+    [Theory]
+    [MemberData(nameof(CommandData))]
+    public void SerializeAsObject_RoundTrips(RNetCommand command)
+    {
+        var json = JsonSerializer.Serialize<object>(command, Options);
+        var result = JsonSerializer.Deserialize<RNetCommand>(json, Options);
+
+        Assert.NotNull(result);
+        Assert.IsType(command.GetType(), result);
+        Assert.Equal(command, result);
+    }
+}

--- a/src/Net/BlingoEngine.Net.RNetContracts/RNetCommand.cs
+++ b/src/Net/BlingoEngine.Net.RNetContracts/RNetCommand.cs
@@ -1,8 +1,18 @@
-﻿namespace BlingoEngine.Net.RNetContracts;
+﻿using System.Text.Json.Serialization;
+
+namespace BlingoEngine.Net.RNetContracts;
 
 /// <summary>
 /// Base type for commands sent over the network.
 /// </summary>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "$type")]
+[JsonDerivedType(typeof(SetSpritePropCmd), nameof(SetSpritePropCmd))]
+[JsonDerivedType(typeof(SetMemberPropCmd), nameof(SetMemberPropCmd))]
+[JsonDerivedType(typeof(SetCastPropCmd), nameof(SetCastPropCmd))]
+[JsonDerivedType(typeof(GoToFrameCmd), nameof(GoToFrameCmd))]
+[JsonDerivedType(typeof(RewindCmd), nameof(RewindCmd))]
+[JsonDerivedType(typeof(PauseCmd), nameof(PauseCmd))]
+[JsonDerivedType(typeof(ResumeCmd), nameof(ResumeCmd))]
 public abstract record RNetCommand : IRNetCommand;
 
 /// <summary>


### PR DESCRIPTION
## Summary
- annotate `RNetCommand` with `JsonPolymorphic` metadata so SignalR can deserialize derived command payloads from the terminal
- add serialization round-trip tests that cover sending commands as both `RNetCommand` and plain `object`

## Testing
- dotnet test Test/BlingoEngine.Net.RNetPipe.Tests/BlingoEngine.Net.RNetPipe.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d3ae8e94f48332adbf84680250137b