### PR TITLE
Simplify cast import workflow

### DIFF
--- a/WillMoveToOwnRepo/AbstUI/src/AbstUI/Tasks/TaskMessageType.cs
+++ b/WillMoveToOwnRepo/AbstUI/src/AbstUI/Tasks/TaskMessageType.cs
@@ -1,0 +1,8 @@
+namespace AbstUI.Tasks;
+
+public enum TaskMessageType
+{
+    Info,
+    Warning,
+    Error
+}

--- a/src/BlingoEngine/Casts/BlingoCast.cs
+++ b/src/BlingoEngine/Casts/BlingoCast.cs
@@ -1,4 +1,6 @@
-﻿using AbstUI.Primitives;
+﻿using System;
+using System.Collections.Generic;
+using AbstUI.Primitives;
 using BlingoEngine.Bitmaps;
 using BlingoEngine.ColorPalettes;
 using BlingoEngine.Core;
@@ -21,6 +23,8 @@ namespace BlingoEngine.Casts
     /// <inheritdoc/>
     public class BlingoCast : IBlingoCast
     {
+
+        private const int MaxCastSlotNumber = 999;
 
         private readonly BlingoCastLibsContainer _castLibsContainer;
         private readonly IBlingoFrameworkFactory _factory;
@@ -88,6 +92,36 @@ namespace BlingoEngine.Casts
         }
         /// <inheritdoc/>
         public int FindEmpty() => _membersContainer.FindEmpty();
