### PR TITLE
Add Pac-Man sound helpers and bonus display behavior

### DIFF
--- a/Demo/LPacMan/Blingo.PacMan.Core/Models/BonusesModel.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Models/BonusesModel.cs
@@ -1,0 +1,45 @@
+// Copyright to EmmanuelTheCreator.com
+// This file was written in 2005, yeah a lot has evolved since then :-)
+// Converted from original Lingo code, tried to keep it as identical as possible.
+
+using System;
+
+namespace Blingo.PacMan.Core.Models
+{
+    /// <summary>
+    /// Represents the current bonus progression for the player.
+    /// </summary>
+    public interface IBonusesModel
+    {
+        int Level { get; set; }
+
+        event Action<int>? LevelChanged;
+    }
+
+    /// <summary>
+    /// Default implementation backed by a simple property with change notification.
+    /// </summary>
+    public sealed class BonusesModel : IBonusesModel
+    {
+        private const int MaxBonuses = 8;
+        private int _level;
+
+        public event Action<int>? LevelChanged;
+
+        public int Level
+        {
+            get => _level;
+            set
+            {
+                var clampedLevel = Math.Clamp(value, 0, MaxBonuses);
+                if (_level == clampedLevel)
+                {
+                    return;
+                }
+
+                _level = clampedLevel;
+                LevelChanged?.Invoke(_level);
+            }
+        }
+    }
+}

--- a/Demo/LPacMan/Blingo.PacMan.Core/PacManProjectFactory.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/PacManProjectFactory.cs
@@ -1,5 +1,6 @@
 ﻿using BlingoEngine.Casts;
 using BlingoEngine.Core;
+using Blingo.PacMan.Core.Models;
 using BlingoEngine.Members;
 using BlingoEngine.Movies;
 using BlingoEngine.Projects;
