### PR TITLE
Inline LPacMan background sizing callbacks

### DIFF
--- a/Demo/LPacMan/Blingo.PacMan.Core/BlPacManProjectFactory.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/BlPacManProjectFactory.cs
@@ -2,6 +2,7 @@
 using AbstUI.Texts;
 using Blingo.PacMan.Core.Engine;
 using Blingo.PacMan.Core.Game;
+using Blingo.PacMan.Core.Settings;
 using Blingo.PacMan.Core.Sprites.GameObjectBehaviors;
 using Blingo.PacMan.Core.Sprites.GeneralBehaviors;
 using Blingo.PacMan.Core.Sprites.ParentScripts;
@@ -10,6 +11,7 @@ using BlingoEngine.Core;
 using BlingoEngine.Members;
 using BlingoEngine.Movies;
 using BlingoEngine.Projects;
+using BlingoEngine.Sprites;
 using BlingoEngine.Setup;
 using BlingoEngine.Sounds;
 using BlingoEngine.Texts;
@@ -20,8 +22,8 @@ namespace Blingo.PacMan.Core;
 
 public class BlPacManProjectFactory : IBlingoProjectFactory
 {
-    public const int GameWidth = 448;   // (28) * 16 = 448
-    public const int GameHeight = 576;  // (36) * 16 = 576
+    public static int GameWidth => BlPacManTheme.Stage.Width;
+    public static int GameHeight => BlPacManTheme.Stage.Height;
 
     /// <summary>
     /// Name used throughout the project when referring to the root movie.
@@ -195,11 +197,20 @@ public class BlPacManProjectFactory : IBlingoProjectFactory
                 sprite.Name = "ContinousBackground";
                 sprite.Lock = true;
                 sprite.MemberSourceRect = ARect.New(0, 0, 10, 10);
+                sprite.Width = GameWidth;
+                sprite.Height = GameHeight;
             })
             .SetMember("start")
             .AddBehavior<BlPacManSoundManager>();
 
-        _movie.AddSprite(PCSpriteNums.GameBG, 1, GameStartFrame - 1, 0, 0, sprite => sprite.Lock = true).SetMember("start").AddBehavior<BlPacManMenuStartBehavior>(); ;
+        _movie.AddSprite(PCSpriteNums.GameBG, 1, GameStartFrame - 1, 0, 0, sprite =>
+            {
+                sprite.Lock = true;
+                sprite.Width = GameWidth;
+                sprite.Height = GameHeight;
+            })
+            .SetMember("start")
+            .AddBehavior<BlPacManMenuStartBehavior>();
 
         _movie.AddSprite(PCSpriteNums.BtnStart, 1, GameStartFrame - 1, (_movie.Width / 2) - 50, (_movie.Height / 2) +30).SetMember("T_Start"); // Button Start
 
@@ -212,8 +223,13 @@ public class BlPacManProjectFactory : IBlingoProjectFactory
 
         //var startPrompt = _movie.AddSprite(7, 1, GameStartFrame - 1, centerX, 120f, c => c.MemberSourceRect = new ARect(34, 3, 56, 27)).SetMember("misc");
 
-        var spriteBg = _movie.AddSprite(PCSpriteNums.GameBG, GameStartFrame, frameCount, 0, 0, sprite => sprite.Lock = true)
-            .SetMember("maze-1") ;
+        _movie.AddSprite(PCSpriteNums.GameBG, GameStartFrame, frameCount, 0, 0, sprite =>
+            {
+                sprite.Lock = true;
+                sprite.Width = GameWidth;
+                sprite.Height = GameHeight;
+            })
+            .SetMember("maze-1");
 
 
         var row1 = 5;

--- a/Demo/LPacMan/Blingo.PacMan.Core/Game/BlPacManBonusAvailableManager.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Game/BlPacManBonusAvailableManager.cs
@@ -91,7 +91,8 @@ namespace Blingo.PacMan.Core.Game
             sprite2D.LocH = x;
             sprite2D.LocV = y;
             sprite2D.SetMember("misc");