+
+        public IReadOnlyList<int> ResolveFreeSlotNumbers(int startSlot, int requiredCount)
+        {
+            if (requiredCount <= 0)
+                return Array.Empty<int>();
+
+            var slots = new List<int>(requiredCount);
+            var used = new HashSet<int>();
+
+            int start = startSlot;
+            if (start < 1 || start > MaxCastSlotNumber)
+            {
+                var fallback = FindEmpty();
+                start = fallback >= 1 && fallback <= MaxCastSlotNumber ? fallback : 1;
+            }
+
+            for (int slot = start; slot <= MaxCastSlotNumber && slots.Count < requiredCount; slot++)
+            {
+                if (_membersContainer[slot] == null && used.Add(slot))
+                    slots.Add(slot);
+            }
+
+            for (int slot = 1; slot < start && slots.Count < requiredCount; slot++)
+            {
+                if (_membersContainer[slot] == null && used.Add(slot))
+                    slots.Add(slot);
+            }
+
+            return slots;
+        }
         internal int GetUniqueNumber(int numberInCast)
         {
             //if (Number == 1 ? ((member.CastLibNum - 1) * 131114 : numberInCast : _cast.GetUniqueNumber();

--- a/src/BlingoEngine/Casts/IBlingoCast.cs
+++ b/src/BlingoEngine/Casts/IBlingoCast.cs
@@ -1,4 +1,5 @@
 ﻿using AbstUI.Primitives;
+using System.Collections.Generic;
 using BlingoEngine.Core;
 using BlingoEngine.Members;
 using System;
@@ -60,6 +61,14 @@ namespace BlingoEngine.Casts
         /// displays the next empty cast member position or the position after a specified cast member. This method is available only on the current cast library.
         /// </summary>
         int FindEmpty();
+
+        /// <summary>
+        /// Resolves the next available cast member slots starting from a given slot number.
+        /// </summary>
+        /// <param name="startSlot">The slot number used as a starting point. When zero or negative the search starts from the first available slot.</param>
+        /// <param name="requiredCount">The number of slots that should be returned.</param>
+        /// <returns>A list containing up to <paramref name="requiredCount"/> available slot numbers ordered by appearance.</returns>
+        IReadOnlyList<int> ResolveFreeSlotNumbers(int startSlot, int requiredCount);
         IBlingoMember Add(BlingoMemberType type, int numberInCast, string name, string fileName = "", APoint regPoint = default);
         T Add<T>(int numberInCast, string name, Action<T>? configure = null) where T: IBlingoMember;
 

--- a/src/Director/BlingoEngine.Director.Core/Casts/Commands/DirCastImportDialogHandler.cs
+++ b/src/Director/BlingoEngine.Director.Core/Casts/Commands/DirCastImportDialogHandler.cs
@@ -1,0 +1,44 @@
+using System;
+using AbstUI.Commands;
+using AbstUI.Windowing;
+using BlingoEngine.Director.Core.UI;
+using BlingoEngine.Projects;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BlingoEngine.Director.Core.Casts.Commands;
+
+public class DirCastImportDialogHandler : IAbstCommandHandler<OpenCastImportDialogCommand>
+{
+    private readonly IServiceProvider _services;
+    private readonly IAbstWindowManager _windowManager;
+    private readonly BlingoProjectSettings _projectSettings;
+
+    public DirCastImportDialogHandler(
+        IServiceProvider services,
+        IAbstWindowManager windowManager,
+        BlingoProjectSettings projectSettings)
+    {
+        _services = services;
+        _windowManager = windowManager;
+        _projectSettings = projectSettings;
+    }
+
+    public bool CanExecute(OpenCastImportDialogCommand command) => command.Cast != null;
+
+    public bool Handle(OpenCastImportDialogCommand command)
+    {
+        if (!_projectSettings.HasValidSettings)
+        {
+            _windowManager.OpenWindow(DirectorMenuCodes.ProjectSettingsWindow);
+            _windowManager.ShowNotification(
+                "Configure the project settings before importing members.",
+                AbstUINotificationType.Warning);
+            return false;
+        }
+
+        var dialog = _services.GetRequiredService<DirCastImportDialog>();
+        dialog.Configure(command.Cast, command.StartSlot);
+        _windowManager.ShowCustomDialog("Import cast members", dialog.GetFrameworkPanel());
+        return true;
+    }
+}

--- a/src/Director/BlingoEngine.Director.Core/Casts/Commands/OpenCastImportDialogCommand.cs
+++ b/src/Director/BlingoEngine.Director.Core/Casts/Commands/OpenCastImportDialogCommand.cs
@@ -1,0 +1,9 @@
+using AbstUI.Commands;
+using BlingoEngine.Casts;
+using BlingoEngine.Director.Core.Casts;
+
+namespace BlingoEngine.Director.Core.Casts.Commands;
+
+public sealed record OpenCastImportDialogCommand(
+    IBlingoCast Cast,
+    int StartSlot) : IAbstCommand;

--- a/src/Director/BlingoEngine.Director.Core/Casts/DirCastImportDialog.cs
+++ b/src/Director/BlingoEngine.Director.Core/Casts/DirCastImportDialog.cs
@@ -1,0 +1,343 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using AbstUI.Components.Buttons;
+using AbstUI.Components.Containers;
+using AbstUI.Components.Inputs;
+using AbstUI.Components.Texts;
+using AbstUI.Primitives;
+using AbstUI.Windowing;
+using AbstUI.Tasks;
+using BlingoEngine.Casts;
+using BlingoEngine.Director.Core.Events;
+using BlingoEngine.Director.Core.FileSystems;
+using BlingoEngine.Director.Core.Tools;
+using BlingoEngine.Director.Core.Styles;
+using BlingoEngine.Projects;
+using BlingoEngine.FrameworkCommunication;
+
+namespace BlingoEngine.Director.Core.Casts;
+
+public class DirCastImportDialog
+{
+    private const string FileFilter = "*.* ; All Files";
+
+    private readonly IBlingoFrameworkFactory _factory;
+    private readonly IDirFilePicker _filePicker;
+    private readonly IDirFolderPicker _folderPicker;
+    private readonly IDirectorEventMediator _mediator;
+    private readonly IDirCastImportService _importService;
+    private readonly BlingoProjectSettings _projectSettings;
+    private readonly IAbstWindowManager _windowManager;
+
+    private readonly List<string> _selectedFiles = new();
+    private readonly AbstPanel _root;
+    private readonly AbstLabel _castLabel;
+    private readonly AbstLabel _slotLabel;
+    private readonly AbstInputText _targetFolderInput;
+    private readonly AbstButton _importButton;
+    private readonly AbstWrapPanel _fileListPanel;
+    private readonly AbstWrapPanel _messagePanel;
+
+    private IBlingoCast? _cast;
+    private int _startSlot;
+    private string? _targetFolder;
+
+    public DirCastImportDialog(
+        IBlingoFrameworkFactory factory,
+        IDirFilePicker filePicker,
+        IDirFolderPicker folderPicker,
+        IDirectorEventMediator mediator,
+        IDirCastImportService importService,
+        BlingoProjectSettings projectSettings,
+        IAbstWindowManager windowManager)
+    {
+        _factory = factory;
+        _filePicker = filePicker;
+        _folderPicker = folderPicker;
+        _mediator = mediator;
+        _importService = importService;
+        _projectSettings = projectSettings;
+        _windowManager = windowManager;
+
+        _root = BuildRoot(
+            out _castLabel,
+            out _slotLabel,
+            out _targetFolderInput,
+            out _importButton,
+            out _fileListPanel,
+            out _messagePanel);
+    }
+
+    public IAbstFrameworkPanel GetFrameworkPanel() => _root.Framework<IAbstFrameworkPanel>();
+
+    public void Configure(IBlingoCast cast, int startSlot)
+    {
+        _cast = cast ?? throw new ArgumentNullException(nameof(cast));
+        _startSlot = Math.Max(1, startSlot);
+
+        _castLabel.Text = $"Cast: {cast.Name ?? $"Cast {cast.Number}"}";
+        _slotLabel.Text = $"Start slot: {_startSlot}";
+
+        _targetFolder = Directory.Exists(_projectSettings.ProjectFolder)
+            ? _projectSettings.ProjectFolder
+            : string.Empty;
+        _targetFolderInput.Text = _targetFolder ?? string.Empty;
+
+        _selectedFiles.Clear();
+        UpdateFileList();
+        ClearMessages();
+        UpdateImportButtonState();
+    }
+
+    private AbstPanel BuildRoot(
+        out AbstLabel castLabel,
+        out AbstLabel slotLabel,
+        out AbstInputText targetFolderInput,
+        out AbstButton importButton,
+        out AbstWrapPanel fileListPanel,
+        out AbstWrapPanel messagePanel)
+    {
+        var root = _factory.CreatePanel("CastImportRoot");
+        root.Width = 520;
+        root.Height = 420;
+        root.BackgroundColor = DirectorColors.BG_WhiteMenus;
+
+        var content = _factory.CreateWrapPanel(AOrientation.Vertical, "CastImportContent");
+        content.Width = 500;
+        content.Height = 400;
+        content.ItemMargin = new APoint(0, 8);
+        content.Margin = new AMargin(10, 10, 10, 10);
+        root.AddItem(content);
+
+        var castInfo = _factory.CreateWrapPanel(AOrientation.Vertical, "CastImportHeader");
+        castInfo.Width = 480;
+        castInfo.ItemMargin = new APoint(0, 4);
+        content.AddItem(castInfo);
+
+        castLabel = _factory.CreateLabel("CastImportCastLabel", string.Empty);
+        castInfo.AddItem(castLabel);
+
+        slotLabel = _factory.CreateLabel("CastImportSlotLabel", string.Empty);
+        castInfo.AddItem(slotLabel);
+
+        var fileButtons = _factory.CreateWrapPanel(AOrientation.Horizontal, "CastImportFileButtons");
+        fileButtons.Width = 480;
+        fileButtons.ItemMargin = new APoint(6, 0);
+        content.AddItem(fileButtons);
+
+        var selectFiles = _factory.CreateButton("CastImportSelectFiles", "Select files...");
+        selectFiles.Width = 140;
+        selectFiles.Height = 26;
+        selectFiles.Pressed += OnSelectFiles;
+        fileButtons.AddItem(selectFiles);
+
+        var clearFiles = _factory.CreateButton("CastImportClearFiles", "Clear");
+        clearFiles.Width = 80;
+        clearFiles.Height = 26;
+        clearFiles.Pressed += () =>
+        {
+            _selectedFiles.Clear();
+            UpdateFileList();
+        };
+        fileButtons.AddItem(clearFiles);
+
+        var fileScroll = _factory.CreateScrollContainer("CastImportFileScroll");
+        fileScroll.Width = 480;
+        fileScroll.Height = 140;
+        content.AddItem(fileScroll);
+
+        fileListPanel = _factory.CreateWrapPanel(AOrientation.Vertical, "CastImportFilesPanel");
+        fileListPanel.Width = 460;
+        fileListPanel.ItemMargin = new APoint(0, 2);
+        fileScroll.AddItem(fileListPanel);
+
+        var folderRow = _factory.CreateWrapPanel(AOrientation.Horizontal, "CastImportFolderRow");
+        folderRow.Width = 480;
+        folderRow.ItemMargin = new APoint(6, 0);
+        content.AddItem(folderRow);
+
+        targetFolderInput = _factory.CreateInputText("CastImportTargetFolder", 0, OnTargetFolderChanged);
+        targetFolderInput.Width = 360;
+        targetFolderInput.Height = 26;
+        folderRow.AddItem(targetFolderInput);
+
+        var browseButton = _factory.CreateButton("CastImportBrowseFolder", "Browse...");
+        browseButton.Width = 100;
+        browseButton.Height = 26;
+        browseButton.Pressed += OnBrowseFolder;
+        folderRow.AddItem(browseButton);
+
+        importButton = _factory.CreateButton("CastImportRunButton", "Import");
+        importButton.Width = 120;
+        importButton.Height = 30;
+        importButton.Pressed += ExecuteImport;
+        content.AddItem(importButton);
+
+        messagePanel = _factory.CreateWrapPanel(AOrientation.Vertical, "CastImportMessages");
+        messagePanel.Width = 480;
+        messagePanel.Height = 120;
+        messagePanel.ItemMargin = new APoint(0, 2);
+        content.AddItem(messagePanel);
+
+        return root;
+    }
+
+    private void OnSelectFiles()
+    {
+        var startPath = !string.IsNullOrWhiteSpace(_targetFolder) && Directory.Exists(_targetFolder)
+            ? _targetFolder
+            : _projectSettings.ProjectFolder;
+
+        _filePicker.PickFiles(files =>
+        {
+            if (files == null || files.Count == 0)
+                return;
+
+            _selectedFiles.Clear();
+            foreach (var file in files)
+            {
+                if (!string.IsNullOrWhiteSpace(file))
+                    _selectedFiles.Add(file);
+            }
+
+            UpdateFileList();
+        }, FileFilter, startPath);
+    }
+
+    private void OnBrowseFolder()
+    {
+        var startPath = !string.IsNullOrWhiteSpace(_targetFolder) && Directory.Exists(_targetFolder)
+            ? _targetFolder
+            : _projectSettings.ProjectFolder;
+
+        _folderPicker.PickFolder(folder =>
+        {
+            if (string.IsNullOrWhiteSpace(folder))
+                return;
+
+            _targetFolder = folder;
+            _targetFolderInput.Text = folder;
+            UpdateImportButtonState();
+        }, startPath);
+    }
+
+    private void OnTargetFolderChanged(string folder)
+    {
+        _targetFolder = folder;
+        UpdateImportButtonState();
+    }
+
+    private void ExecuteImport()
+    {
+        if (_cast == null)
+            return;
+
+        var targetFolder = _targetFolder ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(targetFolder))
+            return;
+
+        var result = _importService.ImportMembers(
+            _cast,
+            _projectSettings.ProjectFolder,
+            targetFolder,
+            _startSlot,
+            _selectedFiles);
+
+        ShowMessages(result.Messages);
+        NotifyMessages(result.Messages);
+
+        if (result.ImportedCount > 0)
+        {
+            if (result.LastImportedMember is { } member)
+            {
+                _mediator.RaiseFindMember(member);
+                _mediator.RaiseMemberSelected(member);
+            }
+            _windowManager.ShowNotification($"Imported {result.ImportedCount} member(s).", AbstUINotificationType.Info);
+        }
+        else if (result.Messages.Count == 0)
+        {
+            _windowManager.ShowNotification("No members were imported.", AbstUINotificationType.Warning);
+        }
+
+        UpdateImportButtonState();
+    }
+
+    private void UpdateFileList()
+    {
+        _fileListPanel.RemoveAll();
+        if (_selectedFiles.Count == 0)
+        {
+            var label = _factory.CreateLabel("CastImportNoFiles", "No files selected.");
+            label.FontColor = DirectorColors.TextColorDisabled;
+            _fileListPanel.AddItem(label);
+        }
+        else
+        {
+            for (var i = 0; i < _selectedFiles.Count; i++)
+            {
+                var file = _selectedFiles[i];
+                var label = _factory.CreateLabel($"CastImportFile_{i}", Path.GetFileName(file));
+                _fileListPanel.AddItem(label);
+            }
+        }
+
+        UpdateImportButtonState();
+    }
+
+    private void ClearMessages()
+    {
+        _messagePanel.RemoveAll();
+        var label = _factory.CreateLabel("CastImportNoMessages", "Messages will appear here.");
+        label.FontColor = DirectorColors.TextColorDisabled;
+        _messagePanel.AddItem(label);
+    }
+
+    private void ShowMessages(IReadOnlyList<DirCastImportMessage> messages)
+    {
+        _messagePanel.RemoveAll();
+
+        if (messages.Count == 0)
+        {
+            ClearMessages();
+            return;
+        }
+
+        var index = 0;
+        foreach (var message in messages)
+        {
+            var label = _factory.CreateLabel($"CastImportMessage_{index}", message.Text);
+            label.FontColor = GetMessageColor(message.Type);
+            _messagePanel.AddItem(label);
+            index++;
+        }
+    }
+
+    private void UpdateImportButtonState()
+    {
+        _importButton.Enabled = _selectedFiles.Count > 0 && !string.IsNullOrWhiteSpace(_targetFolder);
+    }
+
+    private void NotifyMessages(IReadOnlyList<DirCastImportMessage> messages)
+    {
+        foreach (var message in messages)
+        {
+            _windowManager.ShowNotification(message.Text, ToNotificationType(message.Type));
+        }
+    }
+
+    private static AbstUINotificationType ToNotificationType(TaskMessageType type) => type switch
+    {
+        TaskMessageType.Error => AbstUINotificationType.Error,
+        TaskMessageType.Warning => AbstUINotificationType.Warning,
+        _ => AbstUINotificationType.Info
+    };
+
+    private static AColor GetMessageColor(TaskMessageType type) => type switch
+    {
+        TaskMessageType.Error => new AColor(180, 0, 0),
+        TaskMessageType.Warning => new AColor(170, 110, 0),
+        _ => DirectorColors.TextColorLabels
+    };
+}

