### PR TITLE
Fix RNet hub command binding with explicit command envelopes

### DIFF
--- a/Test/BlingoEngine.Net.RNetPipe.Tests/RNetCommandSerializationTests.cs
+++ b/Test/BlingoEngine.Net.RNetPipe.Tests/RNetCommandSerializationTests.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using BlingoEngine.Net.RNetContracts;
+
+namespace BlingoEngine.Net.RNetPipe.Tests;
+
+public class RNetCommandSerializationTests
+{
+    public static TheoryData<RNetCommand> CommandData => new()
+    {
+        new SetSpritePropCmd(1, 2, RNetSpriteTypeDto.Sprite2D, "LocH", "42"),
+        new SetMemberPropCmd(3, 4, RNetMemberTypeDto.Bitmap, "Name", "Sprite"),
+        new SetCastPropCmd(5, "Label", "Cast"),
+        new GoToFrameCmd(123),
+        new RewindCmd(),
+        new PauseCmd(),
+        new ResumeCmd(),
+    };
+
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
+
+    [Theory]
+    [MemberData(nameof(CommandData))]
+    public void SerializeAsRNetCommand_RoundTrips(RNetCommand command)
+    {
+        var json = JsonSerializer.Serialize(command, Options);
+        var result = JsonSerializer.Deserialize<RNetCommand>(json, Options);
+
+        Assert.NotNull(result);
+        Assert.IsType(command.GetType(), result);
+        Assert.Equal(command, result);
+    }
+
+    [Theory]
+    [MemberData(nameof(CommandData))]
+    public void SerializeAsObject_RoundTrips(RNetCommand command)
+    {
+        var json = JsonSerializer.Serialize<object>(command, Options);
+        var result = JsonSerializer.Deserialize<RNetCommand>(json, Options);
+
+        Assert.NotNull(result);
+        Assert.IsType(command.GetType(), result);
+        Assert.Equal(command, result);
+    }
+}

