### PR TITLE
Enhance score navigation and show options

### DIFF
--- a/src/Net/BlingoEngine.Net.RNetTerminal/Views/PropertyInspector.cs
+++ b/src/Net/BlingoEngine.Net.RNetTerminal/Views/PropertyInspector.cs
@@ -227,6 +227,23 @@ internal sealed class PropertyInspector : View
                 ShowMember(m);
             }
         };
+        store.SpriteChanged += sprite =>
+        {
+            var current = _sprite;
+            if (current == null)
+            {
+                return;
+            }
+
+            if (sprite.SpriteNum == current.SpriteNum && sprite.BeginFrame == current.BeginFrame)
+            {
+                ShowSprite(sprite);
+                if (sprite.Member != null)
+                {
+                    ShowMember(store.FindMember(sprite.Member.CastLibNum, sprite.Member.MemberNum));
+                }
+            }
+        };
     }
   
 

--- a/src/Net/BlingoEngine.Net.RNetTerminal/Views/RootWindow.cs
+++ b/src/Net/BlingoEngine.Net.RNetTerminal/Views/RootWindow.cs
@@ -41,6 +41,10 @@ namespace BlingoEngine.Net.RNetTerminal.Views
         private Func<RNetCommand, CancellationToken?, Task>? _sendCommandAsync;
         private int _lastRequestedFrame = -1;
         private bool _suppressNextFrameCommand;
+        private CheckBox? _showFirstBehaviorCheckBox;
+        private CheckBox? _showMemberNameCheckBox;
+        private CheckBox? _showSpriteNameCheckBox;
+        private bool _updatingShowMenu;
 
         private int _port => BlingoRNetTerminal.Port;
         public RootWindow()
@@ -53,6 +57,11 @@ namespace BlingoEngine.Net.RNetTerminal.Views
         {
             _setPort = setPort;
             _sendCommandAsync = sendCommandAsync;
+            _score = BuildScoreWindow();
+            _stage = BuildStageWindow();
+            _cast = BuildCastWindow();
+            _propInsp = CreatePropertyInspector(sendCommandAsync);
+            var logs = CreateLog();
             var top = new Window
             {
                 BorderStyle = LineStyle.None,
@@ -66,7 +75,7 @@ namespace BlingoEngine.Net.RNetTerminal.Views
                     NewMenuItemv2("_Host Port", string.Empty, SetPort),
                     NewMenuItemv2("_Quit", string.Empty, () => Application.RequestStop())
                 }),
-                //new MenuBarItemv2("_Edit", System.Array.Empty<MenuItemv2>()),
+                new MenuBarItemv2("_Show", CreateShowMenuItems()),
                 new MenuBarItemv2("_Help", Array.Empty<MenuItemv2>())
             });
             _stageBtn = NewMenuItemv2("_Stage", string.Empty, () => SwitchToStageMode());
@@ -77,6 +86,7 @@ namespace BlingoEngine.Net.RNetTerminal.Views
             top.Add(_stageBtn);
             top.Add(_castBtn);
             RNetTerminalStyle.SetMenuSchema(menu);
+            UpdateShowMenuChecks();
             
 
             _connectionStatusLabel = RUI.NewLabel(string.Empty, Pos.AnchorEnd(15), 0, 15);
@@ -142,13 +152,6 @@ namespace BlingoEngine.Net.RNetTerminal.Views
                 rightPadding.Thickness = new Thickness(0);
             }
 
-            _score = BuildScoreWindow();
-            _stage = BuildStageWindow();
-            _cast = BuildCastWindow();
-            _propInsp = CreatePropertyInspector(sendCommandAsync);
-            var logs = CreateLog();
-
-
             _stage.Visible = true;
             _cast.Visible = false;
 
@@ -183,6 +186,88 @@ namespace BlingoEngine.Net.RNetTerminal.Views
             Application.Run(top);
             top.Dispose();
             store.MovieStateChanged -= OnMovieStateChanged;