--- a/src/Director/BlingoEngine.Director.Core/Casts/DirCastImportService.cs
+++ b/src/Director/BlingoEngine.Director.Core/Casts/DirCastImportService.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using AbstUI.Tasks;
+using BlingoEngine.Casts;
+using BlingoEngine.Members;
+
+namespace BlingoEngine.Director.Core.Casts
+{
+    public record DirCastImportMessage(TaskMessageType Type, string Text);
+
+    public record DirCastImportResult(int ImportedCount, IBlingoMember? LastImportedMember, IReadOnlyList<DirCastImportMessage> Messages);
+
+    public interface IDirCastImportService
+    {
+        DirCastImportResult ImportMembers(IBlingoCast cast, string? projectRoot, string targetFolder, int startSlot, IReadOnlyList<string> sourceFiles);
+    }
+
+    public class DirCastImportService : IDirCastImportService
+    {
+        private static readonly Dictionary<string, BlingoMemberType> FileTypeMap = new(StringComparer.OrdinalIgnoreCase)
+        {
+            [".png"] = BlingoMemberType.Bitmap,
+            [".jpg"] = BlingoMemberType.Bitmap,
+            [".jpeg"] = BlingoMemberType.Bitmap,
+            [".gif"] = BlingoMemberType.Bitmap,
+            [".bmp"] = BlingoMemberType.Bitmap,
+            [".tga"] = BlingoMemberType.Bitmap,
+            [".wav"] = BlingoMemberType.Sound,
+            [".mp3"] = BlingoMemberType.Sound,
+            [".ogg"] = BlingoMemberType.Sound,
+            [".aiff"] = BlingoMemberType.Sound,
+            [".aif"] = BlingoMemberType.Sound,
+            [".txt"] = BlingoMemberType.Text,
+            [".rtf"] = BlingoMemberType.Field,
+            [".cs"] = BlingoMemberType.Script,
+            [".ls"] = BlingoMemberType.Script,
+            [".lingo"] = BlingoMemberType.Script
+        };
+
+        public DirCastImportResult ImportMembers(IBlingoCast cast, string? projectRoot, string targetFolder, int startSlot, IReadOnlyList<string> sourceFiles)
+        {
+            if (cast == null)
+                throw new ArgumentNullException(nameof(cast));
+
+            var messages = new List<DirCastImportMessage>();
+
+            if (sourceFiles == null || sourceFiles.Count == 0)
+                return new DirCastImportResult(0, null, messages);
+
+            var normalizedFiles = NormalizeFiles(sourceFiles, messages);
+            if (normalizedFiles.Count == 0)
+                return new DirCastImportResult(0, null, messages);
+
+            if (string.IsNullOrWhiteSpace(projectRoot))
+            {
+                messages.Add(new DirCastImportMessage(TaskMessageType.Error, "Project folder is not configured."));
+                return new DirCastImportResult(0, null, messages);
+            }
+
+            string normalizedProjectRoot;
+            try
+            {
+                normalizedProjectRoot = Path.GetFullPath(projectRoot);
+            }
+            catch (Exception ex)
+            {
+                messages.Add(new DirCastImportMessage(TaskMessageType.Error, $"Project folder is invalid: {ex.Message}"));
+                return new DirCastImportResult(0, null, messages);
+            }
+
+            if (!Directory.Exists(normalizedProjectRoot))
+            {
+                messages.Add(new DirCastImportMessage(TaskMessageType.Error, "Project folder does not exist."));
+                return new DirCastImportResult(0, null, messages);
+            }
+
+            string normalizedTargetFolder;
+            try
+            {
+                normalizedTargetFolder = Path.GetFullPath(targetFolder);
+            }
+            catch (Exception ex)
+            {
+                messages.Add(new DirCastImportMessage(TaskMessageType.Error, $"Destination folder is invalid: {ex.Message}"));
+                return new DirCastImportResult(0, null, messages);
+            }
+
+            if (!normalizedTargetFolder.StartsWith(normalizedProjectRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                messages.Add(new DirCastImportMessage(TaskMessageType.Error, "Please select a folder inside the project directory."));
+                return new DirCastImportResult(0, null, messages);
+            }
+
+            try
+            {
+                Directory.CreateDirectory(normalizedTargetFolder);
+            }
+            catch (Exception ex)
+            {
+                messages.Add(new DirCastImportMessage(TaskMessageType.Error, $"Failed to create destination folder: {ex.Message}"));
+                return new DirCastImportResult(0, null, messages);
+            }
+
+            var slots = cast.ResolveFreeSlotNumbers(startSlot, normalizedFiles.Count);
+            if (slots.Count == 0)
+            {
+                messages.Add(new DirCastImportMessage(TaskMessageType.Warning, "No empty cast slots are available."));
+                return new DirCastImportResult(0, null, messages);
+            }
+
+            if (slots.Count < normalizedFiles.Count)
+            {
+                messages.Add(new DirCastImportMessage(TaskMessageType.Warning, $"Only {slots.Count} of {normalizedFiles.Count} file(s) can be imported because the cast has no additional empty slots."));
+            }
+
+            int importLimit = Math.Min(slots.Count, normalizedFiles.Count);
+            int imported = 0;
+            IBlingoMember? lastImported = null;
+
+            for (int i = 0; i < importLimit; i++)
+            {
+                var sourcePath = normalizedFiles[i];
+
+                if (!File.Exists(sourcePath))
+                {
+                    messages.Add(new DirCastImportMessage(TaskMessageType.Warning, $"File not found: {sourcePath}"));
+                    continue;
+                }
+
+                if (!TryResolveMemberType(sourcePath, out var memberType))
+                {
+                    messages.Add(new DirCastImportMessage(TaskMessageType.Warning, $"Unsupported member type for \"{Path.GetFileName(sourcePath)}\"."));
+                    continue;
+                }
+
+                var destinationPath = EnsureUniqueFileName(Path.Combine(normalizedTargetFolder, Path.GetFileName(sourcePath)));
+                try
+                {
+                    File.Copy(sourcePath, destinationPath, overwrite: false);
+                }
+                catch (Exception ex)
+                {
+                    messages.Add(new DirCastImportMessage(TaskMessageType.Error, $"Failed to copy \"{Path.GetFileName(sourcePath)}\": {ex.Message}"));
+                    continue;
+                }
+
+                var relativePath = Path.GetRelativePath(normalizedProjectRoot, destinationPath)
+                    .Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+                var memberName = Path.GetFileNameWithoutExtension(destinationPath);
+                int slot = slots[i];
+
+                try
+                {
+                    lastImported = cast.Add(memberType, slot, memberName, relativePath);
+                    imported++;
+                }
+                catch (Exception ex)
+                {
+                    messages.Add(new DirCastImportMessage(TaskMessageType.Error, $"Failed to add cast member for \"{Path.GetFileName(sourcePath)}\": {ex.Message}"));
+                }
+            }
+
+            return new DirCastImportResult(imported, lastImported, messages);
+        }
+
+        private static List<string> NormalizeFiles(IReadOnlyList<string> files, List<DirCastImportMessage> messages)
+        {
+            var normalized = new List<string>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var file in files)
+            {
+                if (string.IsNullOrWhiteSpace(file))
+                    continue;
+
+                try
+                {
+                    var fullPath = Path.GetFullPath(file);
+                    if (seen.Add(fullPath))
+                        normalized.Add(fullPath);
+                }
+                catch (Exception ex)
+                {
+                    messages.Add(new DirCastImportMessage(TaskMessageType.Warning, $"Skipping \"{file}\": {ex.Message}"));
+                }
+            }
+
+            return normalized;
+        }
+
+        private static bool TryResolveMemberType(string filePath, out BlingoMemberType memberType)
+        {
+            var extension = Path.GetExtension(filePath);
+            if (string.IsNullOrWhiteSpace(extension))
+            {
+                memberType = BlingoMemberType.Unknown;
+                return false;
+            }
+
+            if (FileTypeMap.TryGetValue(extension, out memberType))
+                return true;
+
+            memberType = BlingoMemberType.Unknown;
+            return false;
+        }
+
+        private static string EnsureUniqueFileName(string destinationPath)
+        {
+            if (!File.Exists(destinationPath))
+                return destinationPath;
+
+            var directory = Path.GetDirectoryName(destinationPath) ?? string.Empty;
+            var name = Path.GetFileNameWithoutExtension(destinationPath);
+            var extension = Path.GetExtension(destinationPath);
+
+            int counter = 1;
+            string candidate;
+            do
+            {
+                candidate = Path.Combine(directory, $"{name}_{counter}{extension}");
+                counter++;
+            }
+            while (File.Exists(candidate));
+
+            return candidate;
+        }
+    }
+}
+