-            sprite2D.MemberSourceRect = ARect.New(((Tile.DefaultTileSize-1)* index) , 0, Tile.DefaultTileSize-1, Tile.DefaultTileSize-1);
+            var frameSize = TileMath.SpriteSize - 1;
+            sprite2D.MemberSourceRect = ARect.New(frameSize * index, 0, frameSize, frameSize);
 
             return new BonusSprite(name, sprite2D);
         }

--- a/Demo/LPacMan/Blingo.PacMan.Core/Game/BlPacManLivesManager.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Game/BlPacManLivesManager.cs
@@ -142,7 +142,8 @@ public sealed class BlPacManLivesManager
         sprite2D.Name = spriteName;
         sprite2D.Visibility = false;
         sprite2D.SetMember("sprites");
-        sprite2D.MemberSourceRect = ARect.New(0,0, Tile.DefaultTileSize, Tile.DefaultTileSize);
+        var frameSize = TileMath.SpriteSize;
+        sprite2D.MemberSourceRect = ARect.New(0,0, frameSize, frameSize);
 
         if (Math.Abs(ScaleFactor - 1f) > float.Epsilon)
         {

--- a/Demo/LPacMan/Blingo.PacMan.Core/Game/Tile.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Game/Tile.cs
@@ -1,4 +1,5 @@
 using Blingo.PacMan.Core.Enums;
+using Blingo.PacMan.Core.Settings;
 using Blingo.PacMan.Core.Sprites.GameObjectBehaviors;
 
 namespace Blingo.PacMan.Core.Game;
@@ -7,7 +8,7 @@ namespace Blingo.PacMan.Core.Game;
 /// </summary>
 internal static class TileMath
 {
-    public static int SpriteSize = 16;
+    public static int SpriteSize => BlPacManTheme.Actor.SpriteSize;
     /// <summary>
     /// Calculates the Euclidean distance between two map tiles. When either tile is missing,
     /// the method returns <see cref="float.PositiveInfinity"/> so callers can ignore that option.
@@ -48,8 +49,8 @@ internal static class TileMath
 }
 public sealed class Tile
 {
-    public const int DefaultTileSize = 16;
-    private const float _verticalCenterOffset = 2f;
+    public static int DefaultTileSize => BlPacManTheme.Tiles.Size;
+    private static float VerticalCenterOffset => BlPacManTheme.Tiles.VerticalCenterOffset;
 
     public char Code { get; }
 
@@ -78,7 +79,7 @@ public sealed class Tile
         Width = DefaultTileSize;
         Height = DefaultTileSize;
         CenterX = Column * Width + Width / 2f;
-        CenterY = Row * Height + Height / 2f + _verticalCenterOffset;
+        CenterY = Row * Height + Height / 2f + VerticalCenterOffset;
     }
 
     public bool IsWall() => Code == '=';

--- a/Demo/LPacMan/Blingo.PacMan.Core/Settings/BlPacManTheme.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Settings/BlPacManTheme.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using AbstUI.Primitives;
+using Blingo.PacMan.Core.Game;
+
+namespace Blingo.PacMan.Core.Settings;
+
+/// <summary>
+/// Centralises theme-specific geometry and animation declarations so swapping this file swaps the visual theme.
+/// </summary>
+public static class BlPacManTheme
+{
+    /// <summary>
+    /// Stage dimensions shared by every front-end.
+    /// </summary>
+    public static class Stage
+    {
+        public const int Width = 224;
+        public const int Height = 288;
+    }
+
+    /// <summary>
+    /// Tile metrics used to derive sprite placement and movement distances.
+    /// </summary>
+    public static class Tiles
+    {
+        public const int Size = 8;
+        public const float VerticalCenterOffset = Size / 8f;
+    }
+
+    /// <summary>
+    /// Animation frames and sprite information for Pac-Man himself.
+    /// </summary>
+    public static class Actor
+    {
+        public const int SpriteSize = Tiles.Size * 2;
+        public const int SpriteSheetY = 0;
+        private const int DefaultFrameDelay = 2;
+
+        /// <summary>
+        /// Animation loops keyed by their behaviour label.
+        /// </summary>
+        public static IReadOnlyDictionary<string, (ARect[] Frames, int FrameDelay)> Animations { get; } = BuildAnimations();
+
+        private static IReadOnlyDictionary<string, (ARect[] Frames, int FrameDelay)> BuildAnimations()
+        {
+            var animations = new Dictionary<string, (ARect[] Frames, int FrameDelay)>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["left"] = (CreateLoop(0), DefaultFrameDelay),
+                ["right"] = (CreateLoop(0), DefaultFrameDelay),
+                ["up"] = (CreateLoop(0), DefaultFrameDelay),
+                ["down"] = (CreateLoop(0), DefaultFrameDelay),
+            };
+
+            return animations;
+        }
+
+        private static ARect[] CreateLoop(int startColumn)
+        {
+            return new[]
+            {
+                CreateFrame(startColumn + 0),
+                CreateFrame(startColumn + 1),
+                CreateFrame(startColumn + 2),
+                CreateFrame(startColumn + 1),
+            };
+        }
+
+        private static ARect CreateFrame(int column)
+        {
+            var left = column * SpriteSize;
+            var top = SpriteSheetY;
+            return new ARect(left, top, left + SpriteSize, top + SpriteSize);
+        }
+    }
+
+    /// <summary>
+    /// Ghost sprite sheet coordinates and spawn offsets.
+    /// </summary>
+    public static class Ghosts
+    {
+        public const int SpriteSize = Tiles.Size * 2;
+
+        public static IReadOnlyDictionary<MrGhost, ARect> Sprites { get; } = new Dictionary<MrGhost, ARect>
+        {
+            [MrGhost.Blinky] = new ARect(SpriteSize * 0, 0, SpriteSize * 1, SpriteSize),
+            [MrGhost.Pinky] = new ARect(SpriteSize * 1, 0, SpriteSize * 2, SpriteSize),
+            [MrGhost.Inky] = new ARect(SpriteSize * 2, 0, SpriteSize * 3, SpriteSize),
+            [MrGhost.Clyde] = new ARect(SpriteSize * 3, 0, SpriteSize * 4, SpriteSize),
+        };
+
+        public static IReadOnlyDictionary<MrGhost, float> HorizontalOffsets { get; } = new Dictionary<MrGhost, float>
+        {
+            [MrGhost.Blinky] = -Tiles.Size,
+            [MrGhost.Pinky] = -Tiles.Size / 2f,
+            [MrGhost.Inky] = Tiles.Size / 2f,
+            [MrGhost.Clyde] = Tiles.Size,
+        };
+    }
+
+    /// <summary>
+    /// Frames and offsets for the roaming bonus fruit and score popups.
+    /// </summary>
+    public static class Bonus
+    {
+        public const float VerticalOffset = -14f;
+
+        public static int FrameSize => Actor.SpriteSize - 2;
+
+        public static IReadOnlyDictionary<string, ARect[]> Animations { get; } = BuildAnimations();
+
+        public static ARect DefaultFrame => Animations["default"][0];
+
+        private static IReadOnlyDictionary<string, ARect[]> BuildAnimations()
+        {
+            var animations = new Dictionary<string, ARect[]>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["default"] = new[] { CreateFrame(0, 0) },
+                ["score100"] = new[] { CreateFrame(0, FrameSize) },
+                ["score200"] = new[] { CreateFrame(FrameSize * 1, FrameSize) },
+                ["score500"] = new[] { CreateFrame(FrameSize * 2, FrameSize) },
+                ["score700"] = new[] { CreateFrame(FrameSize * 3, FrameSize) },
+                ["score1000"] = new[] { CreateFrame(FrameSize * 4, FrameSize) },
+                ["score2000"] = new[] { CreateFrame(FrameSize * 5, FrameSize) },
+                ["score5000"] = new[] { CreateFrame(FrameSize * 6, FrameSize) },
+            };
+
+            return animations;
+        }
+
+        private static ARect CreateFrame(int offsetX, int offsetY)
+        {
+            return new ARect(offsetX, offsetY, offsetX + FrameSize, offsetY + FrameSize);
+        }
+    }
+}

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManActorBehavior.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManActorBehavior.cs
@@ -13,6 +13,7 @@ using BlingoEngine.Movies;
 using BlingoEngine.Movies.Events;
 using BlingoEngine.Sprites;
 using BlingoEngine.Sprites.Events;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace Blingo.PacMan.Core.Sprites.GameObjectBehaviors;