--- a/Test/BlingoEngine.Net.RNetProjectHost.Tests/BlingoEngine.Net.RNetProjectHost.Tests.csproj
+++ b/Test/BlingoEngine.Net.RNetProjectHost.Tests/BlingoEngine.Net.RNetProjectHost.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Net\BlingoEngine.Net.RNetProjectClient\BlingoEngine.Net.RNetProjectClient.csproj" />
+    <ProjectReference Include="..\..\src\Net\BlingoEngine.Net.RNetProjectHost\BlingoEngine.Net.RNetProjectHost.csproj" />
+    <ProjectReference Include="..\..\src\Net\BlingoEngine.Net.RNetContracts\BlingoEngine.Net.RNetContracts.csproj" />
+    <ProjectReference Include="..\..\src\Net\BlingoEngine.Net.RNetHost.Common\BlingoEngine.Net.RNetHost.Common.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/Test/BlingoEngine.Net.RNetProjectHost.Tests/Fakes/FakeBlingoPlayer.cs
+++ b/Test/BlingoEngine.Net.RNetProjectHost.Tests/Fakes/FakeBlingoPlayer.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BlingoEngine.Casts;
+using BlingoEngine.Core;
+using BlingoEngine.Members;
+using BlingoEngine.Movies;
+using BlingoEngine.Sounds;
+using BlingoEngine.Stages;
+
+namespace BlingoEngine.Net.RNetProjectHost.Tests.Fakes;
+
+internal sealed class FakeBlingoPlayer : IBlingoPlayer
+{
+    private IBlingoMovie? _activeMovie;
+
+    public IBlingoCast ActiveCastLib => throw new NotSupportedException();
+
+    public IBlingoMovie? ActiveMovie => _activeMovie;
+
+    public event Action<IBlingoMovie?>? ActiveMovieChanged;
+
+    public void SetActiveMovie(IBlingoMovie? movie)
+    {
+        _activeMovie = movie;
+        ActiveMovieChanged?.Invoke(movie);
+    }
+
+    public IBlingoSound Sound => throw new NotSupportedException();
+
+    public bool MediaRequiresAsyncPreload { get; set; }
+
+    public int CurrentSpriteNum => 0;
+
+    public bool NetPreset => false;
+
+    public bool ActiveWindow => false;
+
+    public bool SafePlayer { get; set; }
+
+    public string OrganizationName { get; set; } = string.Empty;
+
+    public string ApplicationName { get; set; } = string.Empty;
+
+    public string ApplicationPath { get; set; } = string.Empty;
+
+    public string ProductName { get; set; } = string.Empty;
+
+    public int LastClick => 0;
+
+    public int LastEvent => 0;
+
+    public int LastKey => 0;
+
+    public Version ProductVersion { get; set; } = new(1, 0);
+
+    public IBlingoCastLibsContainer CastLibs => throw new NotSupportedException();
+
+    public IBlingoMember? GetMember(BlingoMemberRef memberRef) => throw new NotSupportedException();
+
+    public T? GetMember<T>(BlingoMemberRef memberRef) where T : class, IBlingoMember => throw new NotSupportedException();
+
+    public IBlingoCast? GetCast(BlingoCastRef castRef) => throw new NotSupportedException();
+
+    public Func<string> AlertHook { get; set; } = () => string.Empty;
+
+    public IBlingoStage Stage => throw new NotSupportedException();
+
+    public void Alert(string message)
+    {
+    }
+
+    public void AppMinimize()
+    {
+    }
+
+    public void Halt()
+    {
+    }
+
+    public void Cursor(int cursorNum)
+    {
+    }
+
+    public void Open(string applicationName)
+    {
+    }
+
+    public void Quit()
+    {
+    }
+
+    public bool WindowPresent() => false;
+
+    public IBlingoCast CastLib(int number) => throw new NotSupportedException();
+
+    public IBlingoCast CastLib(string name) => throw new NotSupportedException();
+
+    public IBlingoPlayer LoadCastLibFromCsv(string castlibName, string pathAndFilenameToCsv, bool isInternal = false) => this;
+
+    public Task<IBlingoPlayer> LoadAsync<TBlingoCastLibBuilder>() where TBlingoCastLibBuilder : class, IBlingoCastLibBuilder, new()
+        => Task.FromResult<IBlingoPlayer>(this);
+
+    public Task<IBlingoPlayer> LoadCastLibFromCsvAsync(string castlibName, string pathAndFilenameToCsv, bool isInternal = false)
+        => Task.FromResult<IBlingoPlayer>(this);
+
+    public IBlingoPlayer AddCastLib(string name, bool isInternal = false, Action<IBlingoCast>? configure = null) => this;
+
+    public IBlingoMovie NewMovie(string movieName, bool andActivate = true) => throw new NotSupportedException();
+
+    public IBlingoMovie? GetMovie(BlingoMovieRef movieRef) => null;
+
+    public Task<IBlingoMovie> LoadMovieAsync(IBlingoMovieBuilder builder) => throw new NotSupportedException();
+
+    public void RunDelayed(Action action, int milliseconds, CancellationTokenSource? cts = null) => action();
+
+    public Task RunOnUIThreadAsync(Action action, CancellationToken ct = default)
+    {
+        action();
+        return Task.CompletedTask;
+    }
+
+    public Task<T> RunOnUIThreadAsync<T>(Func<T> func, CancellationToken ct = default)
+        => Task.FromResult(func());
+
+    public Task<T> RunOnUIThreadAsync<T>(Func<Task<T>> func, CancellationToken ct = default)
+        => func();
+
+    public void RunOnUIThread(Action action) => action();
+}