--- a/src/Director/BlingoEngine.Director.Core/Casts/DirCastItem.cs
+++ b/src/Director/BlingoEngine.Director.Core/Casts/DirCastItem.cs
@@ -28,6 +28,7 @@ public class DirCastItem : IDirCastItem
 
     public IBlingoMember? Member => _member;
     public AbstGfxCanvas Canvas => _canvas;
+    public int SlotNumber => _slotNumber;
 
     public DirCastItem(IBlingoFrameworkFactory factory, IBlingoMember? member, int slotNumber, IDirectorIconManager? iconManager)
     {

--- a/src/Director/BlingoEngine.Director.Core/Casts/DirCastTab.cs
+++ b/src/Director/BlingoEngine.Director.Core/Casts/DirCastTab.cs
@@ -1,23 +1,26 @@
-﻿using System.Collections.Generic;
-using BlingoEngine.FrameworkCommunication;
-using BlingoEngine.Members;
+using System;
+using System.Collections.Generic;
 using AbstUI.Commands;
-using BlingoEngine.Director.Core.Scripts.Commands;
-using BlingoEngine.Director.Core.Tools;
-using BlingoEngine.Director.Core.Icons;
-using BlingoEngine.Events;
-using BlingoEngine.Texts;
+using AbstUI.Components.Buttons;
+using AbstUI.Components.Containers;
+using AbstUI.Inputs;
+using AbstUI.Primitives;
+using AbstUI.Windowing;
+using AbstUI.Windowing.Commands;
 using BlingoEngine.Bitmaps;
-using BlingoEngine.Scripts;
-using BlingoEngine.Director.Core.UI;
 using BlingoEngine.Casts;
 using BlingoEngine.Core;
-using AbstUI.Primitives;
-using AbstUI.Inputs;
+using BlingoEngine.Director.Core.Casts.Commands;
+using BlingoEngine.Director.Core.Icons;
+using BlingoEngine.Director.Core.Scripts.Commands;
 using BlingoEngine.Director.Core.Styles;
-using AbstUI.Components.Containers;
-using AbstUI.Components.Buttons;
-using AbstUI.Windowing.Commands;
+using BlingoEngine.Director.Core.Tools;
+using BlingoEngine.Director.Core.UI;
+using BlingoEngine.Events;
+using BlingoEngine.FrameworkCommunication;
+using BlingoEngine.Members;
+using BlingoEngine.Scripts;
+using BlingoEngine.Texts;
 
 namespace BlingoEngine.Director.Core.Casts
 {
@@ -38,6 +41,7 @@ namespace BlingoEngine.Director.Core.Casts
         private readonly IBlingoFrameworkFactory _factory;
         private readonly IDirectorIconManager _iconManager;
         private readonly MemberNavigationBar _navBar;
+        private readonly AbstContextMenu _contextMenu;
         private IDirCastItem? _selected;
         private IDirCastItem? _hoveredItem;
         private DirCastItem? _dragItem;
@@ -45,6 +49,7 @@ namespace BlingoEngine.Director.Core.Casts
         private float _dragStartX, _dragStartY;
         private int _columns = 1;
         private bool _listView;
+        private int _contextSlot;
         private static bool _openingEditor;
         private static readonly object _lock = new();
 
@@ -52,12 +57,22 @@ namespace BlingoEngine.Director.Core.Casts
         internal AbstTabItem TabItem => _tabItem;
 
         public int Width { get; private set; }
+        internal IBlingoCast Cast => _cast;
 
-        public DirCastTab(IBlingoFrameworkFactory factory, IBlingoCast cast, IDirectorIconManager iconManager, IAbstCommandManager commandManager, IDirectorEventMediator mediator, IBlingoPlayer player)
+        public DirCastTab(
+            IBlingoFrameworkFactory factory,
+            IBlingoCast cast,
+            IDirectorIconManager iconManager,
+            IAbstCommandManager commandManager,
+            IDirectorEventMediator mediator,
+            IBlingoPlayer player,
+            Func<AbstContextMenu> contextMenuFactory)
         {
             _commandManager = commandManager;
             _factory = factory;
             _iconManager = iconManager;
+            _contextMenu = (contextMenuFactory ?? throw new ArgumentNullException(nameof(contextMenuFactory)))();
+            _contextMenu.AddItemFluent(string.Empty, "Import member", () => _contextSlot > 0, StartImportMembers);
             var tabName = cast.Name ?? $"Cast{cast.Number}";
             _tabItem = factory.CreateTabItem("Cast_" + tabName, tabName);
             _root = factory.CreatePanel(tabName + "_Root");
@@ -96,6 +111,7 @@ namespace BlingoEngine.Director.Core.Casts
             _cast.MemberAdded -= MemberAdded;
             _cast.MemberDeleted -= MemberDeleted;
             _cast.MemberNameChanged -= MemberNameChanged;
+            _contextMenu.Dispose();
         }
 
         private void MemberNameChanged(IBlingoMember member)
@@ -236,25 +252,40 @@ namespace BlingoEngine.Director.Core.Casts
             switch (e.Type)
             {
                 case AbstMouseEventType.MouseDown:
-                    var member = memberHover;
-                    var item = hoverItem;
-                    if (item != null)
                     {
-                        Select(item);
-                        if (member != null)
+                        var member = memberHover;
+                        var item = hoverItem;
+                        int slotNumber = item is DirCastItem gridItem
+                            ? gridItem.SlotNumber
+                            : member?.NumberInCast ?? 0;
+                        bool isRightClick = e.Mouse.RightMouseDown;
+                        bool isDoubleClick = e.Mouse.DoubleClick;
+
+                        if (item != null)
                         {
-                            if (e.Mouse.DoubleClick)
+                            Select(item);
+                            if (member != null)
                             {
-                                OpenEditor(member);
+                                if (isDoubleClick && !isRightClick)
+                                    OpenEditor(member);
+
                                 MemberSelected?.Invoke(member, item);
+
+                                if (isRightClick)
+                                {
+                                    ShowContextMenu(slotNumber);
+                                }
+                                else if (!isDoubleClick)
+                                {
+                                    _dragStartX = x;
+                                    _dragStartY = y;
+                                    _dragging = false;
+                                    _dragItem = item as DirCastItem;
+                                }
                             }
-                            else
+                            else if (isRightClick && slotNumber > 0)
                             {
-                                MemberSelected?.Invoke(member, item);
-                                _dragStartX = x;
-                                _dragStartY = y;
-                                _dragging = false;
-                                _dragItem = item as DirCastItem;
+                                ShowContextMenu(slotNumber);
                             }
                         }
                     }
@@ -329,6 +360,25 @@ namespace BlingoEngine.Director.Core.Casts
             _scroll.RemoveItem(list ? _wrap : _listWrap);
             _scroll.AddItem(list ? _listWrap : _wrap);
             Select(null);
+        }
+
+        private void ShowContextMenu(int slotNumber)
+        {
+            if (slotNumber <= 0)
+                return;
+
+            _contextSlot = slotNumber;
+            _contextMenu.Popup();
+        }
+
+        private void StartImportMembers()
+        {
+            if (_contextSlot <= 0)
+                return;
+
+            var slot = _contextSlot;
+            _contextSlot = 0;
+            _commandManager.Handle(new OpenCastImportDialogCommand(_cast, slot));
         }
 
         private void OpenEditor(IBlingoMember member)

--- a/src/Director/BlingoEngine.Director.Core/Casts/DirectorCastWindow.cs
+++ b/src/Director/BlingoEngine.Director.Core/Casts/DirectorCastWindow.cs
@@ -1,4 +1,6 @@
-﻿using AbstUI.Commands;
+﻿using System;
+using System.Collections.Generic;
+using AbstUI.Commands;
 using AbstUI.Components.Containers;
 using AbstUI.Inputs;
 using AbstUI.Windowing;
@@ -28,7 +30,13 @@ namespace BlingoEngine.Director.Core.Casts
         public AbstTabContainer TabContainer => _tabs;
         public IBlingoMember? SelectedMember => _selected;
 
-        public DirectorCastWindow(IServiceProvider serviceProvider, IBlingoFrameworkFactory factory, IDirectorEventMediator mediator, IAbstCommandManager commandManager, IDirectorIconManager iconManager, IBlingoPlayer player) : base(serviceProvider, DirectorMenuCodes.CastWindow)
+        public DirectorCastWindow(
+            IServiceProvider serviceProvider,
+            IBlingoFrameworkFactory factory,
+            IDirectorEventMediator mediator,
+            IAbstCommandManager commandManager,
+            IDirectorIconManager iconManager,
+            IBlingoPlayer player) : base(serviceProvider, DirectorMenuCodes.CastWindow)
         {
             _player = (BlingoPlayer)player;
             _player.ActiveMovieChanged += OnActiveMovieChanged;
@@ -44,7 +52,7 @@ namespace BlingoEngine.Director.Core.Casts
             _tabs = factory.CreateTabContainer("CastTabs");
             //_tabs.Height = Height;
             _mediator.Subscribe(this);
-            
+
         }
        
         protected override void OnInit(IAbstFrameworkWindow frameworkWindow)
@@ -54,12 +62,13 @@ namespace BlingoEngine.Director.Core.Casts
             _mouseSub = MouseT.OnMouseEvent(OnMouseEvent);
             Content = _tabs;
         }
-       
+
         protected override void OnDispose()
         {
             _mediator.Unsubscribe(this);
             _mouseSub?.Release();
             _player.ActiveMovieChanged -= OnActiveMovieChanged;
+            ClearTabs();
             base.OnDispose();
         }
 
@@ -73,23 +82,36 @@ namespace BlingoEngine.Director.Core.Casts
 
         private void SetActiveMovie(IBlingoMovie? movie)
         {
-            _tabMap.Clear();
-            foreach (var tab in _tabMap)
-                tab.Value.Dispose();
-            _tabs.ClearTabs();
+            ClearTabs();
             if (movie == null)
                 return;
 
             foreach (var cast in movie.CastLib.GetAll())
             {
-                var tab = new DirCastTab(_factory, cast, _iconManager, _commandManager, _mediator, _player);
-                tab.SetViewportSize((int)_tabs.Width,(int) _tabs.Height);
+                var tab = new DirCastTab(
+                    _factory,
+                    cast,
+                    _iconManager,
+                    _commandManager,
+                    _mediator,
+                    _player,
+                    () => CreateContextMenu());
+                tab.SetViewportSize((int)_tabs.Width, (int)_tabs.Height);
                 _tabs.AddTab(tab.TabItem);
                 _tabMap[tab.TabItem.Title] = tab;
                 tab.MemberSelected += (m, i) => OnMemberSelected(tab, m, i);
-
                 tab.LoadAllMembers();
             }
+        }
+
+        private void ClearTabs()
+        {
+            foreach (var tab in _tabMap.Values)
+            {
+                tab.Dispose();
+            }
+            _tabMap.Clear();
+            _tabs.ClearTabs();
         }
         protected override void OnResizing(bool firstLoad, int width, int height)
         {

--- a/src/Director/BlingoEngine.Director.Core/DirectorSetup.cs
+++ b/src/Director/BlingoEngine.Director.Core/DirectorSetup.cs
@@ -71,6 +71,10 @@ namespace BlingoEngine.Director.Core
 
                     .AddTransient(p => new Lazy<IDirectorScriptsManager>(() => p.GetRequiredService<DirectorScriptsManager>()))
 
+                    .AddTransient<IDirCastImportService, DirCastImportService>()
+                    .AddTransient<DirCastImportDialog>()
+                    .AddTransient<DirCastImportDialogHandler>()
+
                     // Windows
                     .AddSingleton<DirectorMainMenu>()
 
@@ -142,6 +146,7 @@ namespace BlingoEngine.Director.Core
                         .Register<DirectorScriptsManager, OpenScriptCommand>()
                         .Register<BlingoCodeImporterPopupHandler, OpenBlingoCodeImporterCommand>()
                         .Register<BlingoCSharpConverterPopupHandler, OpenBlingoCSharpConverterCommand>()
+                        .Register<DirCastImportDialogHandler, OpenCastImportDialogCommand>()
                         .Register<DirectorProjectManager, SaveDirProjectSettingsCommand>()
                         .Register<DirectorPropertyInspectorWindow, OpenBehaviorPopupCommand>()
                         .Register<CompileProjectCommandHandler, CompileProjectCommand>()

--- a/src/Director/BlingoEngine.Director.Core/FileSystems/IDirFilePicker.cs
+++ b/src/Director/BlingoEngine.Director.Core/FileSystems/IDirFilePicker.cs
@@ -1,10 +1,10 @@
-﻿
-
+﻿using System.Collections.Generic;
 
 namespace BlingoEngine.Director.Core.FileSystems;
 
 public interface IDirFilePicker
 {
     void PickFile(Action<string> onPicked, string filter, string? currentFile = null);
-}
 
+    void PickFiles(Action<IReadOnlyList<string>> onPicked, string filter, string? currentPath = null);
+}

--- a/src/Director/BlingoEngine.Director.LGodot/FileSystems/GodotFilePicker.cs
+++ b/src/Director/BlingoEngine.Director.LGodot/FileSystems/GodotFilePicker.cs
@@ -1,4 +1,7 @@
-﻿using Godot;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Godot;
 using BlingoEngine.Director.Core.FileSystems;
 using BlingoEngine.LGodot;
 
@@ -16,20 +19,79 @@ public partial class GodotFilePicker : IDirFilePicker
     public void PickFile(Action<string> onPicked, string filter, string? currentFile = null)
     {
 #if USE_WINDOWS_FEATURES
-        var dialog = new FileDialog
-        {
-            Access = FileDialog.AccessEnum.Filesystem,
-            FileMode = FileDialog.FileModeEnum.OpenFile,
-            Filters = new[] { filter },
-            CurrentFile = currentFile
-        };
-
-        dialog.FileSelected += h => onPicked(h);
-        _directorRoot.RootNode.AddChild(dialog);
-        dialog.PopupCentered();
+        var dialog = CreateDialog(FileDialog.FileModeEnum.OpenFile, filter, currentFile, treatCurrentPathAsFile: true);
+        dialog.FileSelected += onPicked;
+        ShowDialog(dialog);
 #else
         GD.PushWarning("File picker not available. Define USE_WINDOWS_FEATURES in your Godot project to enable it.");
 #endif
     }
-}
 