@@ -27,20 +28,14 @@ internal sealed class BlPacManActorBehavior : BlingoSpriteBehavior,
     IHasKeyDownEvent,
     IHasExitFrameEvent
 {
-    public static int SprSize = 16;
-    public static int SprY = 0;
-    private static readonly ARect[] _leftAnimation =
-    {
-        ARect.New(SprSize * 0, SprY, SprSize, SprSize),
-        ARect.New(SprSize * 1, SprY, SprSize, SprSize),
-        ARect.New(SprSize * 2, SprY, SprSize, SprSize),
-        ARect.New(SprSize * 1, SprY, SprSize, SprSize),
-    };
-    private static readonly ARect[] _rightAnimation = _leftAnimation;
-    private static readonly ARect[] _upAnimation = _leftAnimation;
-    private static readonly ARect[] _downAnimation = _leftAnimation;
+    public static int SprSize => BlPacManTheme.Actor.SpriteSize;
+    public static int SprY => BlPacManTheme.Actor.SpriteSheetY;
+    private static readonly IReadOnlyDictionary<string, (ARect[] Frames, int FrameDelay)> _animationDefinitions =
+        BlPacManTheme.Actor.Animations;
 
-    //private static readonly ARect[] _leftAnimation =
+    // Legacy 16px sprite loops retained for reference. To reinstate them, move the values below into
+    // BlPacManTheme.Actor.Animations.
+    //var leftAnimation = new[]
     //{
     //    ARect.New(SprSize * 12, SprY, SprSize, SprSize),
     //    ARect.New(SprSize * 13, SprY, SprSize, SprSize),
@@ -50,7 +45,7 @@ internal sealed class BlPacManActorBehavior : BlingoSpriteBehavior,
     //    ARect.New(SprSize * 13, SprY, SprSize, SprSize),
     //};
 
-    //private static readonly ARect[] _rightAnimation =
+    //var rightAnimation = new[]
     //{
     //    ARect.New(SprSize * 0, SprY, SprSize, SprSize),
     //    ARect.New(SprSize * 1, SprY, SprSize, SprSize),
@@ -60,7 +55,7 @@ internal sealed class BlPacManActorBehavior : BlingoSpriteBehavior,
     //    ARect.New(SprSize * 1, SprY, SprSize, SprSize),
     //};
 
-    //private static readonly ARect[] _upAnimation =
+    //var upAnimation = new[]
     //{
     //    ARect.New(SprSize * 8,  SprY, SprSize, SprSize),
     //    ARect.New(SprSize * 9,  SprY, SprSize, SprSize),
@@ -70,7 +65,7 @@ internal sealed class BlPacManActorBehavior : BlingoSpriteBehavior,
     //    ARect.New(SprSize * 9,  SprY, SprSize, SprSize),
     //};
 
-    //private static readonly ARect[] _downAnimation =
+    //var downAnimation = new[]
     //{
     //    ARect.New(SprSize * 4, SprY, SprSize, SprSize),
     //    ARect.New(SprSize * 5, SprY, SprSize, SprSize),
@@ -337,10 +332,10 @@ internal sealed class BlPacManActorBehavior : BlingoSpriteBehavior,
     {
         SendSprite<BlPacManAnimationBehavior>(Me.SpriteNum, behavior =>
         {
-            behavior.SetAnimationRects("left", _leftAnimation, 2);
-            behavior.SetAnimationRects("right", _rightAnimation, 2);
-            behavior.SetAnimationRects("up", _upAnimation, 2);
-            behavior.SetAnimationRects("down", _downAnimation, 2);
+            foreach (var (name, definition) in _animationDefinitions)
+            {
+                behavior.SetAnimationRects(name, definition.Frames, definition.FrameDelay);
+            }
         });
     }
 

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManGameBehavior.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManGameBehavior.cs
@@ -1,3 +1,4 @@
+using Blingo.PacMan.Core;
 using Blingo.PacMan.Core.Datas;
 using Blingo.PacMan.Core.Engine;
 using Blingo.PacMan.Core.Game;
@@ -154,6 +155,11 @@ internal sealed class BlPacManGameBehavior : BlingoSpriteBehavior,
         _globals.BonusAvailableManager.Init(_Movie);
         _globals.LivesManager.Init(_Movie,_Player);
         _gameBG.SetMember(_currentGameSettings.MazeMemberName);
+        if (_gameBG.Sprite is BlingoSprite2D background)
+        {
+            background.Width = BlPacManProjectFactory.GameWidth;
+            background.Height = BlPacManProjectFactory.GameHeight;
+        }
 
     }
 

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManGhostBehavior.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManGhostBehavior.cs
@@ -10,6 +10,7 @@ using BlingoEngine.Movies;
 using BlingoEngine.Movies.Events;
 using BlingoEngine.Sprites;
 using BlingoEngine.Sprites.Events;