--- a/Test/BlingoEngine.Net.RNetProjectHost.Tests/Fakes/FakePublisher.cs
+++ b/Test/BlingoEngine.Net.RNetProjectHost.Tests/Fakes/FakePublisher.cs
@@ -1,0 +1,79 @@
+using System;
+using BlingoEngine.Core;
+using BlingoEngine.Net.RNetContracts;
+using BlingoEngine.Net.RNetHost.Common;
+
+namespace BlingoEngine.Net.RNetProjectHost.Tests.Fakes;
+
+internal sealed class FakePublisher : IRNetPublisherEngineBridge
+{
+    public void Enable(IBlingoPlayer player)
+    {
+    }
+
+    public void Disable()
+    {
+    }
+
+    public void TryPublishFrame(StageFrameDto frame)
+    {
+    }
+
+    public void TryPublishDelta(SpriteDeltaDto delta)
+    {
+    }
+
+    public void TryPublishKeyframe(KeyframeDto keyframe)
+    {
+    }
+
+    public void TryPublishFilmLoop(FilmLoopDto filmLoop)
+    {
+    }
+
+    public void TryPublishSound(SoundEventDto sound)
+    {
+    }
+
+    public void TryPublishTempo(TempoDto tempo)
+    {
+    }
+
+    public void TryPublishColorPalette(ColorPaletteDto palette)
+    {
+    }
+
+    public void TryPublishFrameScript(FrameScriptDto script)
+    {
+    }
+
+    public void TryPublishTransition(TransitionDto transition)
+    {
+    }
+
+    public void TryPublishMemberProperty(RNetMemberPropertyDto property)
+    {
+    }
+
+    public void TryPublishMovieProperty(RNetMoviePropertyDto property)
+    {
+    }
+
+    public void TryPublishStageProperty(RNetStagePropertyDto property)
+    {
+    }
+
+    public void TryPublishTextStyle(TextStyleDto style)
+    {
+    }
+
+    public void TryPublishSpriteCollectionEvent(RNetSpriteCollectionEventDto evt)
+    {
+    }
+
+    public void FlushQueuedProperties()
+    {
+    }
+
+    public bool TryDrainCommands(Action<IRNetCommand> apply) => false;
+}

--- a/Test/BlingoEngine.Net.RNetProjectHost.Tests/Fakes/TestConfig.cs
+++ b/Test/BlingoEngine.Net.RNetProjectHost.Tests/Fakes/TestConfig.cs
@@ -1,0 +1,15 @@
+using BlingoEngine.Net.RNetContracts;
+using BlingoEngine.Net.RNetHost.Common;
+
+namespace BlingoEngine.Net.RNetProjectHost.Tests.Fakes;
+
+internal sealed class TestConfig : IRNetConfiguration
+{
+    public TestConfig(int port) => Port = port;
+
+    public int Port { get; set; }
+    public bool AutoStartRNetHostOnStartup { get; set; }
+    public string ClientName { get; set; } = "TestHost";
+    public RNetRemoteRole RemoteRole { get; set; } = RNetRemoteRole.Host;
+    public RNetClientType ClientType { get; set; } = RNetClientType.Project;
+}

--- a/Test/BlingoEngine.Net.RNetProjectHost.Tests/Fakes/TestProjectBus.cs
+++ b/Test/BlingoEngine.Net.RNetProjectHost.Tests/Fakes/TestProjectBus.cs
@@ -1,0 +1,37 @@
+using System.Threading.Channels;
+using BlingoEngine.Net.RNetContracts;
+using BlingoEngine.Net.RNetProjectHost;
+
+namespace BlingoEngine.Net.RNetProjectHost.Tests.Fakes;
+
+internal sealed class TestProjectBus : IRNetProjectBus
+{
+    public Channel<StageFrameDto> Frames { get; } = CreateChannel<StageFrameDto>();
+    public Channel<SpriteDeltaDto> Deltas { get; } = CreateChannel<SpriteDeltaDto>();
+    public Channel<KeyframeDto> Keyframes { get; } = CreateChannel<KeyframeDto>();
+    public Channel<FilmLoopDto> FilmLoops { get; } = CreateChannel<FilmLoopDto>();
+    public Channel<SoundEventDto> Sounds { get; } = CreateChannel<SoundEventDto>();
+    public Channel<TempoDto> Tempos { get; } = CreateChannel<TempoDto>();
+    public Channel<ColorPaletteDto> ColorPalettes { get; } = CreateChannel<ColorPaletteDto>();
+    public Channel<FrameScriptDto> FrameScripts { get; } = CreateChannel<FrameScriptDto>();
+    public Channel<TransitionDto> Transitions { get; } = CreateChannel<TransitionDto>();
+    public Channel<RNetMemberPropertyDto> MemberProperties { get; } = CreateChannel<RNetMemberPropertyDto>();
+    public Channel<TextStyleDto> TextStyles { get; } = CreateChannel<TextStyleDto>();
+    public Channel<RNetMoviePropertyDto> MovieProperties { get; } = CreateChannel<RNetMoviePropertyDto>();
+    public Channel<RNetStagePropertyDto> StageProperties { get; } = CreateChannel<RNetStagePropertyDto>();
+    public Channel<RNetSpriteCollectionEventDto> SpriteCollectionEvents { get; } = CreateChannel<RNetSpriteCollectionEventDto>();
+    public Channel<IRNetCommand> Commands { get; } = CreateCommandChannel();
+
+    private static Channel<T> CreateChannel<T>() => Channel.CreateUnbounded<T>(new UnboundedChannelOptions
+    {
+        SingleReader = false,
+        SingleWriter = false
+    });
+
+    private static Channel<IRNetCommand> CreateCommandChannel()
+        => Channel.CreateUnbounded<IRNetCommand>(new UnboundedChannelOptions
+        {
+            SingleReader = false,
+            SingleWriter = false
+        });
+}

