### PR TITLE
Add idle frame handling and document frame lifecycle

### DIFF
--- a/Test/BlingoEngine.Tests/Casts/DummyTextMember.cs
+++ b/Test/BlingoEngine.Tests/Casts/DummyTextMember.cs
@@ -32,7 +32,7 @@ internal class DummyTextMember : IBlingoMemberTextBase, IBlingoMemberTextBaseInt
     public int Height { get; set; }
     public long Size { get; set; }
     public string Comments { get; set; } = string.Empty;
-    public string FileName { get; set; }
+    public string FileName { get; set; } = string.Empty;
     public BlingoMemberType Type { get; set; } = BlingoMemberType.Text;
     public string CastName => string.Empty;
     public IBlingoCast Cast => _cast;
@@ -95,7 +95,7 @@ internal class DummyTextMember : IBlingoMemberTextBase, IBlingoMemberTextBaseInt
     public IAbstTexture2D? GetTexture() => null;
     public void ChangesHasBeenApplied() { }
     public void LoadFile() { LoadFileCalled = true; }
-    public void SetFileName(string name) => _fileName = name;
+    public void SetFileName(string name) => FileName = name;
 
     public string GetTextMDString()
     {

--- a/Test/BlingoEngine.Tests/Fakes/FakeBlingoMovieBuilder.cs
+++ b/Test/BlingoEngine.Tests/Fakes/FakeBlingoMovieBuilder.cs
@@ -1,0 +1,552 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+using AbstUI.Components;
+using AbstUI.Components.Buttons;
+using AbstUI.Components.Containers;
+using AbstUI.Components.Graphics;
+using AbstUI.Components.Inputs;
+using AbstUI.Components.Menus;
+using AbstUI.Components.Texts;
+using AbstUI.Inputs;
+using AbstUI.Primitives;
+using AbstUI.Windowing;
+using BlingoEngine.Bitmaps;
+using BlingoEngine.Casts;
+using BlingoEngine.Core;
+using BlingoEngine.Events;
+using BlingoEngine.FilmLoops;
+using BlingoEngine.FrameworkCommunication;
+using BlingoEngine.Inputs;
+using BlingoEngine.Members;
+using BlingoEngine.Movies;
+using BlingoEngine.Shapes;
+using BlingoEngine.Sounds;
+using BlingoEngine.Sprites;
+using BlingoEngine.Stages;
+using BlingoEngine.Texts;
+using BlingoEngine.Transitions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BlingoEngine.Tests.Fakes;
+
+internal sealed class FakeBlingoMovieBuilder
+{
+    private FakeBlingoMovieBuilder(BlingoMovie movie, RecordingTransitionPlayer transitionPlayer)
+    {
+        Movie = movie;
+        TransitionPlayer = transitionPlayer;
+    }
+
+    internal BlingoMovie Movie { get; }
+
+    internal RecordingTransitionPlayer TransitionPlayer { get; }
+
+    internal static FakeBlingoMovieBuilder Create(
+        BlingoEventMediator mediator,
+        List<string> timeline,
+        Action<Options>? configure = null)
+    {
+        var options = new Options();
+        configure?.Invoke(options);
+
+        var movie = (BlingoMovie)FormatterServices.GetUninitializedObject(typeof(BlingoMovie));
+
+        PrivateFieldSetter.SetField(movie, "_eventMediator", mediator);
+        PrivateFieldSetter.SetField(movie, "_actorList", new ActorList());
+        PrivateFieldSetter.SetField(movie, "_spriteManagers", new List<BlingoSpriteManager>());
+        PrivateFieldSetter.SetField(movie, "_onRemoveMe", (Action<BlingoMovie>)(_ => { }));
+        PrivateFieldSetter.SetField(movie, "_idleHandlerPeriod", 1);
+        PrivateFieldSetter.SetField(movie, "_idleIntervalSeconds", 1f / 60f);
+
+        var frameworkStage = new StubFrameworkStage();
+        var stage = new BlingoStage(frameworkStage);
+        frameworkStage.AttachStage(stage);
+        PrivateFieldSetter.SetField(movie, "_stage", stage);
+
+        var frameworkMovie = new StubFrameworkMovie();
+        PrivateFieldSetter.SetField(movie, "_frameworkMovie", frameworkMovie);
+
+        var frameworkMouse = new StubFrameworkMouse();
+        var stageMouse = new BlingoStageMouse(stage, frameworkMouse);
+        PrivateFieldSetter.SetField(movie, "_blingoMouse", stageMouse);
+
+        var factory = new StubFrameworkFactory();
+        var environment = CreateEnvironment(movie, mediator, stageMouse, factory);
+        var spritesPlayer = new StubSpritesPlayer();
+
+        var spriteManager = CreateSprite2DManager(movie, mediator, stageMouse, environment, spritesPlayer, timeline);
+        PrivateFieldSetter.SetField(movie, "_sprite2DManager", spriteManager);
+
+        var transitionManagerObject = CreateTransitionManager(movie, mediator, timeline, options);
+        var transitionManager = (BlingoSpriteManager)transitionManagerObject;
+
+        var managers = new List<BlingoSpriteManager> { transitionManager };
+        PrivateFieldSetter.SetField(movie, "_spriteManagers", managers);
+        PrivateFieldSetter.SetField(movie, "_transitionManager", transitionManagerObject);
+
+        var transitionPlayer = new RecordingTransitionPlayer(timeline);
+        PrivateFieldSetter.SetField(movie, "_transitionPlayer", transitionPlayer);
+
+        PrivateFieldSetter.SetField(movie, "_lastFrame", 0);
+        PrivateFieldSetter.SetField(movie, "_currentFrame", 0);
+        PrivateFieldSetter.SetField(movie, "_nextFrame", -1);
+
+        return new FakeBlingoMovieBuilder(movie, transitionPlayer);
+    }
+
+    internal sealed class Options
+    {
+        internal bool RecordTransitionLifecycle { get; set; }
+        internal int? TransitionActivationFrame { get; set; }
+    }
+
+    internal sealed class RecordingTransitionPlayer : IBlingoTransitionPlayer
+    {
+        internal RecordingTransitionPlayer(List<string> timeline) => Timeline = timeline;
+
+        private List<string> Timeline { get; }
+
+        internal int StartCallCount { get; private set; }
+
+        internal bool StartResult { get; set; } = true;
+
+        public bool Start(BlingoTransitionSprite sprite)
+        {
+            StartCallCount++;
+            return StartResult;
+        }
+
+        public void Tick()
+        {
+        }
+
+        public bool IsActive => false;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private static IBlingoMovieEnvironment CreateEnvironment(
+        BlingoMovie movie,
+        BlingoEventMediator mediator,
+        BlingoStageMouse mouse,
+        IBlingoFrameworkFactory factory)
+    {
+        var environmentType = typeof(BlingoMovie).Assembly.GetType("BlingoEngine.Movies.BlingoMovieEnvironment", throwOnError: true)!;
+        var environment = (IBlingoMovieEnvironment)FormatterServices.GetUninitializedObject(environmentType);
+
+        PrivateFieldSetter.SetField(environment, "_eventMediator", mediator);
+        PrivateFieldSetter.SetField(environment, "_movie", movie);
+        PrivateFieldSetter.SetField(environment, "_factory", factory);
+        PrivateFieldSetter.SetField(environment, "_mouse", mouse);
+        PrivateFieldSetter.SetField(environment, "_clock", new BlingoClock());
+        PrivateFieldSetter.SetField(environment, "_logger", NullLogger<BlingoMovieEnvironment>.Instance);
+        PrivateFieldSetter.SetField(environment, "_globals", new BlingoGlobalVars());
+        PrivateFieldSetter.SetField(environment, "_castLibsContainer", new BlingoCastLibsContainer(factory));
+
+        return environment;
+    }
+
+    private static BlingoSprite2DManager CreateSprite2DManager(
+        BlingoMovie movie,
+        BlingoEventMediator mediator,
+        BlingoStageMouse mouse,
+        IBlingoMovieEnvironment environment,
+        IBlingoSpritesPlayer spritesPlayer,
+        List<string> timeline)
+    {
+        var manager = (BlingoSprite2DManager)FormatterServices.GetUninitializedObject(typeof(BlingoSprite2DManager));
+
+        PrivateFieldSetter.SetField(manager, "_movie", movie);
+        PrivateFieldSetter.SetField(manager, "_environment", environment);
+        PrivateFieldSetter.SetField(manager, "_mutedSprites", new List<int>());
+        PrivateFieldSetter.SetField(manager, "_spriteChannels", new Dictionary<int, BlingoSpriteChannel>());
+        var spritesByName = new Dictionary<string, BlingoSprite2D>();
+        PrivateFieldSetter.SetField(manager, "_spritesByName", spritesByName);
+        var allTimeSprites = new List<BlingoSprite2D>();
+        PrivateFieldSetter.SetField(manager, "_allTimeSprites", allTimeSprites);
+        PrivateFieldSetter.SetField(manager, "_newPuppetSprites", new List<BlingoSprite2D>());
+        PrivateFieldSetter.SetField(manager, "_activeSprites", new Dictionary<int, BlingoSprite2D>());
+        PrivateFieldSetter.SetField(manager, "_activeSpritesOrdered", new List<BlingoSprite2D>());
+        PrivateFieldSetter.SetField(manager, "_enteredSprites", new List<BlingoSprite2D>());
+        PrivateFieldSetter.SetField(manager, "_exitedSprites", new List<BlingoSprite2D>());
+        PrivateFieldSetter.SetField(manager, "_changedMembers", new List<BlingoMember>());
+        PrivateFieldSetter.SetField(manager, "_deletedPuppetSpritesCache", new Dictionary<int, BlingoSprite2D>());
+        PrivateFieldSetter.SetField(manager, "<SpriteNumChannelOffset>k__BackingField", BlingoSprite2D.SpriteNumOffset);
+        PrivateFieldSetter.SetField(manager, "_blingoMouse", mouse);
+
+        var channel = new BlingoSpriteChannel(1, movie);
+        var channels = new Dictionary<int, BlingoSpriteChannel> { [1] = channel };
+        PrivateFieldSetter.SetField(manager, "_spriteChannels", channels);
+
+        var frameworkSprite = new StubFrameworkSprite
+        {
+            Name = "Sprite_1"
+        };
+
+        var sprite = new RecordingSprite2D(environment, spritesPlayer, timeline);
+        sprite.Init(frameworkSprite);
+        PrivateFieldSetter.SetField(sprite, "<SpriteNum>k__BackingField", 1);
+        sprite.BeginFrame = 1;
+        sprite.EndFrame = 1;
+        spritesByName[frameworkSprite.Name] = sprite;
+        allTimeSprites.Add(sprite);
+
+        return manager;
+    }
+
+    private static object CreateTransitionManager(
+        BlingoMovie movie,
+        BlingoEventMediator mediator,
+        List<string> timeline,
+        Options options)
+    {
+        var managerType = typeof(BlingoMovie).Assembly.GetType("BlingoEngine.Transitions.BlingoSpriteTransitionManager", throwOnError: true)!;
+        var manager = FormatterServices.GetUninitializedObject(managerType);
+
+        PrivateFieldSetter.SetField(manager, "_movie", movie);
+        PrivateFieldSetter.SetField(manager, "_environment", null);
+        PrivateFieldSetter.SetField(manager, "_mutedSprites", new List<int>());
+        PrivateFieldSetter.SetField(manager, "_spriteChannels", new Dictionary<int, BlingoSpriteChannel>());
+        var allTimeSprites = new List<BlingoTransitionSprite>();
+        PrivateFieldSetter.SetField(manager, "_allTimeSprites", allTimeSprites);
+        PrivateFieldSetter.SetField(manager, "_newPuppetSprites", new List<BlingoTransitionSprite>());
+        PrivateFieldSetter.SetField(manager, "_activeSprites", new Dictionary<int, BlingoTransitionSprite>());
+        PrivateFieldSetter.SetField(manager, "_activeSpritesOrdered", new List<BlingoTransitionSprite>());
+        PrivateFieldSetter.SetField(manager, "_enteredSprites", new List<BlingoTransitionSprite>());
+        PrivateFieldSetter.SetField(manager, "_exitedSprites", new List<BlingoTransitionSprite>());
+        PrivateFieldSetter.SetField(manager, "_deletedPuppetSpritesCache", new Dictionary<int, BlingoTransitionSprite>());
+        PrivateFieldSetter.SetField(manager, "<SpriteNumChannelOffset>k__BackingField", BlingoTransitionSprite.SpriteNumOffset);
+
+        if (options.RecordTransitionLifecycle && options.TransitionActivationFrame.HasValue)
+        {
+            var cast = new StubCast();
+            var sprite = new RecordingTransitionSprite(mediator, cast, _ => { }, timeline);
+            PrivateFieldSetter.SetField(sprite, "<SpriteNum>k__BackingField", 1);
+            sprite.BeginFrame = options.TransitionActivationFrame.Value;
+            sprite.EndFrame = options.TransitionActivationFrame.Value;
+            allTimeSprites.Add(sprite);
+        }
+
+        return manager;
+    }
+
+    private sealed class RecordingSprite2D : BlingoSprite2D
+    {
+        private readonly List<string> _timeline;
+
+        internal RecordingSprite2D(IBlingoMovieEnvironment environment, IBlingoSpritesPlayer spritesPlayer, List<string> timeline)
+            : base(environment, spritesPlayer)
+        {
+            _timeline = timeline;
+        }
+
+        protected override void BeginSprite()
+        {
+            _timeline.Add("beginSprite");
+        }
+
+        protected override void EndSprite()
+        {
+            _timeline.Add("endSprite");
+        }
+    }
+
+    private sealed class RecordingTransitionSprite : BlingoTransitionSprite
+    {
+        private readonly List<string> _timeline;
+
+        internal RecordingTransitionSprite(IBlingoEventMediator mediator, IBlingoCast cast, Action<BlingoTransitionSprite> removeMe, List<string> timeline)
+            : base(mediator, cast, removeMe)
+        {
+            _timeline = timeline;
+        }
+
+        protected override void BeginSprite()
+        {
+            _timeline.Add("transition.beginSprite");
+        }
+
+        protected override void EndSprite()
+        {
+            _timeline.Add("transition.endSprite");
+        }
+    }
+
+    private sealed class StubSpritesPlayer : IBlingoSpritesPlayer
+    {
+        public int CurrentFrame => 1;
+        public int GetMaxLocZ() => 0;
+    }
+
+    private sealed class StubFrameworkFactory : IBlingoFrameworkFactory
+    {
+        public IAbstComponentFactory ComponentFactory => throw new NotImplementedException();
+        public BlingoStage CreateStage(BlingoPlayer blingoPlayer) => throw new NotImplementedException();
+        public BlingoMovie AddMovie(BlingoStage stage, BlingoMovie blingoMovie) => throw new NotImplementedException();
+        public T CreateMember<T>(IBlingoCast cast, int numberInCast, string name = "") where T : BlingoMember => throw new NotImplementedException();
+        public BlingoMemberBitmap CreateMemberBitmap(IBlingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
+        public BlingoMemberSound CreateMemberSound(IBlingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
+        public BlingoFilmLoopMember CreateMemberFilmLoop(IBlingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
+        public BlingoMemberShape CreateMemberShape(IBlingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
+        public BlingoMemberField CreateMemberField(IBlingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
+        public BlingoMemberText CreateMemberText(IBlingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
+        public BlingoMember CreateScript(IBlingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
+        public BlingoMember CreateEmpty(IBlingoCast cast, int numberInCast, string name = "", string? fileName = null, APoint regPoint = default) => throw new NotImplementedException();
+        public BlingoSound CreateSound(IBlingoCastLibsContainer castLibsContainer) => throw new NotImplementedException();
+        public BlingoSoundChannel CreateSoundChannel(int number) => throw new NotImplementedException();
+        public BlingoStageMouse CreateMouse(BlingoStage stage) => throw new NotImplementedException();
+        public BlingoKey CreateKey() => throw new NotImplementedException();
+        public AbstGfxCanvas CreateGfxCanvas(string name, int width, int height) => throw new NotImplementedException();
+        public AbstWrapPanel CreateWrapPanel(AOrientation orientation, string name) => throw new NotImplementedException();
+        public AbstPanel CreatePanel(string name) => throw new NotImplementedException();
+        public AbstLayoutWrapper CreateLayoutWrapper(IAbstNode content, float? x, float? y) => throw new NotImplementedException();
+        public AbstTabContainer CreateTabContainer(string name) => throw new NotImplementedException();
+        public AbstTabItem CreateTabItem(string name, string title) => throw new NotImplementedException();
+        public AbstScrollContainer CreateScrollContainer(string name) => throw new NotImplementedException();
+        public AbstInputSlider<float> CreateInputSliderFloat(AOrientation orientation, string name, float? min = null, float? max = null, float? step = null, Action<float>? onChange = null) => throw new NotImplementedException();
+        public AbstInputSlider<int> CreateInputSliderInt(AOrientation orientation, string name, int? min = null, int? max = null, int? step = null, Action<int>? onChange = null) => throw new NotImplementedException();
+        public AbstInputText CreateInputText(string name, int maxLength = 0, Action<string>? onChange = null, bool multiLine = false) => throw new NotImplementedException();
+        public AbstInputNumber<float> CreateInputNumberFloat(string name, float? min = null, float? max = null, Action<float>? onChange = null) => throw new NotImplementedException();
+        public AbstInputNumber<int> CreateInputNumberInt(string name, int? min = null, int? max = null, Action<int>? onChange = null) => throw new NotImplementedException();
+        public AbstInputSpinBox CreateSpinBox(string name, float? min = null, float? max = null, Action<float>? onChange = null) => throw new NotImplementedException();
+        public AbstInputCheckbox CreateInputCheckbox(string name, Action<bool>? onChange = null) => throw new NotImplementedException();
+        public AbstInputCombobox CreateInputCombobox(string name, Action<string?>? onChange = null) => throw new NotImplementedException();
+        public AbstItemList CreateItemList(string name, Action<string?>? onChange = null) => throw new NotImplementedException();
+        public AbstColorPicker CreateColorPicker(string name, Action<AColor>? onChange = null) => throw new NotImplementedException();
+        public AbstLabel CreateLabel(string name, string text = "") => throw new NotImplementedException();
+        public AbstButton CreateButton(string name, string text = "") => throw new NotImplementedException();
+        public AbstStateButton CreateStateButton(string name, IAbstTexture2D? texture = null, string text = "", Action<bool>? onChange = null) => throw new NotImplementedException();
+        public AbstMenu CreateMenu(string name) => throw new NotImplementedException();
+        public AbstMenuItem CreateMenuItem(string name, string? shortcut = null) => throw new NotImplementedException();
+        public AbstMenu CreateContextMenu(object window) => throw new NotImplementedException();
+        public AbstHorizontalLineSeparator CreateHorizontalLineSeparator(string name) => throw new NotImplementedException();
+        public AbstVerticalLineSeparator CreateVerticalLineSeparator(string name) => throw new NotImplementedException();
+        public BlingoSprite2D CreateSprite2D(IBlingoMovie movie, Action<BlingoSprite2D> onRemoveMe) => throw new NotImplementedException();
+    }
+
+    private sealed class StubCast : IBlingoCast
+    {
+        public string Name { get; set; } = "Cast";
+        public string FileName { get; set; } = string.Empty;
+        public int Number => 1;
+        public PreLoadModeType PreLoadMode { get; set; }
+        public bool IsInternal => true;
+        public CastMemberSelection? Selection { get; set; }
+        public event Action<IBlingoMember>? MemberAdded
+        {
+            add { }
+            remove { }
+        }
+        public event Action<IBlingoMember>? MemberDeleted
+        {
+            add { }
+            remove { }
+        }
+        public event Action<IBlingoMember>? MemberNameChanged
+        {
+            add { }
+            remove { }
+        }
+        public T? GetMember<T>(int number) where T : IBlingoMember => default;
+        public T? GetMember<T>(string name) where T : IBlingoMember => default;
+        public IBlingoMembersContainer Member => throw new NotImplementedException();
+        public int FindEmpty() => 0;
+        public IBlingoMember Add(BlingoMemberType type, int numberInCast, string name, string fileName = "", APoint regPoint = default) => throw new NotImplementedException();
+        public T Add<T>(int numberInCast, string name, Action<T>? configure = null) where T : IBlingoMember => throw new NotImplementedException();
+        public IEnumerable<IBlingoMember> GetAll() => Array.Empty<IBlingoMember>();
+        public void SwapMembers(int slot1, int slot2)
+        {
+        }
+        public void Save()
+        {
+        }
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class StubFrameworkMovie : IBlingoFrameworkMovie
+    {
+        public string Name { get; set; } = "Movie";
+        public bool Visibility { get; set; } = true;
+        public float Width { get; set; }
+        public float Height { get; set; }
+        public AMargin Margin { get; set; }
+        public int ZIndex { get; set; }
+        public object FrameworkNode => this;
+        public void UpdateStage()
+        {
+        }
+        public void RemoveMe()
+        {
+        }
+        public APoint GetGlobalMousePosition() => default;
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class StubFrameworkStage : IBlingoFrameworkStage
+    {
+        private BlingoStage? _stage;
+        private readonly StubTexture2D _texture = new();
+
+        public string Name { get; set; } = "Stage";
+        public bool Visibility { get; set; } = true;
+        public float Width { get; set; } = 640f;
+        public float Height { get; set; } = 480f;
+        public AMargin Margin { get; set; }
+        public int ZIndex { get; set; }
+        public object FrameworkNode => this;
+        public BlingoStage BlingoStage => _stage ?? throw new InvalidOperationException();
+        public float Scale { get; set; } = 1f;
+        public void AttachStage(BlingoStage stage) => _stage = stage;
+        public void SetActiveMovie(BlingoMovie? blingoMovie)
+        {
+        }
+        public void ApplyPropertyChanges()
+        {
+        }
+        public void RequestNextFrameScreenshot(Action<IAbstTexture2D> onCaptured)
+            => onCaptured(_texture);
+        public IAbstTexture2D GetScreenshot() => _texture;
+        public void ShowTransition(IAbstTexture2D startTexture)
+        {
+        }
+        public void UpdateTransitionFrame(IAbstTexture2D texture, ARect targetRect)
+        {
+        }
+        public void HideTransition()
+        {
+        }
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class StubFrameworkMouse : IBlingoFrameworkMouse
+    {
+        private AMouseCursor _cursor = AMouseCursor.Arrow;
+        public void HideMouse(bool state)
+        {
+        }
+        public void Release()
+        {
+        }
+        public void ReplaceMouseObj(IAbstMouse blingoMouse)
+        {
+        }
+        public void SetCursor(AMouseCursor cursor) => _cursor = cursor;
+        public AMouseCursor GetCursor() => _cursor;
+        public void SetCursor(BlingoMemberBitmap? image)
+        {
+        }
+        public void SetOffset(int x, int y)
+        {
+        }
+    }
+
+    private sealed class StubFrameworkSprite : IBlingoFrameworkSprite
+    {
+        public string Name { get; set; } = string.Empty;
+        public bool Visibility { get; set; } = true;
+        public float Width { get; set; }
+        public float Height { get; set; }
+        public AMargin Margin { get; set; }
+        public int ZIndex { get; set; }
+        public object FrameworkNode => this;
+        public float Blend { get; set; }
+        public float X { get; set; }
+        public float Y { get; set; }
+        public APoint RegPoint { get; set; }
+        public float DesiredHeight { get; set; }
+        public float DesiredWidth { get; set; }
+        public float Rotation { get; set; }
+        public float Skew { get; set; }
+        public bool FlipH { get; set; }
+        public bool FlipV { get; set; }
+        public bool DirectToStage { get; set; }
+        public int Ink { get; set; }
+        public void MemberChanged()
+        {
+        }
+        public void RemoveMe()
+        {
+        }
+        public void Show()
+        {
+        }
+        public void Hide()
+        {
+        }
+        public void SetPosition(APoint point)
+        {
+            X = point.X;
+            Y = point.Y;
+        }
+        public void ApplyMemberChangesOnStepFrame()
+        {
+        }
+        public void SetTexture(IAbstTexture2D texture)
+        {
+        }
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class StubTexture2D : IAbstTexture2D
+    {
+        public int Width => 0;
+        public int Height => 0;
+        public bool IsDisposed => false;
+        public string Name { get; set; } = "Texture";
+        public IAbstUITextureUserSubscription AddUser(object user) => new StubTextureSubscription(this);
+        public byte[] GetPixels() => Array.Empty<byte>();
+        public void SetARGBPixels(byte[] argbPixels)
+        {
+        }
+        public void SetRGBAPixels(byte[] rgbaPixels)
+        {
+        }
+        public IAbstTexture2D Clone() => this;
+        public void Dispose()
+        {
+        }
+
+        private sealed class StubTextureSubscription : IAbstUITextureUserSubscription
+        {
+            internal StubTextureSubscription(IAbstTexture2D texture) => Texture = texture;
+            public IAbstTexture2D Texture { get; }
+            public void Release()
+            {
+            }
+        }
+    }
+}
+
+internal static class PrivateFieldSetter
+{
+    internal static void SetField(object target, string fieldName, object? value)
+    {
+        var type = target.GetType();
+        while (type != null)
+        {
+            var field = type.GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            if (field != null)
+            {
+                field.SetValue(target, value);
+                return;
+            }
+
+            type = type.BaseType;
+        }
+
+        throw new InvalidOperationException($"Field '{fieldName}' not found on type '{target.GetType()}'.");
+    }
+}

--- a/Test/BlingoEngine.Tests/MovieEventOrderTests.cs
+++ b/Test/BlingoEngine.Tests/MovieEventOrderTests.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Linq;
+using BlingoEngine.Events;
+using BlingoEngine.Movies;
+using BlingoEngine.Movies.Events;
+using BlingoEngine.Tests.Fakes;
+
+namespace BlingoEngine.Tests;
+
+public class MovieEventOrderTests
+{
+    [Fact]
+    public void AdvanceFrame_RaisesFrameLifecycleEventsInManualOrder()
+    {
+        var timeline = new List<string>();
+        var mediator = new BlingoEventMediator();
+        var frameHandler = new RecordingFrameHandler(timeline);
+        mediator.Subscribe(frameHandler);
+        mediator.SubscribeStepFrame(frameHandler);
+
+        var harness = FakeBlingoMovieBuilder.Create(mediator, timeline);
+        PrivateFieldSetter.SetField(harness.Movie, "_isPlaying", true);
+
+        harness.Movie.AdvanceFrame();
+        harness.Movie.OnIdle(1f / 60f);
+        harness.Movie.AdvanceFrame();
+
+        var expected = new[]
+        {
+            "beginSprite",
+            "stepFrame",
+            "prepareFrame",
+            "enterFrame",
+            "idleFrame",
+            "exitFrame",
+            "endSprite"
+        };
+
+        Assert.True(timeline.Count >= expected.Length, "timeline missing expected callbacks");
+        Assert.Equal(expected, timeline.Take(expected.Length));
+    }
+}
+
+public class TransitionEventOrderTests
+{
+    [Fact]
+    public void AdvanceFrame_RaisesTransitionLifecycleAroundFrameHandlers()
+    {
+        var timeline = new List<string>();
+        var mediator = new BlingoEventMediator();
+        var frameHandler = new RecordingFrameHandler(timeline);
+        mediator.Subscribe(frameHandler);
+        mediator.SubscribeStepFrame(frameHandler);
+
+        var harness = FakeBlingoMovieBuilder.Create(mediator, timeline, options =>
+        {
+            options.RecordTransitionLifecycle = true;
+            options.TransitionActivationFrame = 1;
+        });
+
+        harness.TransitionPlayer.StartResult = false;
+        PrivateFieldSetter.SetField(harness.Movie, "_isPlaying", true);
+
+        harness.Movie.AdvanceFrame();
+        harness.Movie.OnIdle(1f / 60f);
+        harness.Movie.AdvanceFrame();
+
+        var expected = new[]
+        {
+            "beginSprite",
+            "transition.beginSprite",
+            "stepFrame",
+            "prepareFrame",
+            "enterFrame",
+            "idleFrame",
+            "exitFrame",
+            "endSprite",
+            "transition.endSprite"
+        };
+
+        Assert.True(timeline.Count >= expected.Length, "timeline missing expected callbacks");
+        Assert.Equal(expected, timeline.Take(expected.Length));
+        Assert.Equal(1, harness.TransitionPlayer.StartCallCount);
+    }
+}
+
+internal sealed class RecordingFrameHandler : IHasStepFrameEvent, IHasPrepareFrameEvent,
+    IHasEnterFrameEvent, IHasIdleFrameEvent, IHasExitFrameEvent
+{
+    private readonly List<string> _timeline;
+
+    internal RecordingFrameHandler(List<string> timeline) => _timeline = timeline;
+
+    public void StepFrame() => _timeline.Add("stepFrame");
+
+    public void PrepareFrame() => _timeline.Add("prepareFrame");
+
+    public void EnterFrame() => _timeline.Add("enterFrame");
+
+    public void IdleFrame() => _timeline.Add("idleFrame");
+
+    public void ExitFrame() => _timeline.Add("exitFrame");
+}

--- a/src/BlingoEngine/Core/BlingoClock.cs
+++ b/src/BlingoEngine/Core/BlingoClock.cs
@@ -6,6 +6,7 @@
     public interface IBlingoClockListener
     {
         void OnTick();
+        void OnIdle(float deltaTime);
     }
     /// <summary>
     /// Lingo Clock interface.
@@ -38,12 +39,28 @@
             _accumulatedTime += deltaTime;
             float frameTime = 1f / FrameRate;
 
+            int framesDispatched = 0;
             while (_accumulatedTime >= frameTime)
             {
                 foreach (var l in _listeners) l.OnTick();
                 EngineTickCount++;
-
+                framesDispatched++;
                 _accumulatedTime -= frameTime;
+            }
+
+            if (framesDispatched == 0)
+            {
+                if (deltaTime > 0f)
+                {
+                    foreach (var listener in _listeners)
+                        listener.OnIdle(deltaTime);
+                }
+            }
+            else if (_accumulatedTime > 0f)
+            {
+                var idleDelta = _accumulatedTime;
+                foreach (var listener in _listeners)
+                    listener.OnIdle(idleDelta);
             }
         }
 

--- a/src/BlingoEngine/Events/BlingoEventMediator.cs
+++ b/src/BlingoEngine/Events/BlingoEventMediator.cs
@@ -28,6 +28,7 @@ namespace BlingoEngine.Events
         private readonly List<IHasStepFrameEvent> _stepFrames = new(); // must be handled by actorlist
         private readonly List<IHasPrepareFrameEvent> _prepareFrames = new();
         private readonly List<IHasEnterFrameEvent> _enterFrames = new();
+        private readonly List<IHasIdleFrameEvent> _idleFrames = new();
         private readonly List<IHasExitFrameEvent> _exitFrames = new();
         private readonly List<IHasFocusEvent> _focuss = new();
         private readonly List<IHasBlurEvent> _blurs = new();
@@ -83,6 +84,7 @@ namespace BlingoEngine.Events
 
             if (ms is IHasPrepareFrameEvent prepareFrameEvent) Insert(_prepareFrames, prepareFrameEvent);
             if (ms is IHasEnterFrameEvent enterFrameEvent) Insert(_enterFrames, enterFrameEvent);
+            if (ms is IHasIdleFrameEvent idleFrameEvent) Insert(_idleFrames, idleFrameEvent);
             if (ms is IHasExitFrameEvent exitFrameEvent) Insert(_exitFrames, exitFrameEvent);
             if (ms is IHasFocusEvent focusEvent) Insert(_focuss, focusEvent);
             if (ms is IHasBlurEvent blurEvent) Insert(_blurs, blurEvent);
@@ -113,6 +115,7 @@ namespace BlingoEngine.Events
             // Not stepframe it seems stepframe is only used through the actor list.
             if (ms is IHasPrepareFrameEvent prepareFrameEvent) _prepareFrames.Remove(prepareFrameEvent);
             if (ms is IHasEnterFrameEvent enterFrameEvent) _enterFrames.Remove(enterFrameEvent);
+            if (ms is IHasIdleFrameEvent idleFrameEvent) _idleFrames.Remove(idleFrameEvent);
             if (ms is IHasExitFrameEvent exitFrameEvent) _exitFrames.Remove(exitFrameEvent);
             if (ms is IHasFocusEvent focusEvent) _focuss.Remove(focusEvent);
             if (ms is IHasBlurEvent blurEvent) _blurs.Remove(blurEvent);
@@ -148,6 +151,7 @@ namespace BlingoEngine.Events
             FilterList(_mouseExits);
             FilterList(_prepareFrames);
             FilterList(_enterFrames);
+            FilterList(_idleFrames);
             FilterList(_exitFrames);
             FilterList(_focuss);
             FilterList(_blurs);
@@ -172,6 +176,7 @@ namespace BlingoEngine.Events
         internal void RaiseStepFrame() => _stepFrames.ForEach(x => x.StepFrame());
         internal void RaisePrepareFrame() => _prepareFrames.ForEach(x => x.PrepareFrame());
         internal void RaiseEnterFrame() => _enterFrames.ForEach(x => x.EnterFrame());
+        internal void RaiseIdleFrame() => _idleFrames.ForEach(x => x.IdleFrame());
         internal void RaiseExitFrame() => _exitFrames.ForEach(x => x.ExitFrame());
         public void RaiseFocus() => _focuss.ForEach(x => x.Focus());
         public void RaiseBlur() => _blurs.ForEach(x => x.Blur());

--- a/src/BlingoEngine/Movies/BlingoDebugOverlay.cs
+++ b/src/BlingoEngine/Movies/BlingoDebugOverlay.cs
@@ -75,6 +75,11 @@ public class BlingoDebugOverlay : IBlingoClockListener
         _engineFrames++;
     }
 
+    public void OnIdle(float deltaTime)
+    {
+        // Idle callbacks do not affect the debug overlay.
+    }
+
     public void Prepare()
     {
         throw new NotImplementedException();

--- a/src/BlingoEngine/Movies/BlingoMovie.cs
+++ b/src/BlingoEngine/Movies/BlingoMovie.cs
@@ -1,5 +1,5 @@
-﻿using System.Linq;
 using AbstUI.Primitives;
+using AbstUI.Components;
 using BlingoEngine.Casts;
 using BlingoEngine.Core;
 using BlingoEngine.Events;
@@ -17,8 +17,6 @@ using Microsoft.Extensions.DependencyInjection;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Collections.Generic;
-using System.Linq;
-using AbstUI.Components;
 
 namespace BlingoEngine.Movies
 {
@@ -58,6 +56,20 @@ namespace BlingoEngine.Movies
         private readonly ActorList _actorList = new ActorList();
         private readonly BlingoMovieScriptContainer _movieScripts;
         private readonly List<BlingoSpriteManager> _spriteManagers = new();
+
+        // Director bases idle timing on a 60 Hz clock where idleHandlerPeriod skips ticks before
+        // issuing an on idle. Period 0 removes that throttle so handlers can run as fast as
+        // possible during the delay between enterFrame and exitFrame (see the Director MX 2004
+        // Scripting manual entry for idleHandlerPeriod).
+        private const float IdleBaseIntervalSeconds = 1f / 60f;
+        private const float UnthrottledIdleQuantumSeconds = 1f / 1000f;
+        private const int MaxIdleDispatchPerTick = 10_000;
+
+        private bool _frameIsActive;
+        private bool _hasPendingEndSprites;
+        private float _idleAccumulator;
+        private int _idleHandlerPeriod = 1;
+        private float _idleIntervalSeconds = IdleBaseIntervalSeconds;
 
 
         #region Properties
@@ -186,6 +198,26 @@ namespace BlingoEngine.Movies
         {
             get => _tempoManager.Tempo;
             set => _tempoManager.ChangeTempo(value);
+        }
+
+        /// <summary>
+        /// Mirrors Director's <c>_movie.idleHandlerPeriod</c>: 0 runs on idle as often as possible,
+        /// positive values cap the frequency to 60/n events per second using the 60 Hz idle
+        /// timer described in the Director scripting manual.
+        /// </summary>
+        public int IdleHandlerPeriod
+        {
+            get => _idleHandlerPeriod;
+            set
+            {
+                var normalized = value < 0 ? 0 : value;
+                if (SetProperty(ref _idleHandlerPeriod, normalized, nameof(IdleHandlerPeriod)))
+                {
+                    _idleIntervalSeconds = normalized == 0
+                        ? UnthrottledIdleQuantumSeconds
+                        : normalized * IdleBaseIntervalSeconds;
+                }
+            }
         }
         public int MaxSpriteChannelCount
         {
@@ -361,7 +393,46 @@ namespace BlingoEngine.Movies
                     AdvanceFrame();
             }
         }
+
+        /// <summary>
+        /// Dispatches <c>idleFrame</c> callbacks while the playhead is waiting inside a frame.
+        /// </summary>
+        public void OnIdle(float deltaTime)
+        {
+            if (deltaTime <= 0f)
+                return;
+
+            if (!_isPlaying || !_frameIsActive)
+            {
+                if (!_frameIsActive)
+                    _idleAccumulator = 0f;
+                return;
+            }
+
+            _idleAccumulator += deltaTime;
+            var interval = _idleHandlerPeriod == 0 ? UnthrottledIdleQuantumSeconds : _idleIntervalSeconds;
+
+            int dispatchCount = 0;
+            while (_idleAccumulator >= interval && dispatchCount < MaxIdleDispatchPerTick)
+            {
+                _eventMediator.RaiseIdleFrame();
+                dispatchCount++;
+                _idleAccumulator -= interval;
+
+                if (_idleHandlerPeriod == 0 && _idleAccumulator < interval)
+                    break;
+            }
+
+            if (dispatchCount == MaxIdleDispatchPerTick)
+                _idleAccumulator = 0f;
+        }
         private bool _isAdvancing;
+
+        /// <summary>
+        /// Advances the playhead by a single frame following Director's documented event order:
+        /// <c>beginSprite</c> → <c>stepFrame</c> → <c>prepareFrame</c> → <c>enterFrame</c> → idle →
+        /// <c>exitFrame</c> → <c>endSprite</c>.
+        /// </summary>
         public void AdvanceFrame()
         {
             if (_isAdvancing) return;
@@ -369,7 +440,6 @@ namespace BlingoEngine.Movies
 
             try
             {
-
                 var frameChanged = false;
                 if (_nextFrame < 0)
                 {
@@ -381,34 +451,40 @@ namespace BlingoEngine.Movies
                     frameChanged = SetProperty(ref _currentFrame, _nextFrame, nameof(CurrentFrame));
                     _nextFrame = -1;
                 }
+
                 if (frameChanged)
                 {
                     OnPropertyChanged(nameof(Frame));
 
                     var transitionSprite = _transitionManager.GetFrameSprite(_currentFrame);
-                    if (transitionSprite != null)
-                    {
-                        if (_transitionPlayer.Start(transitionSprite))
-                            _skipStepFrame = true;
-                    }
+                    if (transitionSprite != null && _transitionPlayer.Start(transitionSprite))
+                        _skipStepFrame = true;
 
-                    // update the list with all ended, and all the new started sprites.
+                    // Detect sprite lifecycle changes before raising frame handlers.
                     _sprite2DManager.UpdateActiveSprites(_currentFrame, _lastFrame);
                     _spriteManagers.ForEach(x => x.UpdateActiveSprites(_currentFrame, _lastFrame));
+                }
 
-                    // End the sprites first, the frame has change, start by ending all sprites, that are not on this frame anymore.
-                    _sprite2DManager.EndSprites();
-                    _spriteManagers.ForEach(x => x.EndSprites());
+                // Finish the previous frame (exitFrame/endSprite) before we start dispatching
+                // events for the new frame. Director does this when the playhead crosses into
+                // a new frame so handlers see a clean transition.
+                CompleteActiveFrame();
 
-                    // Begin the new sprites
+                if (frameChanged)
+                {
+                    // Director delivers beginSprite before any of the frame handlers run.
                     _sprite2DManager.BeginSprites();
                     _spriteManagers.ForEach(x => x.BeginSprites());
+
+                    _hasPendingEndSprites = true;
                 }
                 else
                 {
                     // Are there new puppet sprites set.
                     _sprite2DManager.DoPuppetSprites();
+                    _hasPendingEndSprites = false;
                 }
+
                 _lastFrame = _currentFrame;
 
                 if (_needToRaiseStartMovie)
@@ -421,23 +497,40 @@ namespace BlingoEngine.Movies
                 _sprite2DManager.PreStepFrame();
                 if (!_skipStepFrame)
                     _eventMediator.RaiseStepFrame();
+                // The canonical handler order for an active frame. Idle callbacks are pumped
+                // later via OnIdle while _frameIsActive remains true.
                 _eventMediator.RaisePrepareFrame();
                 _eventMediator.RaiseEnterFrame();
+                _frameIsActive = true;
 
                 OnUpdateStage();
                 _skipStepFrame = false;
                 if (frameChanged)
                     CurrentFrameChanged?.Invoke(_currentFrame);
-
-                _eventMediator.RaiseExitFrame();
             }
             finally
             {
-                //_sprite2DManager.EndSprites();
-                //_spriteManagers.ForEach(x => x.EndSprites());
                 _isAdvancing = false;
             }
 
+        }
+
+        private void CompleteActiveFrame()
+        {
+            if (!_frameIsActive)
+                return;
+
+            _eventMediator.RaiseExitFrame();
+
+            if (_hasPendingEndSprites)
+            {
+                _sprite2DManager.EndSprites();
+                _spriteManagers.ForEach(x => x.EndSprites());
+                _hasPendingEndSprites = false;
+            }
+
+            _frameIsActive = false;
+            _idleAccumulator = 0f;
         }
 
 
@@ -466,6 +559,7 @@ namespace BlingoEngine.Movies
             PlayStateChanged?.Invoke(false);
             _environment.Sound.StopAll();
             //_spriteManager.EndSprites();
+            CompleteActiveFrame();
             _eventMediator.RaiseStopMovie();
             // EndSprite
             // StopMovie

--- a/src/BlingoEngine/Movies/Events/IHasIdleFrameEvent.cs
+++ b/src/BlingoEngine/Movies/Events/IHasIdleFrameEvent.cs
@@ -1,0 +1,11 @@
+namespace BlingoEngine.Movies.Events
+{
+    /// <summary>
+    /// Receives idle ticks between <c>enterFrame</c> and <c>exitFrame</c>.
+    /// </summary>
+    public interface IHasIdleFrameEvent
+    {
+        /// <summary>Invoked while the playhead is waiting inside a frame.</summary>
+        void IdleFrame();
+    }
+}

--- a/src/BlingoEngine/Sprites/BlingoSprite.cs
+++ b/src/BlingoEngine/Sprites/BlingoSprite.cs
@@ -156,6 +156,10 @@ namespace BlingoEngine.Sprites
 
 
 
+        /// <summary>
+        /// Invoked when <c>beginSprite</c> fires, before any <c>stepFrame</c>,
+        /// <c>prepareFrame</c> or <c>enterFrame</c> handlers run.
+        /// </summary>
         internal virtual void DoBeginSprite()
         {
             if (InitialState != null)
@@ -173,8 +177,12 @@ namespace BlingoEngine.Sprites
 
             BeginSprite();
         }
+        /// <summary>Override to respond to the sprite's <c>beginSprite</c> event.</summary>
         protected virtual void BeginSprite() { }
 
+        /// <summary>
+        /// Invoked after <c>exitFrame</c> once the sprite is about to leave the stage.
+        /// </summary>
         internal virtual void DoEndSprite()
         {
 
@@ -186,6 +194,7 @@ namespace BlingoEngine.Sprites
             }
             EndSprite();
         }
+        /// <summary>Override to respond to the sprite's <c>endSprite</c> event.</summary>
         protected virtual void EndSprite() { }
         public virtual string GetFullName() => $"{SpriteNum}.{Name}";
 

--- a/src/BlingoEngine/Sprites/BlingoSpriteManager.cs
+++ b/src/BlingoEngine/Sprites/BlingoSpriteManager.cs
@@ -390,6 +390,10 @@ namespace BlingoEngine.Sprites
         }
 
 
+        /// <summary>
+        /// Raises <c>beginSprite</c> for sprites entering the current frame before
+        /// <c>stepFrame</c>/<c>prepareFrame</c>/<c>enterFrame</c> handlers are dispatched.
+        /// </summary>
         internal override void BeginSprites()
         {
             foreach (var sprite in _enteredSprites)
@@ -397,6 +401,9 @@ namespace BlingoEngine.Sprites
         }
         protected virtual void OnBeginSprite(TSprite sprite) => sprite.DoBeginSprite();
 
+        /// <summary>
+        /// Runs after <c>exitFrame</c> so sprites can clean up during their <c>endSprite</c> handlers.
+        /// </summary>
         internal override void EndSprites()
         {
             foreach (var sprite in _exitedSprites)


### PR DESCRIPTION
## Summary
- add an idle frame message interface and plumb idle dispatch through the clock and event mediator
- document sprite/moviel lifecycle methods and ensure BlingoMovie raises events in Director order with idle throttling
- add reusable fake movie builder plus unit tests that assert frame and transition event ordering

## Testing
- dotnet test Test/BlingoEngine.Tests/BlingoEngine.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d3ddb960b48332a5c48f3f6161c11f