+    public void PickFiles(Action<IReadOnlyList<string>> onPicked, string filter, string? currentPath = null)
+    {
+#if USE_WINDOWS_FEATURES
+        var dialog = CreateDialog(FileDialog.FileModeEnum.OpenFiles, filter, currentPath, treatCurrentPathAsFile: false);
+        dialog.FilesSelected += files =>
+        {
+            if (files.Length > 0)
+                onPicked(Array.AsReadOnly(files));
+        };
+        ShowDialog(dialog);
+#else
+        GD.PushWarning("File picker not available. Define USE_WINDOWS_FEATURES in your Godot project to enable it.");
+#endif
+    }
+
+#if USE_WINDOWS_FEATURES
+    private FileDialog CreateDialog(FileDialog.FileModeEnum mode, string filter, string? currentPath, bool treatCurrentPathAsFile)
+    {
+        var dialog = new FileDialog
+        {
+            Access = FileDialog.AccessEnum.Filesystem,
+            FileMode = mode,
+            Filters = new[] { filter }
+        };
+
+        ConfigureInitialPath(dialog, currentPath, treatCurrentPathAsFile);
+        return dialog;
+    }
+
+    private void ConfigureInitialPath(FileDialog dialog, string? currentPath, bool treatCurrentPathAsFile)
+    {
+        if (string.IsNullOrWhiteSpace(currentPath))
+            return;
+
+        try
+        {
+            if (treatCurrentPathAsFile && !string.IsNullOrWhiteSpace(currentPath))
+            {
+                dialog.CurrentFile = currentPath;
+                var directory = Path.GetDirectoryName(currentPath);
+                if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory))
+                    dialog.CurrentDir = directory;
+                return;
+            }
+
+            if (Directory.Exists(currentPath))
+            {
+                dialog.CurrentDir = currentPath;
+                return;
+            }
+
+            var pathDirectory = Path.GetDirectoryName(currentPath);
+            if (!string.IsNullOrEmpty(pathDirectory) && Directory.Exists(pathDirectory))
+                dialog.CurrentDir = pathDirectory;
+        }
+        catch (Exception)
+        {
+            // Ignore invalid paths and fall back to default dialog location.
+        }
+    }
+
+    private void ShowDialog(FileDialog dialog)
+    {
+        _directorRoot.RootNode.AddChild(dialog);
+        dialog.PopupCentered();
+    }
+#endif
+}


### PR DESCRIPTION
## Summary
- let DirCastTab build its own context menu and fire OpenCastImportDialogCommand without extra UI glue
- update DirCastImportDialog to rely on the director event mediator instead of a callback when finishing imports
- remove the unused DirCastImportUiController registration and slim the import command signature

## Testing
- dotnet build src/Director/BlingoEngine.Director.Core/BlingoEngine.Director.Core.csproj
- dotnet build src/Director/BlingoEngine.Director.LGodot/BlingoEngine.Director.LGodot.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d7623f14b883329a1e4ae696ef7fe1