### PR TITLE
Implement Unity texture pixel IO and share grid test fakes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ These instructions apply to the entire repository.
 - Do not remove existing comments from code.
 - When writing new classes, place members in the order: fields, then properties, then constructors.
 - Avoid adding business logic or default implementations inside interfaces to preserve .NET Framework 4.8 compatibility.
+- When introducing new reusable test utilities or fakes, place their implementations under the test project's `/Fakes/` directory so future tests can consume them.
 
 ## Project Structure
 

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstBaseGridTextureTests.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstBaseGridTextureTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using AbstUI.Primitives;
+using FluentAssertions;
+using Xunit;
+using AbstUI.Tests.Fakes;
+
+namespace AbstUI.Tests;
+
+public class AbstBaseGridTextureTests
+{
+    [Fact]
+    public void GetPixels_WithFourTiles_ComposesCombinedBuffer()
+    {
+        var grid = new TestGridTexture(32, 32, tileSize: 16);
+
+        grid.EnsureTile((0, 0)).SetPixels(CreateTileData(16, 16, startValue: 1));
+        grid.EnsureTile((1, 0)).SetPixels(CreateTileData(16, 16, startValue: 2));
+        grid.EnsureTile((0, 1)).SetPixels(CreateTileData(16, 16, startValue: 3));
+        grid.EnsureTile((1, 1)).SetPixels(CreateTileData(16, 16, startValue: 4));
+
+        var expected = grid.CombineTiles();
+
+        var pixels = grid.GetPixels();
+
+        pixels.Should().Equal(expected);
+    }
+
+    [Fact]
+    public void SetARGBPixels_WithFourTiles_DistributesBufferAcrossTiles()
+    {
+        var grid = new TestGridTexture(32, 32, tileSize: 16);
+        var pixels = CreateImageBuffer(grid.Width, grid.Height, startValue: 42);
+
+        grid.SetARGBPixels(pixels);
+
+        grid.Tiles.Should().HaveCount(4);
+        grid.Tiles.Keys.Should().BeEquivalentTo(new[] { (0, 0), (1, 0), (0, 1), (1, 1) });
+
+        foreach (var (coordinates, tile) in grid.Tiles)
+        {
+            var expected = ExtractTileRegion(pixels, grid.Width, grid.TileLength, coordinates, tile.Width, tile.Height);
+            tile.PixelData.ToArray().Should().Equal(expected);
+        }
+
+        grid.GetPixels().Should().Equal(pixels);
+    }
+
+    [Fact]
+    public void SetRGBAPixels_WithFourTiles_DistributesBufferAcrossTiles()
+    {
+        var grid = new TestGridTexture(32, 32, tileSize: 16);
+        var pixels = CreateImageBuffer(grid.Width, grid.Height, startValue: 200);
+
+        grid.SetRGBAPixels(pixels);
+
+        grid.Tiles.Should().HaveCount(4);
+        grid.Tiles.Keys.Should().BeEquivalentTo(new[] { (0, 0), (1, 0), (0, 1), (1, 1) });
+
+        foreach (var (coordinates, tile) in grid.Tiles)
+        {
+            var expected = ExtractTileRegion(pixels, grid.Width, grid.TileLength, coordinates, tile.Width, tile.Height);
+            tile.PixelData.ToArray().Should().Equal(expected);
+        }
+
+        grid.GetPixels().Should().Equal(pixels);
+    }
+
+    private static byte[] CreateImageBuffer(int width, int height, byte startValue)
+    {
+        var buffer = new byte[checked(width * height * 4)];
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            buffer[i] = (byte)(startValue + i);
+        }
+
+        return buffer;
+    }
+
+    private static byte[] CreateTileData(int width, int height, byte startValue)
+    {
+        var buffer = new byte[checked(width * height * 4)];
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            buffer[i] = (byte)(startValue + i);
+        }
+
+        return buffer;
+    }
+
+    private static byte[] ExtractTileRegion(byte[] source, int imageWidth, int tileSize, (int X, int Y) coordinates, int tileWidth, int tileHeight)
+    {
+        var region = new byte[checked(tileWidth * tileHeight * 4)];
+        int srcStride = imageWidth * 4;
+        int destStride = tileWidth * 4;
+        int offsetX = coordinates.X * tileSize;
+        int offsetY = coordinates.Y * tileSize;
+
+        for (int row = 0; row < tileHeight; row++)
+        {
+            int srcIndex = ((offsetY + row) * srcStride) + (offsetX * 4);
+            Array.Copy(source, srcIndex, region, row * destStride, destStride);
+        }
+
+        return region;
+    }
+
+}

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstImagePainterGridTests.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstImagePainterGridTests.cs
@@ -1,0 +1,56 @@
+using System.Linq;
+using AbstUI.Primitives;
+using AbstUI.Styles;
+using AbstUI.Tests.Fakes;
+using FluentAssertions;
+
+namespace AbstUI.Tests;
+
+public class AbstImagePainterGridTests
+{
+    [Fact]
+    public void Render_LineCrossingMultipleColumns_RendersEachTile()
+    {
+        var painter = new TestGridPainter(64, 64, tileSize: 16);
+        painter.DrawLine(new APoint(0, 8), new APoint(40, 8), AColors.White);
+
+        painter.Render();
+
+        painter.RenderPasses.Should().HaveCount(3);
+        painter.RenderPasses
+            .Select(pass => (X: pass.OffsetX / painter.TileSize, Y: pass.OffsetY / painter.TileSize))
+            .Should().BeEquivalentTo(new[] { (0, 0), (1, 0), (2, 0) });
+
+        foreach (var pass in painter.RenderPasses)
+        {
+            pass.Texture.IsTile.Should().BeTrue();
+            pass.Texture.Lines.Should().HaveCount(1);
+            var record = pass.Texture.Lines[0];
+            record.LocalStart.Should().Be(new APoint(0 - pass.OffsetX, 8 - pass.OffsetY));
+            record.LocalEnd.Should().Be(new APoint(40 - pass.OffsetX, 8 - pass.OffsetY));
+        }
+    }
+
+    [Fact]
+    public void Render_LineCrossingMultipleRows_RendersEachTile()
+    {
+        var painter = new TestGridPainter(64, 64, tileSize: 16);
+        painter.DrawLine(new APoint(8, 0), new APoint(8, 40), AColors.White);
+
+        painter.Render();
+
+        painter.RenderPasses.Should().HaveCount(3);
+        painter.RenderPasses
+            .Select(pass => (X: pass.OffsetX / painter.TileSize, Y: pass.OffsetY / painter.TileSize))
+            .Should().BeEquivalentTo(new[] { (0, 0), (0, 1), (0, 2) });
+
+        foreach (var pass in painter.RenderPasses)
+        {
+            pass.Texture.IsTile.Should().BeTrue();
+            pass.Texture.Lines.Should().HaveCount(1);
+            var record = pass.Texture.Lines[0];
+            record.LocalStart.Should().Be(new APoint(8 - pass.OffsetX, 0 - pass.OffsetY));
+            record.LocalEnd.Should().Be(new APoint(8 - pass.OffsetX, 40 - pass.OffsetY));
+        }
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/fakes/TestGridPainter.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/fakes/TestGridPainter.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using AbstUI.Components.Graphics;
+using AbstUI.Primitives;
+using AbstUI.Styles;
+using AbstUI.Texts;
+
+namespace AbstUI.Tests.Fakes;
+
+internal sealed class TestGridPainter : AbstImagePainter<TestTexture>
+{
+    private readonly List<RenderPass> _renderPasses = new();
+    private readonly TestTexture _target;
+    private TestTexture? _currentTexture;
+    private int _tileCounter;
+
+    public TestGridPainter(int width, int height, int tileSize)
+        : base(width, height, width, height)
+    {
+        Name = "TestPainter";
+        TileSize = tileSize;
+        UseTextureGrid = true;
+        _target = new TestTexture("Target", width, height, isTile: false);
+    }
+
+    public IReadOnlyList<RenderPass> RenderPasses => _renderPasses;
+
+    protected override void BeginRender(AColor clearColor)
+    {
+        var texture = _currentTexture ?? _target;
+        _renderPasses.Add(new RenderPass(texture, OffsetX, OffsetY, clearColor));
+    }
+
+    protected override void EndRender()
+    {
+        _currentTexture = null;
+    }
+
+    protected override void ResizeTexture(int width, int height)
+    {
+        _target.Width = width;
+        _target.Height = height;
+    }
+
+    protected override TestTexture CreateTileTexture(int width, int height)
+        => new($"Tile_{_tileCounter++}", width, height, isTile: true);
+
+    protected override void DestroyTileTexture(TestTexture texture)
+    {
+        texture.MarkDestroyed();
+    }
+
+    protected override void UseTexture(TestTexture texture)
+    {
+        _currentTexture = texture;
+    }
+
+    protected override byte[] GetTexturePixels(TestTexture texture, int width, int height)
+        => throw new NotSupportedException();
+
+    protected override void SetTextureARGBPixels(TestTexture texture, int width, int height, byte[] argbPixels)
+        => throw new NotSupportedException();
+
+    protected override void SetTextureRGBAPixels(TestTexture texture, int width, int height, byte[] rgbaPixels)
+        => throw new NotSupportedException();
+
+    protected override TestTexture Target => _target;
+
+    public override void SetPixel(APoint point, AColor color)
+        => throw new NotSupportedException();
+
+    public override void DrawLine(APoint start, APoint end, AColor color, float width = 1)
+    {
+        var s = start;
+        var e = end;
+        int maxX = (int)MathF.Ceiling(MathF.Max(s.X, e.X)) + 1;
+        int maxY = (int)MathF.Ceiling(MathF.Max(s.Y, e.Y)) + 1;
+        var pos = new APoint(0, 0);
+        var size = new APoint(maxX, maxY);
+        var action = new DrawAction(false, pos, size, null, null, (texture, _, _) =>
+        {
+            var localStart = new APoint(s.X - OffsetX, s.Y - OffsetY);
+            var localEnd = new APoint(e.X - OffsetX, e.Y - OffsetY);
+            texture.RecordLine(localStart, localEnd, OffsetX, OffsetY);
+        });
+        AddDrawAction(action);
+    }
+
+    public override void DrawRect(ARect rect, AColor color, bool filled = true, float width = 1)
+        => throw new NotSupportedException();
+
+    public override void DrawCircle(APoint center, float radius, AColor color, bool filled = true, float width = 1)
+        => throw new NotSupportedException();
+
+    public override void DrawArc(APoint center, float radius, float startDeg, float endDeg, int segments, AColor color, float width = 1)
+        => throw new NotSupportedException();
+
+    public override void DrawPolygon(IReadOnlyList<APoint> points, AColor color, bool filled = true, float width = 1)
+        => throw new NotSupportedException();
+
+    public override void DrawPicture(byte[] data, int width, int height, APoint position, APixelFormat format)
+        => throw new NotSupportedException();
+
+    public override void DrawPicture(IAbstTexture2D texture, int width, int height, APoint position)
+        => throw new NotSupportedException();
+
+    public override void DrawText(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, AbstTextAlignment alignment = AbstTextAlignment.Left, AbstFontStyle style = AbstFontStyle.Regular, int letterSpacing = 0)
+        => throw new NotSupportedException();
+
+    public override void DrawSingleLine(APoint position, string text, string? font = null, AColor? color = null, int fontSize = 12, int width = -1, int height = -1, AbstTextAlignment alignment = AbstTextAlignment.Left, AbstFontStyle style = AbstFontStyle.Regular, int letterSpacing = 0)
+        => throw new NotSupportedException();
+
+    public override IAbstTexture2D GetTexture(string? name = null)
+        => throw new NotSupportedException();
+
+    public override void Dispose()
+    {
+        DisposeTiles();
+    }
+}
+
+internal sealed class TestTexture
+{
+    private readonly List<LineRecord> _lines = new();
+
+    public TestTexture(string name, int width, int height, bool isTile)
+    {
+        Name = name;
+        Width = width;
+        Height = height;
+        IsTile = isTile;
+    }
+
+    public string Name { get; }
+
+    public int Width { get; set; }
+
+    public int Height { get; set; }
+
+    public bool IsTile { get; }
+
+    public bool IsDestroyed { get; private set; }
+
+    public IReadOnlyList<LineRecord> Lines => _lines;
+
+    public void RecordLine(APoint localStart, APoint localEnd, int offsetX, int offsetY)
+    {
+        _lines.Add(new LineRecord(localStart, localEnd, offsetX, offsetY));
+    }
+
+    public void MarkDestroyed()
+    {
+        IsDestroyed = true;
+    }
+
+    public readonly record struct LineRecord(APoint LocalStart, APoint LocalEnd, int OffsetX, int OffsetY)
+    {
+        public APoint GlobalStart => new(LocalStart.X + OffsetX, LocalStart.Y + OffsetY);
+
+        public APoint GlobalEnd => new(LocalEnd.X + OffsetX, LocalEnd.Y + OffsetY);
+    }
+}
+
+internal readonly record struct RenderPass(TestTexture Texture, int OffsetX, int OffsetY, AColor ClearColor);

--- a/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/fakes/TestGridTexture.cs
+++ b/WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/fakes/TestGridTexture.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AbstUI.Bitmaps;
+using AbstUI.Primitives;
+
+namespace AbstUI.Tests.Fakes;
+
+internal sealed class TestGridTexture : AbstBaseGridTexture<int>
+{
+    private readonly Dictionary<(int X, int Y), TestTileTexture> _tiles = new();
+    private readonly int _tileSize;
+    private int _width;
+    private int _height;
+
+    public override int Width => _width;
+    public override int Height => _height;
+    public int TileLength => _tileSize;
+    public IReadOnlyDictionary<(int X, int Y), TestTileTexture> Tiles => _tiles;
+
+    public TestGridTexture(int width, int height, int tileSize)
+        : base("TestGrid")
+    {
+        _width = width;
+        _height = height;
+        _tileSize = tileSize;
+    }
+
+    public TestTileTexture EnsureTile((int X, int Y) coordinates)
+    {
+        if (!TryComputeTileBounds(coordinates, TileLength, Width, Height, out _, out _, out var tileWidth, out var tileHeight))
+            throw new ArgumentOutOfRangeException(nameof(coordinates));
+
+        return (TestTileTexture)GetOrCreateTile(coordinates, tileWidth, tileHeight);
+    }
+
+    protected override int TileSize => _tileSize;
+
+    protected override AbstBaseTexture2D<int> CreateTile((int X, int Y) coordinates, int width, int height)
+    {
+        var tile = new TestTileTexture(coordinates, width, height);
+        _tiles[coordinates] = tile;
+        return tile;
+    }
+
+    protected override void ResizeTile((int X, int Y) coordinates, AbstBaseTexture2D<int> tile, int width, int height)
+    {
+        ((TestTileTexture)tile).Resize(width, height);
+    }
+
+    protected override void OnTileRemoved((int X, int Y) coordinates, AbstBaseTexture2D<int> tile)
+    {
+        base.OnTileRemoved(coordinates, tile);
+        _tiles.Remove(coordinates);
+    }
+
+    protected override void DisposeTexture()
+    {
+        DisposeRegisteredTiles();
+        _tiles.Clear();
+    }
+
+    public override IAbstTexture2D Clone()
+        => throw new NotSupportedException("Test grid texture does not support cloning.");
+}
+
+internal sealed class TestTileTexture : AbstBaseTexture2D<int>
+{
+    private byte[] _pixels;
+    private int _width;
+    private int _height;
+
+    public override int Width => _width;
+    public override int Height => _height;
+    public ReadOnlyMemory<byte> PixelData => _pixels;
+
+    public TestTileTexture((int X, int Y) coordinates, int width, int height)
+        : base($"Tile_{coordinates.X}_{coordinates.Y}")
+    {
+        _width = width;
+        _height = height;
+        _pixels = new byte[checked(width * height * 4)];
+    }
+
+    public void SetPixels(byte[] pixels)
+    {
+        if (pixels.Length != Width * Height * 4)
+            throw new ArgumentException("Tile pixel data length does not match tile dimensions.", nameof(pixels));
+
+        _pixels = pixels.ToArray();
+    }
+
+    public void Resize(int width, int height)
+    {
+        _width = width;
+        _height = height;
+        _pixels = new byte[checked(width * height * 4)];
+    }
+
+    protected override void DisposeTexture()
+    {
+        _pixels = Array.Empty<byte>();
+    }
+
+    public override byte[] GetPixels()
+        => _pixels.ToArray();
+
+    public override void SetARGBPixels(byte[] argbPixels)
+    {
+        if (argbPixels.Length != Width * Height * 4)
+            throw new ArgumentException("ARGB buffer length does not match tile dimensions.", nameof(argbPixels));
+
+        _pixels = argbPixels.ToArray();
+    }
+
+    public override void SetRGBAPixels(byte[] rgbaPixels)
+    {
+        if (rgbaPixels.Length != Width * Height * 4)
+            throw new ArgumentException("RGBA buffer length does not match tile dimensions.", nameof(rgbaPixels));
+
+        _pixels = rgbaPixels.ToArray();
+    }
+
+    public override IAbstTexture2D Clone()
+        => throw new NotSupportedException("Test tile texture does not support cloning.");
+}
+
+internal static class TestGridTextureExtensions
+{
+    public static byte[] CombineTiles(this TestGridTexture grid)
+    {
+        int width = grid.Width;
+        int height = grid.Height;
+        int tileSize = grid.TileLength;
+        var combined = new byte[checked(width * height * 4)];
+        int destStride = width * 4;
+
+        foreach (var (coordinates, tile) in grid.Tiles)
+        {
+            int offsetX = coordinates.X * tileSize;
+            int offsetY = coordinates.Y * tileSize;
+            int tileWidth = tile.Width;
+            int tileHeight = tile.Height;
+            int tileStride = tileWidth * 4;
+            var tilePixels = tile.PixelData.Span;
+
+            for (int row = 0; row < tileHeight; row++)
+            {
+                int destIndex = ((offsetY + row) * destStride) + (offsetX * 4);
+                tilePixels.Slice(row * tileStride, tileStride).CopyTo(combined.AsSpan(destIndex, tileStride));
+            }
+        }
+
+        return combined;
+    }
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Bitmaps/UnityImageTexture.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.LUnity/Bitmaps/UnityImageTexture.cs
@@ -1,6 +1,9 @@
+using System;
 using AbstUI.Bitmaps;
 using AbstUI.Primitives;
 using UnityEngine;
+using Unity.Collections;
+using AbstUI.Tools;
 
 namespace AbstUI.LUnity.Bitmaps;
 
@@ -34,21 +37,80 @@ public class UnityTexture2D : AbstBaseTexture2D<Texture2D>
 
     public override byte[] GetPixels()
     {
-        throw new NotImplementedException();
+        if (Texture == null)
+            return Array.Empty<byte>();
+
+#if UNITY_2021_1_OR_NEWER
+        var data = Texture.GetRawTextureData<byte>();
+        return data.ToArray();
+#else
+        var colors = Texture.GetPixels32();
+        var buffer = new byte[colors.Length * 4];
+        for (int i = 0; i < colors.Length; i++)
+        {
+            int index = i * 4;
+            buffer[index] = colors[i].r;
+            buffer[index + 1] = colors[i].g;
+            buffer[index + 2] = colors[i].b;
+            buffer[index + 3] = colors[i].a;
+        }
+        return buffer;
+#endif
     }
 
     public override void SetARGBPixels(byte[] argbPixels)
     {
-        throw new NotImplementedException();
+        if (Texture == null)
+            return;
+        if (argbPixels == null || argbPixels.Length != Width * Height * 4)
+            throw new ArgumentException("Expected ARGB8888 buffer with Width*Height*4 bytes.", nameof(argbPixels));
+
+        var buffer = (byte[])argbPixels.Clone();
+        APixel.ToRGBA(buffer);
+        SetRGBAPixels(buffer);
     }
 
     public override void SetRGBAPixels(byte[] rgbaPixels)
     {
-        throw new NotImplementedException();
+        if (Texture == null)
+            return;
+        if (rgbaPixels == null || rgbaPixels.Length != Width * Height * 4)
+            throw new ArgumentException("Expected RGBA8888 buffer with Width*Height*4 bytes.", nameof(rgbaPixels));
+
+#if UNITY_2021_1_OR_NEWER
+        Texture.LoadRawTextureData(rgbaPixels);
+        Texture.Apply();
+#else
+        var colors = new Color32[Width * Height];
+        for (int i = 0; i < colors.Length; i++)
+        {
+            int index = i * 4;
+            colors[i] = new Color32(rgbaPixels[index], rgbaPixels[index + 1], rgbaPixels[index + 2], rgbaPixels[index + 3]);
+        }
+        Texture.SetPixels32(colors);
+        Texture.Apply();
+#endif
     }
 
     public override IAbstTexture2D Clone()
     {
-        throw new NotImplementedException();
+        if (Texture == null)
+            throw new InvalidOperationException("Cannot clone a disposed texture.");
+
+        var clone = new Texture2D(Texture.width, Texture.height, Texture.format, Texture.mipmapCount > 0)
+        {
+            filterMode = Texture.filterMode,
+            wrapMode = Texture.wrapMode,
+        };
+
+#if UNITY_2021_1_OR_NEWER
+        clone.LoadRawTextureData(GetPixels());
+        clone.Apply();
+#else
+        clone.SetPixels32(Texture.GetPixels32());
+        clone.Apply();
+#endif
+
+        return new UnityTexture2D(clone, Name + "_Clone");
     }
 }

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Graphics/SDLImagePainterV2.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI.SDL2/Components/Graphics/SDLImagePainterV2.cs
@@ -1,3 +1,4 @@
+using AbstUI.Bitmaps;
 using AbstUI.Components.Graphics;
 using AbstUI.Primitives;
 using AbstUI.SDL2.Bitmaps;
@@ -96,6 +97,14 @@ public class SDLImagePainterV2 : AbstImagePainter<nint>
     protected override void UseTexture(nint texture)
     {
         _texture = texture;
+    }
+
+    protected override AbstBaseTexture2D<nint>? CreateTilePixelsHost((int X, int Y) coordinates, nint texture, int width, int height)
+    {
+        if (texture == nint.Zero)
+            return null;
+
+        return new SdlTexture2D(texture, width, height, $"{Name}_Tile_{coordinates.X}_{coordinates.Y}", Renderer);
     }
 
     public override void SetPixel(APoint point, AColor color)

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Bitmaps/AbstBaseGridTexture.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Bitmaps/AbstBaseGridTexture.cs
@@ -1,0 +1,538 @@
+using System;
+using System.Collections.Generic;
+using AbstUI.Primitives;
+
+namespace AbstUI.Bitmaps;
+
+public abstract class AbstBaseGridTexture<TFrameworkTexture> : AbstBaseTexture2D<TFrameworkTexture>
+{
+    private static readonly AbstBaseTexture2D<TFrameworkTexture>[] EmptyTiles = Array.Empty<AbstBaseTexture2D<TFrameworkTexture>>();
+    private static readonly (int X, int Y)[] EmptyCoordinates = Array.Empty<(int X, int Y)>();
+
+    private readonly Dictionary<(int X, int Y), AbstBaseTexture2D<TFrameworkTexture>>? _tileMap;
+    private readonly List<AbstBaseTexture2D<TFrameworkTexture>>? _tileList;
+    private readonly HashSet<(int X, int Y)>? _dirtyTiles;
+
+    public IReadOnlyList<AbstBaseTexture2D<TFrameworkTexture>> TileTextures =>
+        _tileList as IReadOnlyList<AbstBaseTexture2D<TFrameworkTexture>> ?? EmptyTiles;
+
+    public IReadOnlyCollection<(int X, int Y)> DirtyTiles =>
+        _dirtyTiles as IReadOnlyCollection<(int X, int Y)> ?? EmptyCoordinates;
+
+    public bool HasDirtyTiles => _dirtyTiles != null && _dirtyTiles.Count > 0;
+
+    protected virtual int TileSize => 0;
+
+    protected AbstBaseGridTexture(string name = "", bool manageTiles = true)
+        : base(name)
+    {
+        if (manageTiles)
+        {
+            _tileMap = new Dictionary<(int X, int Y), AbstBaseTexture2D<TFrameworkTexture>>();
+            _tileList = new List<AbstBaseTexture2D<TFrameworkTexture>>();
+            _dirtyTiles = new HashSet<(int X, int Y)>();
+        }
+    }
+
+    protected Dictionary<(int X, int Y), AbstBaseTexture2D<TFrameworkTexture>> TileMap =>
+        _tileMap ?? throw new InvalidOperationException("Tile management is disabled for this texture.");
+
+    protected List<AbstBaseTexture2D<TFrameworkTexture>> TileList =>
+        _tileList ?? throw new InvalidOperationException("Tile management is disabled for this texture.");
+
+    protected HashSet<(int X, int Y)> DirtyTileSet =>
+        _dirtyTiles ?? throw new InvalidOperationException("Tile management is disabled for this texture.");
+
+    protected abstract AbstBaseTexture2D<TFrameworkTexture> CreateTile((int X, int Y) coordinates, int width, int height);
+
+    protected virtual void ResizeTile((int X, int Y) coordinates, AbstBaseTexture2D<TFrameworkTexture> tile, int width, int height)
+    {
+        throw new NotSupportedException($"{GetType().Name} must override ResizeTile to support dynamic tile sizing.");
+    }
+
+    protected virtual void OnTileRemoved((int X, int Y) coordinates, AbstBaseTexture2D<TFrameworkTexture> tile)
+    {
+        tile.Dispose();
+    }
+
+    protected AbstBaseTexture2D<TFrameworkTexture> GetOrCreateTile((int X, int Y) coordinates, int width, int height)
+    {
+        if (_tileMap == null)
+            throw new InvalidOperationException("Tile management is disabled for this texture.");
+
+        if (_tileMap.TryGetValue(coordinates, out var tile))
+        {
+            if (tile.Width != width || tile.Height != height)
+                ResizeTile(coordinates, tile, width, height);
+            return tile;
+        }
+
+        var created = CreateTile(coordinates, width, height);
+        _tileMap.Add(coordinates, created);
+        _tileList!.Add(created);
+        return created;
+    }
+
+    protected bool TryGetTile((int X, int Y) coordinates, out AbstBaseTexture2D<TFrameworkTexture> tile)
+    {
+        if (_tileMap == null)
+        {
+            tile = default!;
+            return false;
+        }
+
+        if (_tileMap.TryGetValue(coordinates, out var existing))
+        {
+            tile = existing;
+            return true;
+        }
+
+        tile = default!;
+        return false;
+    }
+
+    protected void RemoveTile((int X, int Y) coordinates)
+    {
+        if (_tileMap == null)
+            return;
+
+        if (_tileMap.TryGetValue(coordinates, out var tile))
+        {
+            _tileMap.Remove(coordinates);
+            _tileList!.Remove(tile);
+            OnTileRemoved(coordinates, tile);
+        }
+    }
+
+    protected void ClearTiles(bool disposeTiles = true)
+    {
+        if (_tileMap == null)
+            return;
+
+        if (disposeTiles)
+        {
+            foreach (var pair in _tileMap)
+                OnTileRemoved(pair.Key, pair.Value);
+        }
+
+        _tileMap.Clear();
+        _tileList!.Clear();
+    }
+
+    protected void DisposeRegisteredTiles()
+    {
+        ClearTiles();
+        ClearDirtyTiles();
+    }
+
+    protected void MarkTileDirty((int X, int Y) coordinates)
+    {
+        DirtyTileSet.Add(coordinates);
+    }
+
+    protected void MarkTilesDirty(TileRange range)
+    {
+        if (!range.HasTiles)
+            return;
+
+        var dirty = DirtyTileSet;
+        for (int x = range.StartX; x <= range.EndX; x++)
+        {
+            for (int y = range.StartY; y <= range.EndY; y++)
+                dirty.Add((x, y));
+        }
+    }
+
+    protected void MarkRegionDirty(APoint position, APoint size, int tileSize)
+    {
+        if (tileSize <= 0)
+            return;
+
+        var range = CalculateTileRange(position, size, tileSize);
+        MarkTilesDirty(range);
+    }
+
+    protected void MarkAllTilesDirty(int width, int height, int tileSize)
+    {
+        if (tileSize <= 0)
+            return;
+
+        var dirty = DirtyTileSet;
+        int tilesX = (Math.Max(width, 0) + tileSize - 1) / tileSize;
+        int tilesY = (Math.Max(height, 0) + tileSize - 1) / tileSize;
+        for (int x = 0; x < tilesX; x++)
+        {
+            for (int y = 0; y < tilesY; y++)
+                dirty.Add((x, y));
+        }
+    }
+
+    protected void ClearDirtyTiles()
+    {
+        _dirtyTiles?.Clear();
+    }
+
+    protected void ForEachTile(
+        int targetWidth,
+        int targetHeight,
+        int tileSize,
+        bool createMissing,
+        Action<(int X, int Y), int, int, int, int, AbstBaseTexture2D<TFrameworkTexture>> callback)
+    {
+        if (_tileMap == null)
+            throw new NotSupportedException("Tile management is disabled for this texture.");
+
+        if (targetWidth <= 0 || targetHeight <= 0)
+            return;
+
+        if (tileSize <= 0)
+            throw new InvalidOperationException("TileSize must be positive to iterate tiles.");
+
+        int tilesX = (Math.Max(targetWidth, 0) + tileSize - 1) / tileSize;
+        int tilesY = (Math.Max(targetHeight, 0) + tileSize - 1) / tileSize;
+
+        for (int x = 0; x < tilesX; x++)
+        {
+            for (int y = 0; y < tilesY; y++)
+            {
+                var coordinates = (x, y);
+                if (!TryComputeTileBounds(coordinates, tileSize, targetWidth, targetHeight, out int offsetX, out int offsetY, out int width, out int height))
+                    continue;
+
+                AbstBaseTexture2D<TFrameworkTexture> tile;
+                if (createMissing)
+                {
+                    tile = GetOrCreateTile(coordinates, width, height);
+                }
+                else if (!TryGetTile(coordinates, out tile))
+                {
+                    continue;
+                }
+
+                var actualWidth = tile.Width;
+                var actualHeight = tile.Height;
+                if (actualWidth <= 0 || actualHeight <= 0)
+                    continue;
+
+                if (actualWidth != width || actualHeight != height)
+                {
+                    width = actualWidth;
+                    height = actualHeight;
+                }
+
+                callback(coordinates, offsetX, offsetY, width, height, tile);
+            }
+        }
+    }
+
+    protected void ForEachDirtyTile(
+        int targetWidth,
+        int targetHeight,
+        int tileSize,
+        Action<(int X, int Y), int, int, int, int, AbstBaseTexture2D<TFrameworkTexture>> callback)
+    {
+        if (_dirtyTiles == null || _dirtyTiles.Count == 0)
+            return;
+
+        foreach (var coordinates in _dirtyTiles)
+        {
+            if (!TryComputeTileBounds(coordinates, tileSize, targetWidth, targetHeight, out int offsetX, out int offsetY, out int width, out int height))
+                continue;
+
+            var tile = GetOrCreateTile(coordinates, width, height);
+            callback(coordinates, offsetX, offsetY, width, height, tile);
+        }
+    }
+
+    protected static bool TryComputeTileBounds((int X, int Y) coordinates, int tileSize, int targetWidth, int targetHeight, out int offsetX, out int offsetY, out int width, out int height)
+    {
+        offsetX = coordinates.X * tileSize;
+        offsetY = coordinates.Y * tileSize;
+        width = Math.Min(tileSize, targetWidth - offsetX);
+        height = Math.Min(tileSize, targetHeight - offsetY);
+
+        if (width <= 0 || height <= 0)
+        {
+            width = 0;
+            height = 0;
+            return false;
+        }
+
+        return true;
+    }
+
+    protected static TileRange CalculateTileRange(APoint position, APoint size, int tileSize)
+    {
+        if (tileSize <= 0 || size.X <= 0 || size.Y <= 0)
+            return default;
+
+        int startX = FastFloor(position.X, tileSize);
+        int startY = FastFloor(position.Y, tileSize);
+        int endX = FastFloor(position.X + size.X - 1, tileSize);
+        int endY = FastFloor(position.Y + size.Y - 1, tileSize);
+
+        startX = Math.Max(0, startX);
+        startY = Math.Max(0, startY);
+        endX = Math.Max(0, endX);
+        endY = Math.Max(0, endY);
+
+        return endX < startX || endY < startY
+            ? default
+            : new TileRange(startX, startY, endX, endY);
+    }
+
+    private static int FastFloor(float value, int tileSize)
+    {
+#if NET48
+        return (int)Math.Floor(value / tileSize);
+#else
+        return (int)MathF.Floor(value / tileSize);
+#endif
+    }
+
+    public override byte[] GetPixels()
+    {
+        if (_tileMap == null)
+            throw new NotSupportedException("Tile management is disabled; override GetPixels in derived class.");
+
+        int width = Width;
+        int height = Height;
+        if (width <= 0 || height <= 0)
+            return Array.Empty<byte>();
+
+        if (_tileMap.Count == 0)
+            return new byte[checked(width * height * 4)];
+
+        int tileSize = TileSize;
+        if (tileSize <= 0)
+            throw new InvalidOperationException("TileSize must be positive to read pixels.");
+
+        int totalPixels = checked(width * height);
+        var pixels = new byte[checked(totalPixels * 4)];
+        int destStride = width * 4;
+
+        ForEachTile(width, height, tileSize, createMissing: false, (coords, offsetX, offsetY, tileWidth, tileHeight, tile) =>
+        {
+            var tilePixels = tile.GetPixels();
+            if (tilePixels.Length == 0)
+                return;
+
+            int srcStride = tileWidth * 4;
+            int expectedLength = srcStride * tileHeight;
+            if (tilePixels.Length < expectedLength)
+                throw new InvalidOperationException($"Tile {coords} returned insufficient pixel data.");
+
+            var tileSpan = tilePixels.AsSpan();
+            var dest = pixels.AsSpan();
+
+            for (int row = 0; row < tileHeight; row++)
+            {
+                int destIndex = ((offsetY + row) * destStride) + (offsetX * 4);
+                tileSpan.Slice(row * srcStride, srcStride).CopyTo(dest.Slice(destIndex, srcStride));
+            }
+        });
+
+        return pixels;
+    }
+
+    public override void SetARGBPixels(byte[] argbPixels)
+        => SetTilePixels(argbPixels, PixelWriteFormat.ARGB);
+
+    public override void SetRGBAPixels(byte[] rgbaPixels)
+        => SetTilePixels(rgbaPixels, PixelWriteFormat.RGBA);
+
+    private void SetTilePixels(byte[] pixels, PixelWriteFormat format)
+    {
+        if (_tileMap == null)
+            throw new NotSupportedException("Tile management is disabled; override pixel setters in derived class.");
+
+        if (pixels == null)
+            throw new ArgumentNullException(nameof(pixels));
+
+        int width = Width;
+        int height = Height;
+        if (width <= 0 || height <= 0)
+        {
+            if (pixels.Length != 0)
+                throw new ArgumentException("Pixel buffer length does not match texture dimensions.", nameof(pixels));
+            return;
+        }
+
+        int expectedLength = checked(width * height * 4);
+        if (pixels.Length != expectedLength)
+            throw new ArgumentException($"Expected buffer length of {expectedLength} for {width}x{height} texture.", nameof(pixels));
+
+        int tileSize = TileSize;
+        if (tileSize <= 0)
+            throw new InvalidOperationException("TileSize must be positive to write pixels.");
+
+        int srcStride = width * 4;
+
+        ForEachTile(width, height, tileSize, createMissing: true, (coords, offsetX, offsetY, tileWidth, tileHeight, tile) =>
+        {
+            int tileStride = tileWidth * 4;
+            int tileLength = tileStride * tileHeight;
+            if (tileLength == 0)
+                return;
+
+            var tileBuffer = new byte[tileLength];
+            var tileSpan = tileBuffer.AsSpan();
+
+            for (int row = 0; row < tileHeight; row++)
+            {
+                int srcIndex = ((offsetY + row) * srcStride) + (offsetX * 4);
+                pixels.AsSpan(srcIndex, tileStride).CopyTo(tileSpan.Slice(row * tileStride, tileStride));
+            }
+
+            switch (format)
+            {
+                case PixelWriteFormat.ARGB:
+                    tile.SetARGBPixels(tileBuffer);
+                    break;
+                case PixelWriteFormat.RGBA:
+                    tile.SetRGBAPixels(tileBuffer);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(format), format, null);
+            }
+        });
+    }
+
+    private enum PixelWriteFormat
+    {
+        ARGB,
+        RGBA,
+    }
+
+    protected readonly struct TileRange
+    {
+        public TileRange(int startX, int startY, int endX, int endY)
+        {
+            StartX = startX;
+            StartY = startY;
+            EndX = endX;
+            EndY = endY;
+        }
+
+        public int StartX { get; }
+        public int StartY { get; }
+        public int EndX { get; }
+        public int EndY { get; }
+        public bool HasTiles => EndX >= StartX && EndY >= StartY;
+    }
+}
+
+public interface ITextureGridOwner<TFrameworkTexture>
+{
+    void DestroyTileTexture(TFrameworkTexture texture);
+    byte[] GetTexturePixels(TFrameworkTexture texture, int width, int height);
+    void SetTextureARGBPixels(TFrameworkTexture texture, int width, int height, byte[] argbPixels);
+    void SetTextureRGBAPixels(TFrameworkTexture texture, int width, int height, byte[] rgbaPixels);
+}
+
+public sealed class TextureGridTile<TFrameworkTexture> : AbstBaseTexture2D<TFrameworkTexture>
+{
+    private readonly ITextureGridOwner<TFrameworkTexture> _owner;
+    private readonly (int X, int Y) _coordinates;
+    private int _width;
+    private int _height;
+    private AbstBaseTexture2D<TFrameworkTexture>? _pixelsHost;
+
+    public TextureGridTile(
+        string baseName,
+        ITextureGridOwner<TFrameworkTexture> owner,
+        (int X, int Y) coordinates,
+        int width,
+        int height,
+        TFrameworkTexture texture,
+        AbstBaseTexture2D<TFrameworkTexture>? pixelsHost)
+        : base($"{baseName}_Tile_{coordinates.X}_{coordinates.Y}")
+    {
+        _owner = owner;
+        _coordinates = coordinates;
+        _width = width;
+        _height = height;
+        Texture = texture;
+        _pixelsHost = pixelsHost;
+    }
+
+    public override int Width => _width;
+    public override int Height => _height;
+    public TFrameworkTexture Texture { get; private set; }
+    public (int X, int Y) Coordinates => _coordinates;
+
+    public void UpdateTexture(TFrameworkTexture texture, int width, int height, AbstBaseTexture2D<TFrameworkTexture>? pixelsHost)
+    {
+        ReleaseCurrentTexture();
+        Texture = texture;
+        _width = width;
+        _height = height;
+        _pixelsHost = pixelsHost;
+    }
+
+    protected override void DisposeTexture()
+    {
+        ReleaseCurrentTexture();
+    }
+
+    public override byte[] GetPixels()
+    {
+        if (IsDefault(Texture))
+            return Array.Empty<byte>();
+
+        if (_pixelsHost != null)
+            return _pixelsHost.GetPixels();
+
+        return _owner.GetTexturePixels(Texture, Width, Height);
+    }
+
+    public override void SetARGBPixels(byte[] argbPixels)
+    {
+        if (IsDefault(Texture))
+            return;
+
+        if (_pixelsHost != null)
+        {
+            _pixelsHost.SetARGBPixels(argbPixels);
+            return;
+        }
+
+        _owner.SetTextureARGBPixels(Texture, Width, Height, argbPixels);
+    }
+
+    public override void SetRGBAPixels(byte[] rgbaPixels)
+    {
+        if (IsDefault(Texture))
+            return;
+
+        if (_pixelsHost != null)
+        {
+            _pixelsHost.SetRGBAPixels(rgbaPixels);
+            return;
+        }
+
+        _owner.SetTextureRGBAPixels(Texture, Width, Height, rgbaPixels);
+    }
+
+    public override IAbstTexture2D Clone() => throw new NotSupportedException("Grid tiles do not support cloning.");
+
+    private void ReleaseCurrentTexture()
+    {
+        if (_pixelsHost != null)
+        {
+            _pixelsHost.Dispose();
+            _pixelsHost = null;
+            Texture = default!;
+            return;
+        }
+
+        if (!IsDefault(Texture))
+        {
+            _owner.DestroyTileTexture(Texture);
+            Texture = default!;
+        }
+    }
+
+    private static bool IsDefault(TFrameworkTexture value)
+        => EqualityComparer<TFrameworkTexture>.Default.Equals(value, default!);
+}

--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Graphics/AbstImagePainter.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Components/Graphics/AbstImagePainter.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using AbstUI.Bitmaps;
 using AbstUI.Primitives;
 using AbstUI.Styles;
 using AbstUI.Texts;
@@ -16,12 +19,8 @@ public abstract class AbstImagePainter<TTexture> : IAbstImagePainter
     private int _width;
     private int _height;
 
-    // Grid rendering support
-    protected readonly Dictionary<(int X, int Y), TTexture> _tiles = new();
-    protected readonly Dictionary<(int X, int Y), List<DrawAction>> _tileActions = new();
-    protected readonly HashSet<(int X, int Y)> _dirtyTiles = new();
-    protected int _offsetX;
-    protected int _offsetY;
+    // Grid rendering support is managed by PainterGridTexture when enabled.
+    private PainterGridTexture? _gridTexture;
 
     protected AbstImagePainter(int width, int height, int maxWidth, int maxHeight)
     {
@@ -62,39 +61,21 @@ public abstract class AbstImagePainter<TTexture> : IAbstImagePainter
     public bool UseTextureGrid { get; set; }
     public int TileSize { get; set; } = 128;
 
-    protected int OffsetX => _offsetX;
-    protected int OffsetY => _offsetY;
+    protected int OffsetX => _gridTexture?.OffsetX ?? 0;
+    protected int OffsetY => _gridTexture?.OffsetY ?? 0;
 
     protected void AddDrawAction(DrawAction action)
     {
         _drawActions.Add(action);
         _dirty = true;
         if (!UseTextureGrid) return;
-#if NET48
-        int startX = Math.Max(0, (int)Math.Floor((action.Position.X / TileSize)));
-        int startY = Math.Max(0, (int)Math.Floor((action.Position.Y / TileSize)));
-        int endX = Math.Max(0, (int)Math.Floor((action.Position.X + action.Size.X - 1) / TileSize));
-        int endY = Math.Max(0, (int)Math.Floor((action.Position.Y + action.Size.Y - 1) / TileSize));
-#else
-        int startX = Math.Max(0, (int)MathF.Floor(action.Position.X / TileSize));
-        int startY = Math.Max(0, (int)MathF.Floor(action.Position.Y / TileSize));
-        int endX = Math.Max(0, (int)MathF.Floor((action.Position.X + action.Size.X - 1) / TileSize));
-        int endY = Math.Max(0, (int)MathF.Floor((action.Position.Y + action.Size.Y - 1) / TileSize));
-#endif
-        for (int x = startX; x <= endX; x++)
-            for (int y = startY; y <= endY; y++)
-                AddTileAction((x, y), action);
+        EnsureGrid().TrackDrawAction(action);
     }
 
     protected void AddTileAction((int X, int Y) tile, DrawAction action)
     {
-        if (!_tileActions.TryGetValue(tile, out var list))
-        {
-            list = new List<DrawAction>();
-            _tileActions[tile] = list;
-        }
-        list.Add(action);
-        _dirtyTiles.Add(tile);
+        if (!UseTextureGrid) return;
+        EnsureGrid().AddTileAction(tile, action);
         _dirty = true;
     }
 
@@ -102,39 +83,21 @@ public abstract class AbstImagePainter<TTexture> : IAbstImagePainter
     {
         _dirty = true;
         if (UseTextureGrid)
-        {
-            int tilesX = (Width + TileSize - 1) / TileSize;
-            int tilesY = (Height + TileSize - 1) / TileSize;
-            for (int x = 0; x < tilesX; x++)
-                for (int y = 0; y < tilesY; y++)
-                    _dirtyTiles.Add((x, y));
-        }
+            EnsureGrid().MarkAllDirty(Width, Height, TileSize);
     }
 
     protected void MarkDirty(APoint position, APoint size)
     {
         _dirty = true;
         if (!UseTextureGrid) return;
-#if NET48
-       int startX = Math.Max(0, (int)Math.Floor(position.X / TileSize));
-        int startY = Math.Max(0, (int)Math.Floor(position.Y / TileSize));
-        int endX = Math.Max(0, (int)Math.Floor((position.X + size.X - 1) / TileSize));
-        int endY = Math.Max(0, (int)Math.Floor((position.Y + size.Y - 1) / TileSize));
-#else
-        int startX = Math.Max(0, (int)MathF.Floor(position.X / TileSize));
-        int startY = Math.Max(0, (int)MathF.Floor(position.Y / TileSize));
-        int endX = Math.Max(0, (int)MathF.Floor((position.X + size.X - 1) / TileSize));
-        int endY = Math.Max(0, (int)MathF.Floor((position.Y + size.Y - 1) / TileSize));
-#endif
-        for (int x = startX; x <= endX; x++)
-            for (int y = startY; y <= endY; y++)
-                _dirtyTiles.Add((x, y));
+        EnsureGrid().MarkDirty(position, size, TileSize);
     }
 
     public void Clear(AColor color)
     {
         _drawActions.Clear();
-        _tileActions.Clear();
+        if (UseTextureGrid)
+            EnsureGrid().ClearActions();
         _clearColor = color;
         MarkDirty();
     }
@@ -192,38 +155,14 @@ public abstract class AbstImagePainter<TTexture> : IAbstImagePainter
             return;
         }
 
-        if (_dirtyTiles.Count == 0 && targetWidth == _width && targetHeight == _height)
+        var grid = EnsureGrid();
+        if (!_dirty && !grid.HasDirtyTiles && targetWidth == _width && targetHeight == _height)
             return;
 
         _width = targetWidth;
         _height = targetHeight;
         var clearColor = _clearColor ?? AColor.FromRGBA(0, 0, 0, 0);
-        foreach (var tilePos in _dirtyTiles)
-        {
-            int ox = tilePos.X * TileSize;
-            int oy = tilePos.Y * TileSize;
-            int tw = Math.Min(TileSize, _width - ox);
-            int th = Math.Min(TileSize, _height - oy);
-            if (!_tiles.TryGetValue(tilePos, out var tex) || tex == null || tex.Equals(default(TTexture)))
-            {
-                tex = CreateTileTexture(tw, th);
-                _tiles[tilePos] = tex;
-            }
-
-            UseTexture(tex);
-            _offsetX = ox;
-            _offsetY = oy;
-            BeginRender(clearColor);
-            if (_tileActions.TryGetValue(tilePos, out var actions))
-            {
-                foreach (var action in actions)
-                    action.Execute(tex, action.SrcRect, action.DestRect);
-            }
-            EndRender();
-        }
-        _offsetX = 0;
-        _offsetY = 0;
-        _dirtyTiles.Clear();
+        grid.Render(targetWidth, targetHeight, TileSize, clearColor);
         _dirty = false;
     }
 