+        }
+
+        private IEnumerable<View> CreateShowMenuItems()
+        {
+            return new View[]
+            {
+                CreateShowMenuCheck("_Show first Behavior", () => _score?.ShowFirstBehavior ?? false, value =>
+                {
+                    if (_score != null)
+                    {
+                        _score.ShowFirstBehavior = value;
+                    }
+                }, checkBox => _showFirstBehaviorCheckBox = checkBox),
+                CreateShowMenuCheck("Show _Member Name", () => _score?.ShowMemberName ?? false, value =>
+                {
+                    if (_score != null)
+                    {
+                        _score.ShowMemberName = value;
+                    }
+                }, checkBox => _showMemberNameCheckBox = checkBox),
+                CreateShowMenuCheck("Show _Sprite Name", () => _score?.ShowSpriteName ?? false, value =>
+                {
+                    if (_score != null)
+                    {
+                        _score.ShowSpriteName = value;
+                    }
+                }, checkBox => _showSpriteNameCheckBox = checkBox)
+            };
+        }
+
+        private MenuItemv2 CreateShowMenuCheck(string label, Func<bool> getter, Action<bool> setter, Action<CheckBox> register)
+        {
+            var checkBox = new CheckBox
+            {
+                Title = label,
+                CheckedState = getter() ? CheckState.Checked : CheckState.UnChecked
+            };
+            register(checkBox);
+            var menuItem = new MenuItemv2 { CommandView = checkBox };
+            menuItem.SetScheme(RNetTerminalStyle.MenuScheme);
+            checkBox.CheckedStateChanged += (_, _) =>
+            {
+                if (_updatingShowMenu)
+                {
+                    return;
+                }
+
+                setter(checkBox.CheckedState == CheckState.Checked);
+                UpdateShowMenuChecks();
+            };
+            return menuItem;
+        }
+
+        private void UpdateShowMenuChecks()
+        {
+            if (_score == null)
+            {
+                return;
+            }
+
+            _updatingShowMenu = true;
+            try
+            {
+                if (_showFirstBehaviorCheckBox != null)
+                {
+                    _showFirstBehaviorCheckBox.CheckedState = _score.ShowFirstBehavior ? CheckState.Checked : CheckState.UnChecked;
+                }
+
+                if (_showMemberNameCheckBox != null)
+                {
+                    _showMemberNameCheckBox.CheckedState = _score.ShowMemberName ? CheckState.Checked : CheckState.UnChecked;
+                }
+
+                if (_showSpriteNameCheckBox != null)
+                {
+                    _showSpriteNameCheckBox.CheckedState = _score.ShowSpriteName ? CheckState.Checked : CheckState.UnChecked;
+                }
+            }
+            finally
+            {
+                _updatingShowMenu = false;
+            }
         }
 
         private MenuItemv2 NewMenuItemv2(string text, string helperText, Action action)

--- a/src/Net/BlingoEngine.Net.RNetTerminal/Views/ScoreView.cs
+++ b/src/Net/BlingoEngine.Net.RNetTerminal/Views/ScoreView.cs
@@ -58,6 +58,9 @@ internal sealed class ScoreView : View
     private int _dragOffset;
     private int _dragOriginalStart;
     private int _dragLength;