--- a/Test/BlingoEngine.Net.RNetProjectHost.Tests/RNetProjectHostIntegrationTests.cs
+++ b/Test/BlingoEngine.Net.RNetProjectHost.Tests/RNetProjectHostIntegrationTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using BlingoEngine.Core;
+using BlingoEngine.Net.RNetContracts;
+using BlingoEngine.Net.RNetHost.Common;
+using BlingoEngine.Net.RNetProjectClient;
+using BlingoEngine.Net.RNetProjectHost;
+using BlingoEngine.Net.RNetProjectHost.Tests.Fakes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BlingoEngine.Net.RNetProjectHost.Tests;
+
+public class RNetProjectHostIntegrationTests
+{
+    private static int _portSeed = 63000;
+
+    [Theory]
+    [MemberData(nameof(CommandData))]
+    public Task HttpClientAndServer_RelayAllCommands(RNetCommand command)
+        => WithServerAndClientAsync(async (scenario, token) =>
+        {
+            var tcs = new TaskCompletionSource<IRNetCommand>(TaskCreationOptions.RunContinuationsAsynchronously);
+            void Handler(IRNetCommand cmd) => tcs.TrySetResult(cmd);
+            scenario.Server.NetCommandReceived += Handler;
+
+            try
+            {
+                await scenario.Client.SendCommandAsync(command, token);
+                var received = await tcs.Task.WaitAsync(token);
+                var typed = Assert.IsAssignableFrom<RNetCommand>(received);
+                Assert.IsType(command.GetType(), typed);
+                Assert.Equal(command, typed);
+            }
+            finally
+            {
+                scenario.Server.NetCommandReceived -= Handler;
+            }
+        });
+
+    public static IEnumerable<object[]> CommandData()
+    {
+        yield return new object[] { new SetSpritePropCmd(3, 1, RNetSpriteTypeDto.Sprite2D, "LocH", "123") };
+        yield return new object[] { new SetMemberPropCmd(1, 5, RNetMemberTypeDto.Bitmap, "Name", "MyBitmap") };
+        yield return new object[] { new SetCastPropCmd(2, "Title", "Cast A") };
+        yield return new object[] { new GoToFrameCmd(42) };
+        yield return new object[] { new RewindCmd() };
+        yield return new object[] { new PauseCmd() };
+        yield return new object[] { new ResumeCmd() };
+    }
+
+    private sealed record HttpScenario(BlingoRNetProjectClient Client, TestProjectBus Bus, RNetProjectServer Server);
+
+    private static async Task WithServerAndClientAsync(Func<HttpScenario, CancellationToken, Task> testBody)
+    {
+        var services = new ServiceCollection();
+        var bus = new TestProjectBus();
+        services.AddSingleton<IRNetProjectBus>(bus);
+        services.AddSingleton<IBlingoPlayer>(new FakeBlingoPlayer());
+        services.AddSingleton<IRNetPublisherEngineBridge>(new FakePublisher());
+        using var provider = services.BuildServiceProvider();
+
+        var port = Interlocked.Increment(ref _portSeed);
+        var server = new RNetProjectServer(new TestConfig(port), NullLogger<RNetProjectServer>.Instance, provider);
+        await server.StartAsync();
+
+        var client = new BlingoRNetProjectClient();
+        var hello = new HelloDto("test-project", "client-id", "1.0", "HttpTest");
+        var uri = new Uri($"http://localhost:{port}/director");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        try
+        {
+            await ConnectWithRetryAsync(client, uri, hello, cts.Token);
+            var scenario = new HttpScenario(client, bus, server);
+            await testBody(scenario, cts.Token);
+        }
+        finally
+        {
+            await client.DisposeAsync();
+            await server.StopAsync();
+        }
+    }
+
+    private static async Task ConnectWithRetryAsync(BlingoRNetProjectClient client, Uri uri, HelloDto hello, CancellationToken ct)
+    {
+        const int maxAttempts = 5;
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            try
+            {
+                await client.ConnectAsync(uri, hello, ct);
+                return;
+            }
+            catch (HttpRequestException) when (attempt < maxAttempts - 1)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(50), ct);
+            }
+            catch (SocketException) when (attempt < maxAttempts - 1)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(50), ct);
+            }
+        }
+    }
+}

