### PR TITLE
Fix Pac-Man ghost spawn position

### DIFF
--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManGhostBehavior.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManGhostBehavior.cs
@@ -229,6 +229,7 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
         var character = EnsureCharacter();
         var map = _globals.Map ?? throw new InvalidOperationException("Pac-Man map is not initialized.");
         character.SetMap(map);
+        SetStartposition();
         character.Speed = _baseSpeed;
         character.EffectiveSpeed = _baseSpeed;
 
@@ -304,16 +305,18 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
         _requestedDirection = _initialDirection;
     }
 
-    private void SetStartposition()
+    private bool SetStartposition()
     {
         var map = _globals.Map;
         var center = map?.HouseCenter ?? map?.House ?? map?.GetTile(map.Width / 2, map.Height / 2);
-        if (center != null)
-        {
-            var offset = _horizontalOffsets.TryGetValue(GhostName, out var value) ? value : 0f;
-            Me.LocH = center.CenterX + offset;
-            Me.LocV = center.CenterY;
-        }
+        if (center is null)
+            return false;
+
+        var offset = _horizontalOffsets.TryGetValue(GhostName, out var value) ? value : 0f;
+        Me.LocH = center.CenterX + offset;
+        Me.LocV = center.CenterY;
+        _character?.UpdateStartPosition(Me.LocH, Me.LocV);
+        return true;
     }
 
     /// <summary>

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/ParentScripts/BlPacManCharacter.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/ParentScripts/BlPacManCharacter.cs
@@ -133,6 +133,41 @@ internal sealed class BlPacManCharacter : BlingoParentScript
         PauseCharacterAnimation();
     }
 
+    public void UpdateStartPosition(float x, float y)
+    {
+        X = x;
+        Y = y;
+        _lastX = x;
+        _lastY = y;
+
+        if (_defaults is CharacterSnapshot snapshot)
+        {
+            _defaults = snapshot with
+            {
+                X = x,
+                Y = y,
+                LastX = x,
+                LastY = y,
+            };
+        }
+        else
+        {
+            _defaults = new CharacterSnapshot(
+                x,
+                y,
+                x,
+                y,
+                Direction,
+                _previousDirection,
+                _nextAnimation,
+                _nextDirection,
+                _moving,
+                Mode,
+                _animation);
+            _defaultsCaptured = true;
+        }
+    }
+
     public void Reset()
     {
         if (_defaults is not CharacterSnapshot snapshot)


### PR DESCRIPTION
## Summary
- add an UpdateStartPosition helper to BlPacManCharacter so runtime resets keep new starting coordinates
- reapply the ghost house starting tile when level settings are configured to keep the ghosts inside the house

## Testing
- dotnet test Test/Blingo.PacMan.Tests/Blingo.PacMan.Tests.csproj *(fails: missing GameModelRepository/GhostMode references in the test project)*

------
https://chatgpt.com/codex/tasks/task_e_68d75ecac6f4833298aacb64ca9dc24f