+    private bool _showFirstBehavior;
+    private bool _showMemberName;
+    private bool _showSpriteName = true;
 
     public Rectangle Bounds => Viewport;
     public Point ContentOffset {
@@ -103,6 +106,111 @@ internal sealed class ScoreView : View
     public event System.Action<int, int, SpriteRef?, BlingoMemberRefDTO?>? InfoChanged;
 
     public void RequestRedraw() => SetNeedsDraw();
+
+    public bool ShowFirstBehavior
+    {
+        get => _showFirstBehavior;
+        set
+        {
+            if (value)
+            {
+                if (_showFirstBehavior && !_showMemberName && !_showSpriteName)
+                {
+                    return;
+                }
+
+                var changed = !_showFirstBehavior || _showMemberName || _showSpriteName;
+                _showFirstBehavior = true;
+                _showMemberName = false;
+                _showSpriteName = false;
+
+                if (changed)
+                {
+                    SetNeedsDraw();
+                }
+            }
+            else
+            {
+                if (!_showFirstBehavior)
+                {
+                    return;
+                }
+
+                _showFirstBehavior = false;
+                SetNeedsDraw();
+            }
+        }
+    }
+
+    public bool ShowMemberName
+    {
+        get => _showMemberName;
+        set
+        {
+            if (value)
+            {
+                if (_showMemberName && !_showFirstBehavior && !_showSpriteName)
+                {
+                    return;
+                }
+
+                var changed = !_showMemberName || _showFirstBehavior || _showSpriteName;
+                _showMemberName = true;
+                _showFirstBehavior = false;
+                _showSpriteName = false;
+
+                if (changed)
+                {
+                    SetNeedsDraw();
+                }
+            }
+            else
+            {
+                if (!_showMemberName)
+                {
+                    return;
+                }
+
+                _showMemberName = false;
+                SetNeedsDraw();
+            }
+        }
+    }
+
+    public bool ShowSpriteName
+    {
+        get => _showSpriteName;
+        set
+        {
+            if (value)
+            {
+                if (_showSpriteName && !_showFirstBehavior && !_showMemberName)
+                {
+                    return;
+                }
+
+                var changed = !_showSpriteName || _showFirstBehavior || _showMemberName;
+                _showSpriteName = true;
+                _showFirstBehavior = false;
+                _showMemberName = false;
+
+                if (changed)
+                {
+                    SetNeedsDraw();
+                }
+            }
+            else
+            {
+                if (!_showSpriteName)
+                {
+                    return;
+                }
+
+                _showSpriteName = false;
+                SetNeedsDraw();
+            }
+        }
+    }
     public void ReloadData()
     {
 
@@ -235,6 +343,24 @@ internal sealed class ScoreView : View
                     return true;
                 case Terminal.Gui.Drivers.KeyCode.CursorRight:
                     MoveCursor(step, 0);
+                    return true;
+                case Terminal.Gui.Drivers.KeyCode.PageUp:
+                    MoveCursor(0, -System.Math.Max(1, GetVisibleChannelCount()));
+                    return true;
+                case Terminal.Gui.Drivers.KeyCode.PageDown:
+                    MoveCursor(0, System.Math.Max(1, GetVisibleChannelCount()));
+                    return true;
+                case Terminal.Gui.Drivers.KeyCode.Home:
+                    if (FrameCount > 0)
+                    {
+                        MoveCursor(-_cursorFrame, 0);
+                    }
+                    return true;
+                case Terminal.Gui.Drivers.KeyCode.End:
+                    if (FrameCount > 0)
+                    {
+                        MoveCursor(FrameCount - 1 - _cursorFrame, 0);
+                    }
                     return true;
                 case Terminal.Gui.Drivers.KeyCode.Enter:
                     ShowActionMenu();
@@ -413,10 +539,8 @@ internal sealed class ScoreView : View
 
     private void ClampContentOffset(ref Point offset)
     {
-        var scrollBarWidth = VerticalScrollBar.Visible ? 1 : 0;
-        var scrollBarHeight = VerticalScrollBar.Visible ? 1 : 0;
-        var visibleFrames = System.Math.Max(0, Bounds.Width - _labelWidth - scrollBarWidth);
-        var visibleChannels = System.Math.Max(0, Bounds.Height - 1 - scrollBarHeight);
+        var visibleFrames = System.Math.Max(0, GetVisibleFrameCount());
+        var visibleChannels = System.Math.Max(0, GetVisibleChannelCount());
         var maxX = System.Math.Max(0, FrameCount - visibleFrames);
         var maxY = System.Math.Max(0, TotalChannels - visibleChannels);
         offset.X = System.Math.Clamp(offset.X, 0, maxX);
@@ -433,6 +557,18 @@ internal sealed class ScoreView : View
     private Point GetOffset() => new(ContentOffset.X, ContentOffset.Y);
 
     private void SetOffset(Point offset)  => ContentOffset = new Point(offset.X, offset.Y);
+
+    private int GetVisibleFrameCount()
+    {
+        var scrollBarWidth = VerticalScrollBar.Visible ? 1 : 0;
+        return System.Math.Max(0, Bounds.Width - _labelWidth - scrollBarWidth);
+    }
+
+    private int GetVisibleChannelCount()
+    {
+        var scrollBarHeight = HorizontalScrollBar.Visible ? 1 : 0;
+        return System.Math.Max(0, Bounds.Height - 1 - scrollBarHeight);
+    }
 
     private void MoveCursor(int dx, int dy)
     {
@@ -452,10 +588,8 @@ internal sealed class ScoreView : View
 
     private void EnsureVisible()
     {
-        var scrollBarWidth = VerticalScrollBar.Visible ? 1 : 0;
-        var scrollBarHeight = VerticalScrollBar.Visible ? 1 : 0;
-        var visibleFrames = System.Math.Max(0, Bounds.Width - _labelWidth - scrollBarWidth);
-        var visibleChannels = System.Math.Max(0, Bounds.Height - 1 - scrollBarHeight);
+        var visibleFrames = System.Math.Max(0, GetVisibleFrameCount());
+        var visibleChannels = System.Math.Max(0, GetVisibleChannelCount());
         var offset = GetOffset();
         if (_cursorFrame < offset.X)
         {
@@ -507,8 +641,8 @@ internal sealed class ScoreView : View
 
         
         SetColorsSchemaNormal();
-        var visibleFrames = System.Math.Max(0, w - _labelWidth);
-        var visibleChannels = System.Math.Max(0, h );
+        var visibleFrames = System.Math.Max(0, GetVisibleFrameCount());
+        var visibleChannels = System.Math.Max(0, GetVisibleChannelCount());
         var posOffset = GetOffset();
         var offsetX = posOffset.X;
         var offsetY = posOffset.Y;
@@ -567,6 +701,7 @@ internal sealed class ScoreView : View
             }
         }
 
+        var store = TerminalDataStore.Instance;
         foreach (var sprite in _sprites)
         {
             var channelIdx = sprite.Channel - 1 + SpecialChannels.Length;
@@ -588,17 +723,27 @@ internal sealed class ScoreView : View
                 Move(_labelWidth + f - offsetX, y);
                 AddRune(' ');
             }
-            var member = TerminalDataStore.Instance.FindMember(sprite.CastLib, sprite.MemberNum);
-            if (member != null && member.Type == BlingoMemberTypeDTO.Text)
+            var member = store.FindMember(sprite.CastLib, sprite.MemberNum);
+            var label = GetSpriteLabel(sprite, member);
+            if (!string.IsNullOrEmpty(label))
             {
-                var maxChars = System.Math.Max(1, (int)(sprite.Width / _stageWidth * (end - start + 1)));
-                var text = member.Name;
-                var len = System.Math.Min(text.Length, System.Math.Min(maxChars, end - start + 1));
-                SetAttribute(new Attribute(ColorName16.Black, bg));
-                for (var i = 0; i < len; i++)
+                var available = System.Math.Max(0, end - start + 1);
+                if (available > 0)
                 {
-                    Move(_labelWidth + start + i - offsetX, y);
-                    AddRune(text[i]);
+                    var maxChars = available;
+                    if (_stageWidth > 0 && sprite.Width > 0)
+                    {
+                        var estimated = (int)System.Math.Max(1, sprite.Width / _stageWidth * available);
+                        maxChars = System.Math.Min(estimated, available);
+                    }
+
+                    var len = System.Math.Min(label.Length, maxChars);
+                    SetAttribute(new Attribute(ColorName16.Black, bg));
+                    for (var i = 0; i < len; i++)
+                    {
+                        Move(_labelWidth + start + i - offsetX, y);
+                        AddRune(label[i]);
+                    }
                 }
             }
             SetAttribute(new Attribute(ColorName16.Black, bg));
@@ -921,6 +1066,46 @@ internal sealed class ScoreView : View
     public void TriggerInfo() => NotifyInfoChanged();
 
     public event System.Action<int>? PlayFromHere;
+
+    private string? GetSpriteLabel(SpriteBlock sprite, BlingoMemberDTO? member)
+    {
+        var parts = new List<string>();
+        var seen = new HashSet<string>(System.StringComparer.Ordinal);
+
+        if (_showFirstBehavior)
+        {
+            var behaviorName = sprite.Sprite.Behaviors.FirstOrDefault()?.Name;
+            if (!string.IsNullOrWhiteSpace(behaviorName) && seen.Add(behaviorName))
+            {
+                parts.Add(behaviorName);
+            }
+        }
+
+        if (_showMemberName && member != null)
+        {
+            var memberName = member.Name;
+            if (!string.IsNullOrWhiteSpace(memberName) && seen.Add(memberName))
+            {
+                parts.Add(memberName);
+            }
+        }
+
+        if (_showSpriteName)
+        {
+            var spriteName = sprite.Sprite.Name;
+            if (!string.IsNullOrWhiteSpace(spriteName) && seen.Add(spriteName))
+            {
+                parts.Add(spriteName);
+            }
+        }
+
+        if (parts.Count == 0)
+        {
+            return null;
+        }
+
+        return string.Join(" • ", parts);
+    }
 
     private sealed class SpecialSpriteBlock
     {


### PR DESCRIPTION
## Summary
- add a Show menu with toggles to expose behavior, member, and sprite name overlays in the score, ensuring only one overlay is visible at a time
- extend ScoreView keyboard handling and rendering so page, home/end navigation works and metadata text stays within sprite blocks
- refresh the property inspector when remote sprite updates arrive so host changes are reflected immediately

## Testing
- dotnet build src/Net/BlingoEngine.Net.RNetTerminal/BlingoEngine.Net.RNetTerminal.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d3d0cf43948332beab20eaea44e601