### PR TITLE
Publish sprite property deltas over RNet

### DIFF
--- a/src/Net/BlingoEngine.Net.RNetHost.Common/DtoExtensions.cs
+++ b/src/Net/BlingoEngine.Net.RNetHost.Common/DtoExtensions.cs
@@ -10,13 +10,7 @@ internal static class DtoExtensions
     /// <summary>Converts a sprite to its network DTO.</summary>
     public static RNetSpriteDto ToDto(this BlingoSprite2D sprite)
     {
-        int castLib = 0;
-        int memberNum = 0;
-        if (sprite.Member is IBlingoMember m)
-        {
-            castLib = m.CastLibNum;
-            memberNum = m.NumberInCast;
-        }
+        var (castLib, memberNum) = GetSpriteMemberInfo(sprite);
 
         return new RNetSpriteDto(
             sprite.SpriteNum,
@@ -32,6 +26,41 @@ internal static class DtoExtensions
             (int)sprite.Skew,
             (int)sprite.Blend,
             sprite.Ink);
+    }
+
+    /// <summary>Converts a sprite to a delta DTO for the specified frame.</summary>
+    public static SpriteDeltaDto ToDelta(this BlingoSprite2D sprite, int frame)
+    {
+        var (castLib, memberNum) = GetSpriteMemberInfo(sprite);
+
+        return new SpriteDeltaDto(
+            frame,
+            sprite.SpriteNum,
+            sprite.BeginFrame,
+            sprite.LocZ,
+            castLib,
+            memberNum,
+            (int)sprite.LocH,
+            (int)sprite.LocV,
+            (int)sprite.Width,
+            (int)sprite.Height,
+            (int)sprite.Rotation,
+            (int)sprite.Skew,
+            (int)sprite.Blend,
+            sprite.Ink);
+    }
+
+    private static (int CastLib, int MemberNum) GetSpriteMemberInfo(BlingoSprite2D sprite)
+    {
+        int castLib = 0;
+        int memberNum = 0;
+        if (sprite.Member is IBlingoMember m)
+        {
+            castLib = m.CastLibNum;
+            memberNum = m.NumberInCast;
+        }
+
+        return (castLib, memberNum);
     }
 }
 

--- a/src/Net/BlingoEngine.Net.RNetHost.Common/RNetPublisherBase.cs
+++ b/src/Net/BlingoEngine.Net.RNetHost.Common/RNetPublisherBase.cs
@@ -21,6 +21,7 @@ namespace BlingoEngine.Net.RNetHost.Common;
 public abstract class RNetPublisherBase : IRNetPublisherEngineBridge
 {
     private readonly ConcurrentDictionary<(int SpriteNum, int BeginFrame), SpriteDeltaDto> _spriteQueue = new();
+    private readonly ConcurrentDictionary<BlingoSprite2D, (int SpriteNum, int BeginFrame)> _spriteKeys = new();
     private readonly ConcurrentDictionary<(int CastLibNum, int MemberNum, string Prop), RNetMemberPropertyDto> _memberQueue = new();
     private readonly ConcurrentDictionary<string, RNetMoviePropertyDto> _movieQueue = new();
     private readonly ConcurrentDictionary<string, RNetStagePropertyDto> _stageQueue = new();
@@ -339,9 +340,17 @@ public abstract class RNetPublisherBase : IRNetPublisherEngineBridge
     {
         if (sender is BlingoSprite2D sprite2D && e.PropertyName is not null)
         {
-            var value = sprite2D.ToDto();
-            // todo
-            //TryPublishSpriteProperty(value);
+            var newKey = (sprite2D.SpriteNum, sprite2D.BeginFrame);
+            if (_spriteKeys.TryGetValue(sprite2D, out var previousKey) && previousKey != newKey)
+            {
+                _spriteQueue.TryRemove(previousKey, out _);
+            }
+
+            var frame = _movie?.Frame ?? sprite2D.BeginFrame;
+            var delta = sprite2D.ToDelta(frame);
+            TryPublishDelta(delta);
+
+            _spriteKeys[sprite2D] = newKey;
         }
     }
 
@@ -374,6 +383,10 @@ public abstract class RNetPublisherBase : IRNetPublisherEngineBridge
         PropertyChangedEventHandler handler = OnSpitePropertyChanged;
         // Currently no per-property sprite publishing.
         Subscribe(sprite, handler);
+        if (sprite is BlingoSprite2D sprite2D)
+        {
+            _spriteKeys[sprite2D] = (sprite2D.SpriteNum, sprite2D.BeginFrame);
+        }
     }
 
    
@@ -389,6 +402,13 @@ public abstract class RNetPublisherBase : IRNetPublisherEngineBridge
         if (_propSubs.Remove(src, out var h))
         {
             src.PropertyChanged -= h;
+        }
+        if (src is BlingoSprite2D sprite2D)
+        {
+            if (_spriteKeys.TryRemove(sprite2D, out var key))
+            {
+                _spriteQueue.TryRemove(key, out _);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add conversion helpers to turn BlingoSprite2D state into sprite delta DTOs
- emit sprite property changes as deltas while keeping queue keys in sync

## Testing
- dotnet test Test/BlingoEngine.Net.RNetPipe.Tests/BlingoEngine.Net.RNetPipe.Tests.csproj
- dotnet test Test/BlingoEngine.Net.RNetProjectHost.Tests/BlingoEngine.Net.RNetProjectHost.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d3dc4b31e883328150a8c3dcbfe228