--- a/src/Net/BlingoEngine.Net.RNetContracts/RNetCommand.cs
+++ b/src/Net/BlingoEngine.Net.RNetContracts/RNetCommand.cs
@@ -1,8 +1,18 @@
-﻿namespace BlingoEngine.Net.RNetContracts;
+﻿using System.Text.Json.Serialization;
+
+namespace BlingoEngine.Net.RNetContracts;
 
 /// <summary>
 /// Base type for commands sent over the network.
 /// </summary>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "$type")]
+[JsonDerivedType(typeof(SetSpritePropCmd), nameof(SetSpritePropCmd))]
+[JsonDerivedType(typeof(SetMemberPropCmd), nameof(SetMemberPropCmd))]
+[JsonDerivedType(typeof(SetCastPropCmd), nameof(SetCastPropCmd))]
+[JsonDerivedType(typeof(GoToFrameCmd), nameof(GoToFrameCmd))]
+[JsonDerivedType(typeof(RewindCmd), nameof(RewindCmd))]
+[JsonDerivedType(typeof(PauseCmd), nameof(PauseCmd))]
+[JsonDerivedType(typeof(ResumeCmd), nameof(ResumeCmd))]
 public abstract record RNetCommand : IRNetCommand;
 
 /// <summary>

--- a/src/Net/BlingoEngine.Net.RNetProjectClient/BlingoRNetProjectClient.cs
+++ b/src/Net/BlingoEngine.Net.RNetProjectClient/BlingoRNetProjectClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using BlingoEngine.Net.RNetClient.Common;
 using BlingoEngine.Net.RNetContracts;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -19,6 +20,7 @@ public sealed class BlingoRNetProjectClient : IBlingoRNetProjectClient
     private HubConnection? _connection;
     private BlingoNetConnectionState _state = BlingoNetConnectionState.Disconnected;
     private readonly IRNetConfiguration _config;
+    private static readonly JsonSerializerOptions CommandSerializerOptions = new(JsonSerializerDefaults.Web);
 
     public BlingoRNetProjectClient(IRNetConfiguration config)
     {
@@ -35,6 +37,8 @@ public sealed class BlingoRNetProjectClient : IBlingoRNetProjectClient
         public RNetClientType ClientType { get; set; } = RNetClientType.Project;
         public RNetRemoteRole RemoteRole { get; set; } = RNetRemoteRole.Client;
     }
+
+    private sealed record CommandEnvelope(string Type, JsonElement Payload);
 
     /// <inheritdoc />
     public event Action<BlingoNetConnectionState>? ConnectionStatusChanged;