+using System.Collections.Generic;
 
 namespace Blingo.PacMan.Core.Sprites.GameObjectBehaviors;
 
@@ -23,22 +24,10 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
     IHasExitFrameEvent
 {
     // Sprite sheet rectangles for each ghost's default animation row.
-    private static readonly Dictionary<MrGhost, ARect> _ghostRects = new()
-    {
-        [MrGhost.Blinky] = new ARect(0, 0, 16, 16),
-        [MrGhost.Pinky] = new ARect(16, 0, 32, 16),
-        [MrGhost.Inky] = new ARect(32, 0, 48, 16),
-        [MrGhost.Clyde] = new ARect(48, 0, 64, 16),
-    };
+    private static readonly IReadOnlyDictionary<MrGhost, ARect> _ghostRects = BlPacManTheme.Ghosts.Sprites;
 
     // Horizontal offsets to stagger the ghosts within the house at level start.
-    private static readonly Dictionary<MrGhost, float> _horizontalOffsets = new()
-    {
-        [MrGhost.Blinky] = -16f,
-        [MrGhost.Pinky] = -8f,
-        [MrGhost.Inky] = 8f,
-        [MrGhost.Clyde] = 16f,
-    };
+    private static readonly IReadOnlyDictionary<MrGhost, float> _horizontalOffsets = BlPacManTheme.Ghosts.HorizontalOffsets;
 
     // Initial direction per ghost to mirror the arcade openings.
     private static readonly Dictionary<MrGhost, BlPacManDirection> _initialDirections = new()
@@ -301,7 +290,8 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
         }
         else
         {
-            Me.MemberSourceRect = new ARect(0, 0, 16, 16);
+            var size = BlPacManTheme.Ghosts.SpriteSize;
+            Me.MemberSourceRect = new ARect(0, 0, size, size);
         }
 
         var map = _globals.Map;

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManRoamingBonusBehavior.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManRoamingBonusBehavior.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using AbstUI.Primitives;
 using Blingo.PacMan.Core.Datas;
 using Blingo.PacMan.Core.Engine;
