### PR TITLE
Fix Godot file pickers opening from exclusive dialogs

### DIFF
--- a/src/Director/BlingoEngine.Director.LGodot/FileSystems/GodotFilePicker.cs
+++ b/src/Director/BlingoEngine.Director.LGodot/FileSystems/GodotFilePicker.cs
@@ -20,7 +20,11 @@ public partial class GodotFilePicker : IDirFilePicker
     {
 #if USE_WINDOWS_FEATURES
         var dialog = CreateDialog(FileDialog.FileModeEnum.OpenFile, filter, currentFile, treatCurrentPathAsFile: true);
-        dialog.FileSelected += onPicked;
+        dialog.FileSelected += path =>
+        {
+            onPicked(path);
+            dialog.QueueFree();
+        };
         ShowDialog(dialog);
 #else
         GD.PushWarning("File picker not available. Define USE_WINDOWS_FEATURES in your Godot project to enable it.");
@@ -35,6 +39,7 @@ public partial class GodotFilePicker : IDirFilePicker
         {
             if (files.Length > 0)
                 onPicked(Array.AsReadOnly(files));
+            dialog.QueueFree();
         };
         ShowDialog(dialog);
 #else
@@ -90,8 +95,19 @@ public partial class GodotFilePicker : IDirFilePicker
 
     private void ShowDialog(FileDialog dialog)
     {
+        PrepareDialog(dialog);
         _directorRoot.RootNode.AddChild(dialog);
         dialog.PopupCentered();
+    }
+
+    private static void PrepareDialog(FileDialog dialog)
+    {
+        dialog.Exclusive = false;
+        dialog.Transient = true;
+        dialog.TransientToFocused = true;
+
+        dialog.CloseRequested += dialog.QueueFree;
+        dialog.Canceled += dialog.QueueFree;
     }
 #endif
 }

--- a/src/Director/BlingoEngine.Director.LGodot/FileSystems/GodotFolderPicker.cs
+++ b/src/Director/BlingoEngine.Director.LGodot/FileSystems/GodotFolderPicker.cs
@@ -25,13 +25,27 @@ namespace BlingoEngine.Director.LGodot.FileSystems
         dialog.DirSelected += h =>
         {
             onPicked(h);
+            dialog.QueueFree();
         };
+        PrepareDialog(dialog);
         _directorRoot.RootNode.AddChild(dialog);
         dialog.PopupCentered();
 #else
             GD.PushWarning("Executable folder picker not available. Define USE_WINDOWS_FEATURES in your Godot project to enable it.");
 #endif
         }
+
+#if USE_WINDOWS_FEATURES
+        private static void PrepareDialog(FileDialog dialog)
+        {
+            dialog.Exclusive = false;
+            dialog.Transient = true;
+            dialog.TransientToFocused = true;
+
+            dialog.CloseRequested += dialog.QueueFree;
+            dialog.Canceled += dialog.QueueFree;
+        }
+#endif
     }
 }
 


### PR DESCRIPTION
## Summary
- make the Godot file and folder pickers non-exclusive so they can open while another dialog is focused
- ensure the pickers clean themselves up after selecting or cancelling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da9cc1c24883328a86b226e1f32903