### PR TITLE
Refactor property inspector to stacked scroll layout

### DIFF
--- a/src/Net/BlingoEngine.Net.RNetTerminal/Views/PropertyInspector.cs
+++ b/src/Net/BlingoEngine.Net.RNetTerminal/Views/PropertyInspector.cs
@@ -14,6 +14,7 @@ using Terminal.Gui.Input;
 using Terminal.Gui.ViewBase;
 using Terminal.Gui.Views;
 using static System.Runtime.InteropServices.JavaScript.JSType;
+using Attribute = Terminal.Gui.Drawing.Attribute;
 
 namespace BlingoEngine.Net.RNetTerminal.Views;
 
@@ -25,28 +26,39 @@ public enum PropertyTarget
 
 internal sealed class PropertyInspector : View
 {
-    private readonly TabView _tabs;
+    private static readonly Scheme SectionTitleScheme = new()
+    {
+        Normal = new Attribute(Color.Black, Color.White),
+        Focus = new Attribute(Color.Black, Color.White),
+        HotNormal = new Attribute(Color.Black, Color.White),
+        HotFocus = new Attribute(Color.Black, Color.White)
+    };
+
+    private readonly View _contentContainer;
+    private readonly Label _selectionLabel;
+    private readonly LineView _verticalSeparator;
+    private readonly List<PropertySection> _sections = new();
+    private readonly List<PropertySection> _visibleSections = new();
     private readonly DataTable _memberTable = new();
     private readonly List<PropertySpec> _memberSpecs = new();
     private readonly TableView _memberTableView;
     private readonly DataTable _spriteTable = new();
     private readonly List<PropertySpec> _spriteSpecs = new();
     private readonly TableView _spriteTableView;
-    private readonly Tab _memberTab;
-    private readonly Tab _spriteTab;
-    private readonly Tab _bitmapTab;
-    private readonly Tab _soundTab;
-    private readonly Tab _movieTab;
-    private readonly Tab _castTab;
-    private readonly Tab _textTab;
-    private readonly Tab _shapeTab;
-    private readonly Tab _guidesTab;
-    private readonly Tab _behaviorTab;
-    private readonly Tab _filmLoopTab;
+    private readonly PropertySection _memberSection;
+    private readonly PropertySection _spriteSection;
+    private readonly PropertySection _bitmapSection;
+    private readonly PropertySection _soundSection;
+    private readonly PropertySection _movieSection;
+    private readonly PropertySection _castSection;
+    private readonly PropertySection _textSection;
+    private readonly PropertySection _shapeSection;
+    private readonly PropertySection _guidesSection;
+    private readonly PropertySection _behaviorSection;
+    private readonly PropertySection _filmLoopSection;
     private Blingo2DSpriteDTO? _sprite;
     private BlingoMemberDTO? _member;
-    private string _lastTab = "Sprite";
-    private string _selectionText = ""; 
+    private string _selectionText = "";
 
     public BlingoMemberDTO? CurrentMember => _member;
 
@@ -58,27 +70,46 @@ internal sealed class PropertyInspector : View
     {
         CanFocus = true;
         Text = "Properties";
-        _tabs = new TabView
+
+        _selectionLabel = new Label
         {
-            Width = Dim.Fill(),
-            Height = Dim.Fill(),
+            X = 1,
+            Y = 0,
+            Width = Dim.Fill() - 1,
+            Height = 1
         };
-        if (_tabs.Border != null)
-            _tabs.Border.Thickness = new Thickness(0);
-        var tabsMargin = _tabs.Margin;
-        if (tabsMargin != null)
-            tabsMargin.Thickness = new Thickness(-1, 0, -1, -1);
-        var tabsPadding = _tabs.Padding;
-        if (tabsPadding != null)
-            tabsPadding.Thickness = new Thickness(0);
-        _tabs.SelectedTabChanged += (_, e) =>
+        _selectionLabel.Text = string.Empty;
+        Add(_selectionLabel);
+
+        _verticalSeparator = new LineView(Orientation.Vertical)
         {
-            if (e.NewTab != null)
-            {
-                _lastTab = e.NewTab.Text?.ToString() ?? _lastTab;
-            }
+            X = 0,
+            Y = 1,
+            Width = 1,
+            Height = Dim.Fill()
         };
-        Add(_tabs);
+        Add(_verticalSeparator);
+
+        _contentContainer = new View
+        {
+            X = 1,
+            Y = 1,
+            Width = Dim.Fill() - 1,
+            Height = Dim.Fill() - 1,
+            ContentSizeTracksViewport = false
+        };
+        var verticalScrollBar = _contentContainer.VerticalScrollBar;
+        if (verticalScrollBar != null)
+        {
+            verticalScrollBar.AutoShow = true;
+        }
+        var horizontalScrollBar = _contentContainer.HorizontalScrollBar;
+        if (horizontalScrollBar != null)
+        {
+            horizontalScrollBar.AutoShow = false;
+            horizontalScrollBar.Visible = false;
+        }
+        Add(_contentContainer);
 
         _spriteSpecs.AddRange(new[]
         {
@@ -100,11 +131,10 @@ internal sealed class PropertyInspector : View
             new PropertySpec("ForeColor", typeof(Color)),
             new PropertySpec("BackColor", typeof(Color)),
         });
-        var tabSpriteTuple = CreateTab("Sprite", _spriteSpecs, PropertyTarget.Sprite);
-        _spriteTab = tabSpriteTuple.Tab;
-        _spriteTable = tabSpriteTuple.Data;
-        _spriteTableView = tabSpriteTuple.View;
-        _tabs.AddTab(_spriteTab,true);
+        var spriteSection = CreateSection("Sprite", _spriteSpecs, PropertyTarget.Sprite);
+        _spriteSection = spriteSection.Section;
+        _spriteTableView = spriteSection.View;
+        _spriteTable = spriteSection.Data;
 
         _memberSpecs.AddRange(new[]
         {
@@ -122,20 +152,21 @@ internal sealed class PropertyInspector : View
             new PropertySpec("PurgePriority", typeof(int), true)
         });
 
-        var tabMemberTuple = CreateTab("Member", _memberSpecs, PropertyTarget.Member);
-        _memberTab = tabMemberTuple.Tab;
-        _memberTableView = tabMemberTuple.View;
-        _memberTable = tabMemberTuple.Data;
-        _tabs.AddTab(_memberTab, true);
+        var memberSection = CreateSection("Member", _memberSpecs, PropertyTarget.Member);
+        _memberSection = memberSection.Section;
+        _memberTableView = memberSection.View;
+        _memberTable = memberSection.Data;
 
-        _bitmapTab = CreateTab("Bitmap", new[]
+        var (bitmapSection, _, _) = CreateSection("Bitmap", new[]
         {
             new PropertySpec("Dimensions", typeof(string), true),
             new PropertySpec("Highlight", typeof(bool)),
             new PropertySpec("RegPointX", typeof(int)),
             new PropertySpec("RegPointY", typeof(int))
         }, PropertyTarget.Member);
-        _soundTab = CreateTab("Sound", new[]
+        _bitmapSection = bitmapSection;
+
+        var (soundSection, _, _) = CreateSection("Sound", new[]
         {
             new PropertySpec("Loop", typeof(bool)),
             new PropertySpec("Duration", typeof(float), true),
@@ -145,7 +176,9 @@ internal sealed class PropertyInspector : View
             new PropertySpec("Play", typeof(bool)),
             new PropertySpec("Stop", typeof(bool))
         }, PropertyTarget.Member);
-        _movieTab = CreateTab("Movie", new[]
+        _soundSection = soundSection;
+
+        var (movieSection, _, _) = CreateSection("Movie", new[]
         {
             new PropertySpec("StageWidth", typeof(int)),
             new PropertySpec("StageHeight", typeof(int)),
@@ -155,18 +188,24 @@ internal sealed class PropertyInspector : View
             new PropertySpec("About", typeof(string)),
             new PropertySpec("Copyright", typeof(string))
         }, PropertyTarget.Member);
-        _castTab = CreateTab("Cast", new[]
+        _movieSection = movieSection;
+
+        var (castSection, _, _) = CreateSection("Cast", new[]
         {
             new PropertySpec("Number", typeof(int)),
             new PropertySpec("Name", typeof(string))
         }, PropertyTarget.Member);
-        _textTab = CreateTab("Text", new[]
+        _castSection = castSection;
+
+        var (textSection, _, _) = CreateSection("Text", new[]
         {
             new PropertySpec("Width", typeof(int)),
             new PropertySpec("Height", typeof(int)),
             new PropertySpec("Edit", typeof(bool))
         }, PropertyTarget.Member);
-        _shapeTab = CreateTab("Shape", new[]
+        _textSection = textSection;
+
+        var (shapeSection, _, _) = CreateSection("Shape", new[]
         {
             new PropertySpec("Shape", typeof(string)),
             new PropertySpec("Filled", typeof(bool)),
@@ -174,7 +213,9 @@ internal sealed class PropertyInspector : View
             new PropertySpec("Height", typeof(int)),
             new PropertySpec("Edit", typeof(bool))
         }, PropertyTarget.Member);
-        _guidesTab = CreateTab("Guides", new[]
+        _shapeSection = shapeSection;
+
+        var (guidesSection, _, _) = CreateSection("Guides", new[]
         {
             new PropertySpec("GuidesColor", typeof(Color)),
             new PropertySpec("GuidesVisible", typeof(bool)),
@@ -189,17 +230,20 @@ internal sealed class PropertyInspector : View
             new PropertySpec("GridWidth", typeof(int)),
             new PropertySpec("GridHeight", typeof(int))
         }, PropertyTarget.Member);
-        _behaviorTab = CreateTab("Behavior", new[] { new PropertySpec("Behaviors", typeof(string)) }, PropertyTarget.Member);
-        _filmLoopTab = CreateTab("FilmLoop", new[]
+        _guidesSection = guidesSection;
+
+        var (behaviorSection, _, _) = CreateSection("Behavior", new[] { new PropertySpec("Behaviors", typeof(string)) }, PropertyTarget.Member);
+        _behaviorSection = behaviorSection;
+
+        var (filmLoopSection, _, _) = CreateSection("FilmLoop", new[]
         {
             new PropertySpec("Framing", typeof(string)),
             new PropertySpec("Loop", typeof(bool)),
             new PropertySpec("FrameCount", typeof(int))
         }, PropertyTarget.Member);
+        _filmLoopSection = filmLoopSection;
 
-        SetTabs( _movieTab);
-        var initial = _tabs.Tabs.FirstOrDefault(t => t.Text.ToString() == _lastTab) ?? _spriteTab;
-        _tabs.SelectedTab = initial;
+        SubViewLayout += (_, _) => UpdateSectionLayout();
 
         var store = TerminalDataStore.Instance;
         UpdateSelection(store.GetSelectedSprite());
@@ -260,11 +304,8 @@ internal sealed class PropertyInspector : View
             ShowMember(null);
         }
         _selectionText = (sprite != null ? "Sprite " + sprite.SpriteNum + ": " : "") + memberText;
-    }
-    private void DrawSelectionHeader()
-    {
-        Move(2, 2);
-        AddStr(_selectionText);
+        _selectionLabel.Text = _selectionText;
+        _selectionLabel.SetNeedsDraw();
     }
 
     public void ShowSprite(Blingo2DSpriteDTO? sprite)
@@ -307,16 +348,85 @@ internal sealed class PropertyInspector : View
 
 
 
-    private void SetTabs(params Tab[] tabs)
+    private void SetVisibleSections(params PropertySection[] sections)
     {
-        foreach (var existing in _tabs.Tabs.ToList())
-            _tabs.RemoveTab(existing);
+        _visibleSections.Clear();
+        foreach (var section in sections)
+        {
+            if (section != null && !_visibleSections.Contains(section))
+            {
+                _visibleSections.Add(section);
+            }
+        }
 
-        foreach (var tab in tabs)
-            _tabs.AddTab(tab, false);
+        UpdateSectionLayout();
+        var verticalScrollBar = _contentContainer.VerticalScrollBar;
+        if (verticalScrollBar != null)
+        {
+            verticalScrollBar.Position = 0;
+        }
     }
 
-   
+    private void UpdateSectionLayout()
+    {
+        foreach (var section in _sections)
+        {
+            section.Container.Visible = false;
+        }
+
+        var y = 0;
+        foreach (var section in _visibleSections)
+        {
+            section.Container.Visible = true;
+            section.Container.X = 0;
+            section.Container.Y = y;
+            y += section.Height;
+        }
+
+        var width = _contentContainer.Frame.Width;
+        if (width <= 0)
+        {
+            width = Frame.Width;
+        }
+        if (width <= 0)
+        {
+            width = 1;
+        }
+
+        var height = y;
+        var visibleHeight = _contentContainer.Frame.Height;
+        if (visibleHeight > 0)
+        {
+            height = Math.Max(height, visibleHeight);
+        }
+        else if (height <= 0)
+        {
+            height = 1;
+            visibleHeight = height;
+        }
+        else
+        {
+            visibleHeight = height;
+        }
+
+        _contentContainer.SetContentSize(new System.Drawing.Size(width, height));
+
+        var verticalScrollBar = _contentContainer.VerticalScrollBar;
+        if (verticalScrollBar != null)
+        {
+            var viewportHeight = visibleHeight > 0 ? visibleHeight : height;
+            verticalScrollBar.VisibleContentSize = viewportHeight;
+            verticalScrollBar.ScrollableContentSize = height;
+            var maxPosition = Math.Max(0, height - viewportHeight);
+            if (verticalScrollBar.Position > maxPosition)
+            {
+                verticalScrollBar.Position = maxPosition;
+            }
+        }
+
+        _contentContainer.SetNeedsDraw();
+    }
+
     private static string? EditValue(Type type, string name, string value)
     {
         string? result = null;
@@ -444,98 +554,107 @@ internal sealed class PropertyInspector : View
 
         if (member == null)
         {
-            var tabsEmpty = new List<Tab>();
+            var sections = new List<PropertySection>();
             if (_sprite != null)
             {
-                tabsEmpty.Add(_spriteTab);
+                sections.Add(_spriteSection);
             }
-            tabsEmpty.Add(_memberTab);
-            SetTabs(tabsEmpty.ToArray());
-            var target = _tabs.Tabs.FirstOrDefault(t => t.Text.ToString() == _lastTab);
-            _tabs.SelectedTab = target ?? (_sprite != null ? _spriteTab : _memberTab);
+            sections.Add(_memberSection);
+            SetVisibleSections(sections.ToArray());
             _memberTableView.SetNeedsDraw();
             return;
         }
 
         _memberTableView.SetNeedsDraw();
 
-        var tabs = new List<Tab>();
+        var visibleSections = new List<PropertySection>();
         if (_sprite != null)
         {
-            tabs.Add(_spriteTab);
+            visibleSections.Add(_spriteSection);
             if (_sprite.Behaviors.Any())
-                tabs.Add(_behaviorTab);
+            {
+                visibleSections.Add(_behaviorSection);
+            }
         }
-        tabs.Add(_memberTab);
-        tabs.Add(_castTab);
+        visibleSections.Add(_memberSection);
+        visibleSections.Add(_castSection);
 
         switch (member.Type)
         {
             case BlingoMemberTypeDTO.Bitmap:
             case BlingoMemberTypeDTO.Picture:
-                tabs.Add(_bitmapTab);
+                visibleSections.Add(_bitmapSection);
                 break;
             case BlingoMemberTypeDTO.Sound:
-                tabs.Add(_soundTab);
+                visibleSections.Add(_soundSection);
                 break;
             case BlingoMemberTypeDTO.Text:
             case BlingoMemberTypeDTO.Field:
-                tabs.Add(_textTab);
+                visibleSections.Add(_textSection);
                 break;
             case BlingoMemberTypeDTO.Shape:
-                tabs.Add(_shapeTab);
+                visibleSections.Add(_shapeSection);
                 break;
             case BlingoMemberTypeDTO.FilmLoop:
-                tabs.Add(_filmLoopTab);
+                visibleSections.Add(_filmLoopSection);
                 break;
             case BlingoMemberTypeDTO.Movie:
-                tabs.Add(_movieTab);
+                visibleSections.Add(_movieSection);
                 break;
         }
 
-        SetTabs(tabs.ToArray());
-        var desired = _tabs.Tabs.FirstOrDefault(t => t.Text.ToString() == _lastTab);
-        _tabs.SelectedTab = desired ?? (_sprite != null ? _spriteTab : _memberTab);
-        _tabs.SetNeedsDraw();
+        SetVisibleSections(visibleSections.ToArray());
     }
 
  
-    protected override bool OnDrawingContent()
-    {
-        // not working yet
-        var ok = base.OnDrawingContent();
-        DrawSelectionHeader();
-        return ok;
-    }
-
-
-
-    private Tab CreateTab(string title, PropertySpec[] props, PropertyTarget target)
-    {
-        var tab = new Tab();
-        RNetTerminalStyle.SetForTableView(tab);
-        tab.DisplayText = title;
-        var tableView = BuildPropertyTableView(props);
-        AttachEditPopup(props, tableView, target);
-        tab.View = tableView.View;
-        return (tab);
-    }
-    private (Tab Tab, TableView View, DataTable Data) CreateTab(string name, IList<PropertySpec> data, PropertyTarget target)
-    {
-        var tab = new Tab();
-        tab.CanFocus = true;
-        RNetTerminalStyle.SetForTableView(tab);
-        tab.DisplayText = name;
-        var tableView = CreateTable(data);
-        AttachEditPopup(data, tableView, target);
-        tab.View = tableView.View;
-        return (tab, tableView.View, tableView.Data);
-    }
-    private (TableView View, DataTable Data) BuildPropertyTableView(PropertySpec[] props)
+    private (PropertySection Section, TableView View, DataTable Data) CreateSection(string title, IList<PropertySpec> props, PropertyTarget target)
     {
         var table = CreateTable(props);
-        
-        return table;
+        AttachEditPopup(props, table, target);
+        var section = BuildSection(title, table.View, table.Data);
+        return (section, table.View, table.Data);
+    }
+
+    private PropertySection BuildSection(string title, TableView tableView, DataTable data)
+    {
+        var tableHeight = Math.Max(1, data.Rows.Count);
+        tableView.Height = tableHeight;
+        tableView.Width = Dim.Fill();
+
+        var container = new View
+        {
+            Width = Dim.Fill(),
+            Height = tableHeight + 2
+        };
+
+        var separator = new LineView(Orientation.Horizontal)
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill()
+        };
+        container.Add(separator);
+
+        var titleLabel = new Label
+        {
+            X = 0,
+            Y = 1,
+            Width = Dim.Fill(),
+            Height = 1
+        };
+        titleLabel.Text = $" {title} ";
+        titleLabel.SetScheme(SectionTitleScheme);
+        container.Add(titleLabel);
+
+        tableView.X = 0;
+        tableView.Y = 2;
+        container.Add(tableView);
+
+        var section = new PropertySection(container, tableView, data, tableHeight + 2);
+        _sections.Add(section);
+        _contentContainer.Add(container);
+
+        return section;
     }
 
     private void AttachEditPopup(IList<PropertySpec> props, (TableView View, DataTable Data) table, PropertyTarget target)
@@ -593,7 +712,6 @@ internal sealed class PropertyInspector : View
         var tableView = new TableView
         {
             Width = Dim.Fill(),
-            Height = Dim.Fill(),
             Table = new DataTableSource(datas),
             FullRowSelect = true
         };
@@ -617,6 +735,22 @@ internal sealed class PropertyInspector : View
         tableView.Style.ColumnStyles.Add(0, new ColumnStyle { Alignment = Alignment.Start });
         tableView.Style.ColumnStyles.Add(1, new ColumnStyle { Alignment = Alignment.End });
         return tableView;
+    }
+
+    private sealed class PropertySection
+    {
+        public PropertySection(View container, TableView tableView, DataTable data, int height)
+        {
+            Container = container;
+            TableView = tableView;
+            Data = data;
+            Height = height;
+        }
+
+        public View Container { get; }
+        public TableView TableView { get; }
+        public DataTable Data { get; }
+        public int Height { get; }
     }
 
     private sealed class PropertySpec


### PR DESCRIPTION
## Summary
- replace the tabbed property inspector with a stacked scrollable view that shows the current selection header alongside a vertical divider
- render each property category with a horizontal separator, styled section title, and the existing table view content
- manage section visibility and scroll sizing so sections are stacked vertically and populate the scrollable container dynamically

## Testing
- dotnet build src/Net/BlingoEngine.Net.RNetTerminal/BlingoEngine.Net.RNetTerminal.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d3fe3aeea48332b0a4e18e576174dc