### PR TITLE
Improve Pac-Man turn handling

### DIFF
--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManActorBehavior.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManActorBehavior.cs
@@ -110,6 +110,7 @@ internal sealed class BlPacManActorBehavior : BlingoSpriteBehavior,
         character.Speed = settings.Speed;
         character.EffectiveSpeed = settings.Speed;
         character.Reset();
+        _requestedDirection = BlPacManDirection.None;
         ResetPosition();
         PublishPosition(character);
     }
@@ -129,6 +130,7 @@ internal sealed class BlPacManActorBehavior : BlingoSpriteBehavior,
         _positionSubscription = character.SubscribePositionChanged(OnPositionChanged);
         PublishPosition(character);
 
+        _requestedDirection = BlPacManDirection.None;
         if (_coordinator is not null && _globals.CurrentPacmanSettings is { } settings)
             Configure(_coordinator, settings);
     }
@@ -154,12 +156,19 @@ internal sealed class BlPacManActorBehavior : BlingoSpriteBehavior,
         if (_globals.State.IsGameplayFrozen)
         {
             character.Update();
-            _requestedDirection = BlPacManDirection.None;
             return;
         }
 
-        character.Move(_requestedDirection);
-        _requestedDirection = BlPacManDirection.None;
+        var requestedDirection = _requestedDirection;
+        character.Move(requestedDirection);
+        if (requestedDirection != BlPacManDirection.None && character.Direction == requestedDirection)
+        {
+            _requestedDirection = BlPacManDirection.None;
+        }
+        else
+        {
+            character.NextDirection = requestedDirection;
+        }
         CheckCollisions(character);
     }
 
@@ -169,13 +178,13 @@ internal sealed class BlPacManActorBehavior : BlingoSpriteBehavior,
     public void KeyDown(BlingoKeyEvent key)
     {
         if (key.KeyPressed(123))
-            _requestedDirection = BlPacManDirection.Left;
+            SetRequestedDirection(BlPacManDirection.Left);
         else if (key.KeyPressed(124))
-            _requestedDirection = BlPacManDirection.Right;
+            SetRequestedDirection(BlPacManDirection.Right);
         else if (key.KeyPressed(126))
-            _requestedDirection = BlPacManDirection.Up;
+            SetRequestedDirection(BlPacManDirection.Up);
         else if (key.KeyPressed(125))
-            _requestedDirection = BlPacManDirection.Down;
+            SetRequestedDirection(BlPacManDirection.Down);
     }
 
     /// <summary>
@@ -218,6 +227,7 @@ internal sealed class BlPacManActorBehavior : BlingoSpriteBehavior,
         ResetPosition();
         character.Update();
         PublishPosition(character);
+        _requestedDirection = BlPacManDirection.None;
     }
 
     /// <summary>
@@ -376,6 +386,15 @@ internal sealed class BlPacManActorBehavior : BlingoSpriteBehavior,
         _character.RotateSprite = true;
         _tileEnteredSubscription = _character.SubscribeTileEntered(OnTileEntered);
         return _character;
+    }
+
+    private void SetRequestedDirection(BlPacManDirection direction)
+    {
+        _requestedDirection = direction;
+        if (_character is { } character)
+        {
+            character.NextDirection = direction;
+        }
     }
 
     private float GetBaseStepSize()

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/ParentScripts/BlPacManCharacter.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/ParentScripts/BlPacManCharacter.cs
@@ -14,7 +14,7 @@ namespace Blingo.PacMan.Core.Sprites.ParentScripts;
 internal sealed class BlPacManCharacter : BlingoParentScript
 {
     private const float DefaultSpeed = 80f;
-    private const float PositionTolerance = 0.5f;
+    private const float PositionTolerance = 1.5f;
 
     private readonly BlPacManEventMediator<BlPacManCharacter> _moveStarted = new();
     private readonly BlPacManEventMediator<BlPacManCharacter> _stopped = new();


### PR DESCRIPTION
## Summary
- Latch Pac-Man direction requests until the character can turn so queued moves execute at the next junction
- Increase the centering tolerance to make intersections more forgiving when changing direction

## Testing
- dotnet test Test/Blingo.PacMan.Tests/Blingo.PacMan.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68daa40718bc8332876ed85be1e648b8