@@ -22,18 +23,8 @@ internal sealed class BlPacManRoamingBonusBehavior : BlingoSpriteBehavior,
     IHasBeginSpriteEvent,
     IHasEndSpriteEvent
 {
-    private static int _frameSize = TileMath.SpriteSize-2;
-    private const float _verticalOffset = -14f;
-
-    private static readonly ARect[] _defaultAnimation = { CreateFrame(0, 0) };
-    internal static ARect DefaultAnimationRect =>_defaultAnimation[0];
-    private static readonly ARect[] _score100Animation = { CreateFrame(0, _frameSize) };
-    private static readonly ARect[] _score200Animation = { CreateFrame(_frameSize, _frameSize) };
-    private static readonly ARect[] _score500Animation = { CreateFrame(_frameSize * 2, _frameSize) };
-    private static readonly ARect[] _score700Animation = { CreateFrame(_frameSize * 3, _frameSize) };
-    private static readonly ARect[] _score1000Animation = { CreateFrame(_frameSize * 4, _frameSize) };
-    private static readonly ARect[] _score2000Animation = { CreateFrame(_frameSize * 5, _frameSize) };
-    private static readonly ARect[] _score5000Animation = { CreateFrame(_frameSize * 6, _frameSize) };
+    private static readonly IReadOnlyDictionary<string, ARect[]> _animations = BlPacManTheme.Bonus.Animations;
+    internal static ARect DefaultAnimationRect => BlPacManTheme.Bonus.DefaultFrame;
 
     private readonly GlobalVars _globals;
     private GameSettings? _settings;
@@ -201,7 +192,7 @@ internal sealed class BlPacManRoamingBonusBehavior : BlingoSpriteBehavior,
         if (member != null)
         {
             Me.Member = member;
-            Me.MemberSourceRect = _defaultAnimation[0];
+            Me.MemberSourceRect = BlPacManTheme.Bonus.DefaultFrame;
         }
 
         ParseMap();
@@ -209,7 +200,7 @@ internal sealed class BlPacManRoamingBonusBehavior : BlingoSpriteBehavior,
         if (_spawnTile is not null)
         {
             Me.LocH = _spawnTile.CenterX;
-            Me.LocV = _spawnTile.CenterY + _verticalOffset;
+            Me.LocV = _spawnTile.CenterY + BlPacManTheme.Bonus.VerticalOffset;
         }
 
         EnsureAnimations();
@@ -267,14 +258,10 @@ internal sealed class BlPacManRoamingBonusBehavior : BlingoSpriteBehavior,
 
         SendSprite<BlPacManAnimationBehavior>(Me.SpriteNum, behavior =>
         {
-            behavior.SetAnimationRects("default", _defaultAnimation, 0);
-            behavior.SetAnimationRects("score100", _score100Animation, 0);
-            behavior.SetAnimationRects("score200", _score200Animation, 0);
-            behavior.SetAnimationRects("score500", _score500Animation, 0);
-            behavior.SetAnimationRects("score700", _score700Animation, 0);
-            behavior.SetAnimationRects("score1000", _score1000Animation, 0);
-            behavior.SetAnimationRects("score2000", _score2000Animation, 0);
-            behavior.SetAnimationRects("score5000", _score5000Animation, 0);
+            foreach (var (name, frames) in _animations)
+            {
+                behavior.SetAnimationRects(name, frames, 0);
+            }
         });
 
         _animationsConfigured = true;
@@ -371,10 +358,4 @@ internal sealed class BlPacManRoamingBonusBehavior : BlingoSpriteBehavior,
         var next = tile.Get(direction);
         return next is not null && !next.IsWall() && !next.IsHouse();
     }
-
-    /// <summary>
-    /// Utility for generating sprite-sheet rectangles.
-    /// </summary>
-    private static ARect CreateFrame(int offsetX, int offsetY) 
-        => new ARect(offsetX, offsetY, offsetX + _frameSize, offsetY + _frameSize);
 }


### PR DESCRIPTION
## Summary
- add a BlPacManTheme settings module that centralizes stage dimensions, tile metrics, and sprite animation data
- refactor LPacMan factory, tile helpers, and gameplay behaviors to source sizes and animations from the shared theme
- set the background sprites' width and height directly within their initialization callbacks to preserve the fluent setup style

## Testing
- dotnet build Demo/LPacMan/Blingo.PacMan.Core/Blingo.PacMan.Core.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d6a48ff5588332b80f960f647cd329