### PR TITLE
Reward block drops based on fall speed

### DIFF
--- a/Demo/TetriGrounds/BlingoEngine.Demo.TetriGrounds.Core/ParentScripts/PlayerBlockScript.cs
+++ b/Demo/TetriGrounds/BlingoEngine.Demo.TetriGrounds.Core/ParentScripts/PlayerBlockScript.cs
@@ -46,6 +46,7 @@ namespace BlingoEngine.Demo.TetriGrounds.Core.ParentScripts
         private bool myDownPressed;
         private bool myStopKeyAction;
         private int myLastKey;
+        private DateTime _currentBlockStartedAt;
 
         /// <summary>
         /// Prepares the controller with references to supporting services and seeds the random piece list.
@@ -237,7 +238,10 @@ namespace BlingoEngine.Demo.TetriGrounds.Core.ParentScripts
         {
             if (myFinished)
                 return;
-            
+
+            var dropDuration = DateTime.UtcNow - _currentBlockStartedAt;
+            var rowsTravelled = Math.Max(0, myY - 2);
+
             foreach (var i in MySubBlocks)
             {
                 int y = (int)i["yy"] + myY;
@@ -249,7 +253,7 @@ namespace BlingoEngine.Demo.TetriGrounds.Core.ParentScripts
             CreateBlock();
             myY = 2;
             myX = myMaxX / 2;
-            myScoreManager.BlockFrozen();// add score when you freeze a block
+            myScoreManager.BlockFrozen(dropDuration, rowsTravelled);// add score when you freeze a block
             myScoreManager.AddDropedBlock(hardDrop); // add that there's a block dropped
 
             // check if we go a level up
@@ -417,6 +421,7 @@ namespace BlingoEngine.Demo.TetriGrounds.Core.ParentScripts
             }
             RefreshBlock();
             UpdateNextBlock();
+            _currentBlockStartedAt = DateTime.UtcNow;
         }
 
         /// <summary>

--- a/Demo/TetriGrounds/BlingoEngine.Demo.TetriGrounds.Core/ParentScripts/ScoreManagerScript.cs
+++ b/Demo/TetriGrounds/BlingoEngine.Demo.TetriGrounds.Core/ParentScripts/ScoreManagerScript.cs
@@ -32,6 +32,10 @@ namespace BlingoEngine.Demo.TetriGrounds.Core.ParentScripts
         private DateTime _started = DateTime.MinValue;
         private TimeSpan _elapsed;
         private readonly TimeSpan myComboDuration = TimeSpan.FromSeconds(2);
+        private const int BlockFreezeBaseScore = 4;
+        private const double MinimumDropSeconds = 0.1;
+        private const double MaximumSpeedForBonus = 10.0;
+        private const int DropSpeedLevelMultiplier = 2;
 
         public bool IsNewHighScore { get; private set; }
 
@@ -141,11 +145,18 @@ namespace BlingoEngine.Demo.TetriGrounds.Core.ParentScripts
             myNumberLinesTot += 1;
         }
         /// <summary>
-        /// Called when the current block locks in place, awarding a small amount of points.
+        /// Called when the current block locks in place, awarding score based on how quickly it fell.
         /// </summary>
-        public void BlockFrozen()
+        public void BlockFrozen(TimeSpan fallDuration, int rowsTravelled)
         {
-            myPlayerScore += 4;
+            var clampedRows = Math.Max(rowsTravelled, 0);
+            var seconds = Math.Max(fallDuration.TotalSeconds, MinimumDropSeconds);
+            var speed = clampedRows / seconds;
+            var clampedSpeed = Math.Min(Math.Max(speed, 0), MaximumSpeedForBonus);
+            var levelMultiplier = Math.Max(myLevel, 1);
+            var speedBonus = (int)Math.Round(clampedSpeed * levelMultiplier * DropSpeedLevelMultiplier);
+
+            myPlayerScore += BlockFreezeBaseScore + speedBonus;
             Refresh();
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- track when each tetromino starts falling and record rows travelled before it locks
- award block-freeze score based on fall speed and level instead of a flat bonus
- reset the drop timer whenever a new block is spawned for accurate scoring

## Testing
- dotnet build Demo/TetriGrounds/BlingoEngine.Demo.TetriGrounds.Core/BlingoEngine.Demo.TetriGrounds.Core.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d3e3068da88332aebe5c66f5e34ce2