### PR TITLE
Guard member source rect adjustments

### DIFF
--- a/src/BlingoEngine.Blazor/Sprites/BlingoBlazorSprite.razor
+++ b/src/BlingoEngine.Blazor/Sprites/BlingoBlazorSprite.razor
@@ -23,6 +23,18 @@
         var drawW = Sprite.DesiredWidth > 0 ? Sprite.DesiredWidth : Sprite.Width;
         var drawH = Sprite.DesiredHeight > 0 ? Sprite.DesiredHeight : Sprite.Height;
 
+        if (Sprite.MemberSourceRect is null)
+        {
+            var x = Sprite.X - Sprite.RegPoint.X;
+            var y = Sprite.Y - Sprite.RegPoint.Y;
+            var scaleX = Sprite.FlipH ? -1 : 1;
+            var scaleY = Sprite.FlipV ? -1 : 1;
+            var defaultTransform = $"translate({Sprite.RegPoint.X}px,{Sprite.RegPoint.Y}px) rotate({Sprite.Rotation}deg) scale({scaleX},{scaleY}) translate(-{Sprite.RegPoint.X}px,-{Sprite.RegPoint.Y}px)";
+            var defaultStyle = $"position:absolute;left:{x}px;top:{y}px;width:{drawW}px;height:{drawH}px;z-index:{Sprite.ZIndex};opacity:{Sprite.Blend};transform:{defaultTransform};";
+            if (!Sprite.Visibility) defaultStyle += "display:none;";
+            return defaultStyle;
+        }
+
         var (baseOffset, sourceWidth, sourceHeight) = Sprite.GetMemberSourceMetrics();
         if (sourceWidth <= 0)
             sourceWidth = drawW != 0 ? drawW : 1f;
@@ -47,7 +59,7 @@
         var transform = $"translate({regPointDisplayX}px,{regPointDisplayY}px) rotate({Sprite.Rotation}deg) scale({flipScaleX},{flipScaleY}) translate(-{regPointDisplayX}px,-{regPointDisplayY}px)";
         var style = $"position:absolute;left:{left}px;top:{top}px;width:{drawW}px;height:{drawH}px;z-index:{Sprite.ZIndex};opacity:{Sprite.Blend};transform:{transform};";
         if (!Sprite.Visibility) style += "display:none;";
-        if (Sprite.MemberSourceRect != null) style += "overflow:hidden;";
+        style += "overflow:hidden;";
         return style;
     }
 

--- a/src/BlingoEngine.Unity/Sprites/BlingoUnitySprite2D.cs
+++ b/src/BlingoEngine.Unity/Sprites/BlingoUnitySprite2D.cs
@@ -184,6 +184,26 @@ public class BlingoUnitySprite2D : IBlingoFrameworkSprite, IBlingoFrameworkSprit
         if (!IsDirty) return;
         IsDirty = false;
 
+        if (_blingoSprite.MemberSourceRect is null)
+        {
+            var pos = new Vector3(_x - _regPoint.X, _y - _regPoint.Y, 0f);
+            _go.transform.localPosition = pos;
+            _go.transform.localEulerAngles = new Vector3(0, 0, _rotation);
+
+            if (_texture?.Texture is Texture2D tex)
+            {
+                float defaultTargetWidth = _desiredWidth == 0 ? tex.width : _desiredWidth;
+                float defaultTargetHeight = _desiredHeight == 0 ? tex.height : _desiredHeight;
+                float defaultScaleX = defaultTargetWidth / tex.width;
+                float defaultScaleY = defaultTargetHeight / tex.height;
+                if (_flipH) defaultScaleX *= -1f;
+                if (_flipV) defaultScaleY *= -1f;
+                _go.transform.localScale = new Vector3(defaultScaleX, defaultScaleY, 1f);
+            }
+
+            return;
+        }
+
         var (baseOffset, sourceWidth, sourceHeight) = _blingoSprite.GetMemberSourceMetrics();
 
         float textureWidth = _texture?.Texture?.width ?? Width;

--- a/src/BlingoEngine/Sprites/BlingoSprite2D.cs
+++ b/src/BlingoEngine/Sprites/BlingoSprite2D.cs
@@ -655,6 +655,7 @@ When a movie stops, events occur in the following order:
         private void MemberHasChanged(bool forceSizeUpdate = false)
         {
             var forceUpdate = forceSizeUpdate || _memberSourceRectChanged;
+            var isCropping = _member is BlingoMemberBitmap && MemberSourceRect is { };
             var existingPlayer = GetActorsOfType<BlingoFilmLoopPlayer>().FirstOrDefault();
             if (_member is BlingoFilmLoopMember)
             {
@@ -675,13 +676,14 @@ When a movie stops, events occur in the following order:
 
             if (_frameworkSprite != null)
             {
-                ApplyMemberSourceRectSize(forceUpdate);
+                var shouldForceSize = forceUpdate && isCropping;
+                ApplyMemberSourceRectSize(shouldForceSize);
                 _frameworkSprite.MemberChanged();
                 _memberSourceRectChanged = false;
             }
             else
             {
-                _memberSourceRectChanged = forceUpdate;
+                _memberSourceRectChanged = forceUpdate && isCropping;
             }
 
             OnPropertyChanged();


### PR DESCRIPTION
## Summary
- keep Blazor sprite layout math identical to the previous behaviour when no member source rect is provided
- fall back to legacy Unity positioning/scaling when the sprite is not cropped so existing games remain unaffected
- ensure the shared sprite logic only forces a resize when a crop rectangle is active so other runtimes keep their custom sizing

## Testing
- dotnet build src/BlingoEngine/BlingoEngine.csproj
- dotnet build src/BlingoEngine.SDL2/BlingoEngine.SDL2.csproj
- dotnet build src/BlingoEngine.LGodot/BlingoEngine.LGodot.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d518ebe1508332b2c46ba122374c03