@@ -42,6 +43,7 @@ public class PacManProjectFactory : IBlingoProjectFactory
                 )
                 .ServicesBlingo(s => s
                     .AddSingleton<IPacManCore, PacManCore>()
+                    .AddSingleton<IBonusesModel, BonusesModel>()
                     )
                 ;
     }

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sounds/PacManSounds.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sounds/PacManSounds.cs
@@ -1,0 +1,64 @@
+// Copyright to EmmanuelTheCreator.com
+// This file was written in 2005, yeah a lot has evolved since then :-)
+// Converted from original Lingo code, tried to keep it as identical as possible.
+
+using BlingoEngine.Core;
+
+namespace Blingo.PacMan.Core
+{
+    /// <summary>
+    /// Convenience extension methods that wrap the various sound cues used throughout the Pac-Man game.
+    /// </summary>
+    internal static class PacManSounds
+    {
+        public static void SoundPlayBack(this IBlingoPlayer player)
+        {
+            var channel = player.Sound.Channel(1);
+            if (channel != null)
+            {
+                channel.Volume = 160;
+            }
+
+            player.Sound.PuppetSound(1, "S_back");
+        }
+
+        public static void SoundStopBack(this IBlingoPlayer player)
+        {
+            player.Sound.Channel(1)?.Stop();
+        }
+
+        public static void SoundPlayBonus(this IBlingoPlayer player) => player.Sound.PuppetSound(2, "S_bonus");
+
+        public static void SoundPlayDead(this IBlingoPlayer player) => player.Sound.PuppetSound(3, "S_dead");
+
+        public static void SoundPlayDot(this IBlingoPlayer player) => player.Sound.PuppetSound(4, "S_dot");
+
+        public static void SoundPlayEat(this IBlingoPlayer player) => player.Sound.PuppetSound(5, "S_eat");
+
+        public static void SoundPlayEaten(this IBlingoPlayer player) => player.Sound.PuppetSound(6, "S_eaten");
+
+        public static void SoundPlayFrightened(this IBlingoPlayer player)
+        {
+            var channel = player.Sound.Channel(1);
+            if (channel != null)
+            {
+                channel.Volume = 160;
+            }
+
+            player.Sound.PuppetSound(1, "S_frightened");
+        }
+
+        public static void SoundPlayIntro(this IBlingoPlayer player)
+        {
+            var channel = player.Sound.Channel(1);
+            if (channel != null)
+            {
+                channel.Volume = 160;
+            }
+
+            player.Sound.PuppetSound(1, "S_intro");
+        }
+
+        public static void SoundPlayLife(this IBlingoPlayer player) => player.Sound.PuppetSound(7, "S_life");
+    }
+}

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/Behaviors/BonusesBehavior.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/Behaviors/BonusesBehavior.cs
@@ -1,0 +1,158 @@
+// Copyright to EmmanuelTheCreator.com
+// This file was written in 2005, yeah a lot has evolved since then :-)
+// Converted from original Lingo code, tried to keep it as identical as possible.
+
+using System;
+using System.Collections.Generic;
+using Blingo.PacMan.Core.Models;
+using BlingoEngine.Members;
+using BlingoEngine.Movies;
+using BlingoEngine.Sprites;
+using BlingoEngine.Sprites.Events;
+
+namespace Blingo.PacMan.Core.Sprites.Behaviors
+{
+    /// <summary>
+    /// Behaviour responsible for displaying the fruit bonuses earned across levels.
+    /// </summary>
+    public sealed class BonusesBehavior : BlingoSpriteBehavior, IHasBeginSpriteEvent, IHasEndSpriteEvent
+    {
+        private const int BonusCount = 8;
+        private readonly List<BonusSprite> _bonuses = new();
+        private readonly IBonusesModel _model;
+        private bool _isInitialized;
+
+        public float ScaleFactor { get; set; } = 1f;
+
+        public float Spacing { get; set; } = 64f;
+
+        public string BonusMemberName { get; set; } = "sprites";
+
+        public string BonusCastLibName { get; set; } = "Data";
+
+        public BonusesBehavior(IBlingoMovieEnvironment env, IBonusesModel model)
+            : base(env)
+        {
+            _model = model ?? throw new ArgumentNullException(nameof(model));
+        }
+
+        public void BeginSprite()
+        {
+            if (!_isInitialized)
+            {
+                InitializeBonuses();
+                _model.LevelChanged += OnLevelChanged;
+                _isInitialized = true;
+            }
+
+            Render();
+        }
+
+        public void EndSprite()
+        {
+            if (!_isInitialized)
+            {
+                return;
+            }
+
+            _model.LevelChanged -= OnLevelChanged;
+
+            foreach (var bonus in _bonuses)
+            {
+                bonus.Dispose();
+            }
+
+            _bonuses.Clear();
+            _isInitialized = false;
+        }
+
+        private void InitializeBonuses()
+        {
+            var baseX = Me.LocH;
+            var baseY = Me.LocV;
+            var spacing = Spacing * (Math.Abs(ScaleFactor) <= float.Epsilon ? 1f : ScaleFactor);
+
+            for (var i = 0; i < BonusCount; i++)
+            {
+                var bonusX = baseX - i * spacing;
+                var bonus = CreateBonusSprite(i, bonusX, baseY);
+                bonus.Hide();
+                _bonuses.Add(bonus);
+            }
+        }
+
+        private void OnLevelChanged(int _)
+        {
+            Render();
+        }
+
+        private void Render()
+        {
+            for (var i = 0; i < _bonuses.Count; i++)
+            {
+                if (i < _model.Level)
+                {
+                    _bonuses[i].Show();
+                }
+                else
+                {
+                    _bonuses[i].Hide();
+                }
+            }
+        }
+
+        private BonusSprite CreateBonusSprite(int index, float x, float y)
+        {
+            var name = $"{Me.SpriteNum}_{Me.Name}_Bonus_{index}";
+            var sprite = _Movie.AddSprite(name, sprite2D =>
+            {
+                sprite2D.BeginFrame = 1;
+                sprite2D.EndFrame = Math.Max(1, _Movie.FrameCount);
+                sprite2D.LocH = x;
+                sprite2D.LocV = y;
+                sprite2D.LocZ = Me.LocZ;
+                sprite2D.Puppet = true;
+                sprite2D.Lock = true;
+
+                var cast = CastLib(BonusCastLibName);
+                var member = cast?.GetMember<BlingoMember>(BonusMemberName);
+                if (member != null)
+                {
+                    sprite2D.Member = member;
+                }
+            });
+
+            return new BonusSprite(_Movie, name, sprite);
+        }
+
+        private sealed class BonusSprite : IDisposable
+        {
+            private readonly IBlingoMovie _movie;
+            private readonly BlingoSprite2D _sprite;
+            private readonly string _name;
+            private bool _disposed;
+
+            public BonusSprite(IBlingoMovie movie, string name, BlingoSprite2D sprite)
+            {
+                _movie = movie ?? throw new ArgumentNullException(nameof(movie));
+                _name = name ?? throw new ArgumentNullException(nameof(name));
+                _sprite = sprite ?? throw new ArgumentNullException(nameof(sprite));
+            }
+
+            public void Show() => _sprite.Visibility = true;
+
+            public void Hide() => _sprite.Visibility = false;
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                _movie.RemoveSprite(_name);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a PacManSounds extension helper that exposes puppetSound wrappers for every Pac-Man audio cue
- introduce a BonusesBehavior that instantiates and toggles the fruit bonus sprites based on the current level model
- register a shared BonusesModel service so behaviors can react to level changes

## Testing
- dotnet build Demo/LPacMan/Blingo.PacMan.Core/Blingo.PacMan.Core.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d425d21df08332b29c7c882f523f9f