@@ -224,7 +228,10 @@ public sealed class BlingoRNetProjectClient : IBlingoRNetProjectClient
     public Task SendCommandAsync(RNetCommand cmd, CancellationToken ct = default)
     {
         EnsureConnected();
-        return _connection!.InvokeAsync("SendCommand", cmd, ct).WaitAsync(TimeSpan.FromSeconds(5), ct);
+        var type = cmd.GetType();
+        var payload = JsonSerializer.SerializeToElement(cmd, type, CommandSerializerOptions);
+        var envelope = new CommandEnvelope(type.Name, payload);
+        return _connection!.InvokeAsync("SendCommand", envelope, ct).WaitAsync(TimeSpan.FromSeconds(5), ct);
     }
 
     /// <inheritdoc />

--- a/src/Net/BlingoEngine.Net.RNetProjectHost/RNetProjectHub.cs
+++ b/src/Net/BlingoEngine.Net.RNetProjectHost/RNetProjectHub.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using BlingoEngine.Core;
 using BlingoEngine.Net.RNetContracts;
 using BlingoEngine.IO;
@@ -18,6 +20,22 @@ public sealed class BlingoRNetProjectHub : Hub
     private readonly IBlingoPlayer _player;
     private readonly ILogger<BlingoRNetProjectHub> _logger;
     private static readonly ConcurrentDictionary<string, DateTime> _heartbeats = new();
+
+    private static readonly JsonSerializerOptions _commandSerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private static readonly IReadOnlyDictionary<string, Type> _commandTypes = new Dictionary<string, Type>(StringComparer.Ordinal)
+    {
+        [nameof(SetSpritePropCmd)] = typeof(SetSpritePropCmd),
+        [nameof(SetMemberPropCmd)] = typeof(SetMemberPropCmd),
+        [nameof(SetCastPropCmd)] = typeof(SetCastPropCmd),
+        [nameof(GoToFrameCmd)] = typeof(GoToFrameCmd),
+        [nameof(RewindCmd)] = typeof(RewindCmd),
+        [nameof(PauseCmd)] = typeof(PauseCmd),
+        [nameof(ResumeCmd)] = typeof(ResumeCmd)
+    };
 
     /// <summary>Initializes a new instance of the <see cref="BlingoRNetProjectHub"/> class.</summary>
     public BlingoRNetProjectHub(IRNetProjectBus bus, IBlingoPlayer player, ILogger<BlingoRNetProjectHub> logger)
@@ -42,9 +60,43 @@ public sealed class BlingoRNetProjectHub : Hub
     /// <summary>
     /// Receives a command from a client.
     /// </summary>
-    public Task SendCommand(RNetCommand cmd)
+    public Task SendCommand(JsonElement payload)
     {
-        _bus.Commands.Writer.TryWrite(cmd);
+        if (!payload.TryGetProperty("type", out var typeProperty) || typeProperty.ValueKind != JsonValueKind.String)
+        {
+            throw new HubException("Command payload missing type discriminator.");
+        }
+
+        var typeName = typeProperty.GetString();
+        if (string.IsNullOrWhiteSpace(typeName) || !_commandTypes.TryGetValue(typeName, out var commandType))
+        {
+            throw new HubException($"Unknown command type '{typeName}'.");
+        }
+
+        if (!payload.TryGetProperty("payload", out var payloadProperty))
+        {
+            throw new HubException("Command payload missing payload body.");
+        }
+
+        try
+        {
+            if (payloadProperty.Deserialize(commandType, _commandSerializerOptions) is not IRNetCommand cmd)
+            {
+                throw new HubException($"Command payload could not be deserialized as '{typeName}'.");
+            }
+
+            _bus.Commands.Writer.TryWrite(cmd);
+        }
+        catch (HubException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to deserialize command payload for type {Type}", typeName);
+            throw new HubException($"Command payload could not be deserialized as '{typeName}'.", ex);
+        }
+
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
## Summary
- wrap SignalR command invocations in a typed envelope from the RNet project client so the hub receives a discriminator
- deserialize the envelope explicitly in the hub with a known command type map and improved error reporting
- add an integration test project for the HTTP host to validate command routing and provide supporting fakes

## Testing
- dotnet test Test/BlingoEngine.Net.RNetProjectHost.Tests/BlingoEngine.Net.RNetProjectHost.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d3ae8e94f48332adbf84680250137b