@@ -232,15 +171,157 @@ public abstract class AbstImagePainter<TTexture> : IAbstImagePainter
     protected abstract void ResizeTexture(int width, int height);
     protected virtual TTexture CreateTileTexture(int width, int height) => default!;
     protected virtual void DestroyTileTexture(TTexture texture) { }
+    protected virtual AbstBaseTexture2D<TTexture>? CreateTilePixelsHost((int X, int Y) coordinates, TTexture texture, int width, int height)
+        => null;
     protected virtual void UseTexture(TTexture texture) { }
+    protected virtual byte[] GetTexturePixels(TTexture texture, int width, int height)
+        => throw new NotSupportedException($"{GetType().Name} does not support pixel readback for grid textures.");
+
+    protected virtual void SetTextureARGBPixels(TTexture texture, int width, int height, byte[] argbPixels)
+        => throw new NotSupportedException($"{GetType().Name} does not support ARGB uploads for grid textures.");
+
+    protected virtual void SetTextureRGBAPixels(TTexture texture, int width, int height, byte[] rgbaPixels)
+        => throw new NotSupportedException($"{GetType().Name} does not support RGBA uploads for grid textures.");
     protected abstract TTexture Target { get; }
 
     protected void DisposeTiles()
     {
-        foreach (var tex in _tiles.Values)
-            DestroyTileTexture(tex);
-        _tiles.Clear();
-        _dirtyTiles.Clear();
+        _gridTexture?.DisposeTiles();
+        _gridTexture = null;
+    }
+
+    private PainterGridTexture EnsureGrid()
+    {
+        return _gridTexture ??= new PainterGridTexture(this);
+    }
+
+    private sealed class PainterGridTexture : AbstBaseGridTexture<TTexture>, ITextureGridOwner<TTexture>
+    {
+        private readonly AbstImagePainter<TTexture> _owner;
+        private readonly Dictionary<(int X, int Y), List<DrawAction>> _tileActions = new();
+
+        public PainterGridTexture(AbstImagePainter<TTexture> owner)
+            : base(owner.Name)
+        {
+            _owner = owner;
+        }
+
+        public override int Width => _owner.Width;
+        public override int Height => _owner.Height;
+        public int OffsetX { get; private set; }
+        public int OffsetY { get; private set; }
+
+        protected override int TileSize => _owner.TileSize;
+
+        public void TrackDrawAction(DrawAction action)
+        {
+            if (_owner.TileSize <= 0)
+                return;
+
+            var range = CalculateTileRange(action.Position, action.Size, _owner.TileSize);
+            if (!range.HasTiles)
+                return;
+
+            for (int x = range.StartX; x <= range.EndX; x++)
+            {
+                for (int y = range.StartY; y <= range.EndY; y++)
+                    AddTileAction((x, y), action);
+            }
+        }
+
+        public void AddTileAction((int X, int Y) tile, DrawAction action)
+        {
+            if (!_tileActions.TryGetValue(tile, out var list))
+            {
+                list = new List<DrawAction>();
+                _tileActions[tile] = list;
+            }
+
+            list.Add(action);
+            MarkTileDirty(tile);
+        }
+
+        public void MarkAllDirty(int width, int height, int tileSize)
+        {
+            MarkAllTilesDirty(width, height, tileSize);
+        }
+
+        public void MarkDirty(APoint position, APoint size, int tileSize)
+        {
+            MarkRegionDirty(position, size, tileSize);
+        }
+
+        public void ClearActions()
+        {
+            _tileActions.Clear();
+            ClearDirtyTiles();
+        }
+
+        public void Render(int targetWidth, int targetHeight, int tileSize, AColor clearColor)
+        {
+            if (tileSize <= 0 || !HasDirtyTiles)
+                return;
+
+            ForEachDirtyTile(targetWidth, targetHeight, tileSize, (coords, offsetX, offsetY, _, _, tileBase) =>
+            {
+                var tile = (TextureGridTile<TTexture>)tileBase;
+                OffsetX = offsetX;
+                OffsetY = offsetY;
+                _owner.UseTexture(tile.Texture);
+                _owner.BeginRender(clearColor);
+                if (_tileActions.TryGetValue(coords, out var actions))
+                {
+                    foreach (var action in actions)
+                        action.Execute(tile.Texture, action.SrcRect, action.DestRect);
+                }
+                _owner.EndRender();
+            });
+
+            OffsetX = 0;
+            OffsetY = 0;
+            ClearDirtyTiles();
+        }
+
+        public void DisposeTiles()
+        {
+            DisposeRegisteredTiles();
+            _tileActions.Clear();
+            OffsetX = 0;
+            OffsetY = 0;
+        }
+
+        protected override AbstBaseTexture2D<TTexture> CreateTile((int X, int Y) coordinates, int width, int height)
+        {
+            var texture = _owner.CreateTileTexture(width, height);
+            var pixelsHost = _owner.CreateTilePixelsHost(coordinates, texture, width, height);
+            return new TextureGridTile<TTexture>(_owner.Name, this, coordinates, width, height, texture, pixelsHost);
+        }
+
+        protected override void ResizeTile((int X, int Y) coordinates, AbstBaseTexture2D<TTexture> tile, int width, int height)
+        {
+            var painterTile = (TextureGridTile<TTexture>)tile;
+            var texture = _owner.CreateTileTexture(width, height);
+            var pixelsHost = _owner.CreateTilePixelsHost(coordinates, texture, width, height);
+            painterTile.UpdateTexture(texture, width, height, pixelsHost);
+        }
+
+        protected override void DisposeTexture()
+        {
+            DisposeTiles();
+        }
+        public override IAbstTexture2D Clone() => throw new NotSupportedException("Grid textures do not support cloning.");
+
+        void ITextureGridOwner<TTexture>.DestroyTileTexture(TTexture texture)
+            => _owner.DestroyTileTexture(texture);
+
+        byte[] ITextureGridOwner<TTexture>.GetTexturePixels(TTexture texture, int width, int height)
+            => _owner.GetTexturePixels(texture, width, height);
+
+        void ITextureGridOwner<TTexture>.SetTextureARGBPixels(TTexture texture, int width, int height, byte[] argbPixels)
+            => _owner.SetTextureARGBPixels(texture, width, height, argbPixels);
+
+        void ITextureGridOwner<TTexture>.SetTextureRGBAPixels(TTexture texture, int width, int height, byte[] rgbaPixels)
+            => _owner.SetTextureRGBAPixels(texture, width, height, rgbaPixels);
     }
 
     public abstract void SetPixel(APoint point, AColor color);


### PR DESCRIPTION
## Summary
- add repository guidance to keep reusable test helpers under the Fakes folder
- implement UnityTexture2D pixel getters/setters and cloning so grid textures can marshal RGBA/ARGB data
- move the grid test helper textures into a shared fakes file and update the grid texture tests to consume it

## Testing
- dotnet test WillMoveToOwnRepo/AbstUI/Test/AbstUI.Tests/AbstUI.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d210eb01288332a85e2a7ba5efe39d