### PR TITLE
Match ghost house behaviour to JavaScript implementation

### DIFF
--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManGhostBehavior.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/GameObjectBehaviors/BlPacManGhostBehavior.cs
@@ -65,19 +65,26 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
     private float _houseBottomBoundary;
     private Tile? _houseEntranceTile;
     private Tile? _houseDoorTile;
+    private Tile? _houseExitDestinationTile;
+    private float _houseExitX;
+    private float _houseExitTargetY;
     private BlPacManDirection _houseDirection = BlPacManDirection.Up;
     private bool _frightenedAnimationsConfigured;
     private bool _frightenedFlashing;
     private int _frightenedDurationFrames;
     private ARect? _defaultRect;
     private ARect? _savedNormalRect;
+    private bool _deadPrepareEnter;
+    private Tile? _deadEndTile;
+    private float _deadEndX;
+    private float _deadEndY;
 
 
     private void UpdateHouseExitAllowance()
     {
         if (_character is { } character)
         {
-            character.AllowHouseExit = _houseExiting;
+            character.AllowHouseExit = _houseExiting || _mode == GhostMode.Dead;
         }
     }
 
@@ -121,7 +128,7 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
         ApplyAppearance();
 
         var character = EnsureCharacter();
-        character.AllowHouseExit = _houseExiting;
+        UpdateHouseExitAllowance();
         character.BeginSprite();
         ConfigureTargets();
         UpdateSpeedForCurrentMode(character.GetTile());
@@ -171,10 +178,9 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
             return;
         }
 
-        if (_mode == GhostMode.Dead && _deadTarget is not null && ReferenceEquals(tile, _deadTarget))
+        if (_mode == GhostMode.Dead && HandleDeadMode(character, tile))
         {
-            _mode = _globalMode;
-            UpdateSpeedForCurrentMode(tile);
+            return;
         }
 
         var currentDirection = character.Direction;
@@ -206,8 +212,7 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
 
     private void HandleHouseMode(BlPacManCharacter character)
     {
-        character.AllowHouseExit = _houseExiting;
-
+        UpdateHouseExitAllowance();
 
         if (!_hasLeftHouse && _globals.State.IsActivePlaying && _houseReleaseCounter > 0)
         {
@@ -215,7 +220,7 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
             if (_houseReleaseCounter == 0)
             {
                 _houseExiting = true;
-                character.AllowHouseExit = true;
+                UpdateHouseExitAllowance();
             }
         }
 
@@ -245,10 +250,9 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
             return;
         }
 
-        if (_houseDoorTile is Tile door)
+        if (_houseDoorTile is Tile)
         {
-            var targetX = door.CenterX;
-            var deltaX = targetX - Me.LocH;
+            var deltaX = _houseExitX - Me.LocH;
             if (Math.Abs(deltaX) > HouseBoundaryTolerance)
             {
                 var direction = deltaX > 0 ? BlPacManDirection.Right : BlPacManDirection.Left;
@@ -257,24 +261,106 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
                 return;
             }
 
-            var exitY = door.CenterY;
-            if (Me.LocV > exitY + HouseBoundaryTolerance)
+            if (Me.LocV > _houseExitTargetY + HouseBoundaryTolerance)
             {
                 _requestedDirection = BlPacManDirection.Up;
                 character.Move(BlPacManDirection.Up);
-                return;
+
+                if (Me.LocV > _houseExitTargetY + HouseBoundaryTolerance)
+                {
+                    return;
+                }
             }
         }
 
+        CompleteHouseExit(character);
+    }
+
+    private void CompleteHouseExit(BlPacManCharacter character)
+    {
         _mode = _globalMode;
         _hasLeftHouse = true;
         _houseExiting = false;
-        character.AllowHouseExit = false;
+        UpdateHouseExitAllowance();
         _requestedDirection = BlPacManDirection.Up;
         character.ForceDirection(BlPacManDirection.Up);
         _turnBack = false;
         UpdateSpeedForCurrentMode(character.GetTile());
         UpdateVisualForMode();
+    }
+
+    private bool HandleDeadMode(BlPacManCharacter character, Tile tile)
+    {
+        UpdateHouseExitAllowance();
+
+        if (!_deadPrepareEnter && _deadTarget is not null && ReferenceEquals(tile, _deadTarget))
+        {
+            _deadPrepareEnter = true;
+        }
+
+        if (!_deadPrepareEnter)
+        {
+            return false;
+        }
+
+        var targetX = _deadEndX;
+        if (Me.LocV < _deadEndY - HouseBoundaryTolerance && _deadTarget is { } deadTarget)
+        {
+            targetX = deadTarget.CenterX;
+        }
+
+        var deltaX = targetX - Me.LocH;
+        if (Math.Abs(deltaX) > HouseBoundaryTolerance)
+        {
+            var direction = deltaX > 0 ? BlPacManDirection.Right : BlPacManDirection.Left;
+            if (_requestedDirection != direction)
+            {
+                character.ForceDirection(direction);
+            }
+
+            _requestedDirection = direction;
+            character.Move(direction);
+            return true;
+        }
+
+        if (Me.LocV < _deadEndY - HouseBoundaryTolerance)
+        {
+            _requestedDirection = BlPacManDirection.Down;
+            character.Move(BlPacManDirection.Down);
+            return true;
+        }
+
+        if (Me.LocV > _deadEndY + HouseBoundaryTolerance)
+        {
+            _requestedDirection = BlPacManDirection.Up;
+            character.Move(BlPacManDirection.Up);
+            return true;
+        }
+
+        ReviveInsideHouse(character);
+        return true;
+    }
+
+    private void ReviveInsideHouse(BlPacManCharacter character)
+    {
+        _deadPrepareEnter = false;
+        _mode = GhostMode.House;
+        _hasLeftHouse = false;
+        _houseDirection = BlPacManDirection.Up;
+        _requestedDirection = _houseDirection;
+        character.ForceDirection(_houseDirection);
+        Me.LocH = _deadEndX;
+        Me.LocV = _deadEndY;
+        _houseReleaseCounter = Math.Max(0, _initialHouseReleaseDelay);
+        _houseExiting = _houseReleaseCounter == 0;
+        UpdateHouseExitAllowance();
+        UpdateSpeedForCurrentMode(character.GetTile());
+        UpdateVisualForMode();
+
+        if (_globals.Map is { } map)
+        {
+            ConfigureDeadReturnTargets(map);
+        }
     }
 
     /// <summary>
@@ -316,6 +402,17 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
             return;
         }
 
+        if (mode == GhostMode.Dead)
+        {
+            _mode = GhostMode.Dead;
+            _frightenedFrames = 0;
+            _deadPrepareEnter = false;
+            UpdateHouseExitAllowance();
+            UpdateSpeedForCurrentMode(_character?.GetTile());
+            UpdateVisualForMode();
+            return;
+        }
+
         if (mode == GhostMode.Scatter || mode == GhostMode.Chase)
         {
             if (_mode is GhostMode.Chase or GhostMode.Scatter && mode.Value != _mode)
@@ -328,6 +425,7 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
         if (_mode != GhostMode.Frightened)
             _frightenedFrames = 0;
 
+        UpdateHouseExitAllowance();
         UpdateSpeedForCurrentMode(_character?.GetTile());
         UpdateVisualForMode();
     }
@@ -406,6 +504,7 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
         _houseExiting = _startOutsideHouse;
         _hasLeftHouse = _startOutsideHouse;
         _houseReleaseCounter = _initialHouseReleaseDelay;
+        _deadPrepareEnter = false;
         UpdateHouseExitAllowance();
 
         if (_defaultRect is { } defaultRect)
@@ -433,6 +532,11 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
         }
 
         UpdateSpeedForCurrentMode(character.GetTile());
+
+        if (_globals.Map is { } map)
+        {
+            ConfigureDeadReturnTargets(map);
+        }
     }
 
     /// <summary>
@@ -567,6 +671,7 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
 
         _scatterTarget = DetermineScatterTarget(map);
         _deadTarget = DetermineDeadTarget(map);
+        ConfigureDeadReturnTargets(map);
     }
 
     private void ConfigureFrightenedAnimations()
@@ -680,6 +785,18 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
         }
     }
 
+    private void ConfigureDeadReturnTargets(Map map)
+    {
+        _houseExitDestinationTile = _houseDoorTile?.GetUp();
+        _houseExitX = _houseDoorTile?.CenterX ?? Me.LocH;
+        _houseExitTargetY = _houseExitDestinationTile?.CenterY ?? _houseDoorTile?.CenterY ?? _houseTopBoundary;
+
+        _deadEndY = _houseEntranceTile?.CenterY ?? Me.LocV;
+        _deadEndX = Me.LocH;
+        _deadEndTile = map.GetTile(_deadEndX, _deadEndY, true);
+        _deadPrepareEnter = false;
+    }
+
     /// <summary>
     /// Returns the corner tile that the ghost should orbit during scatter mode.
     /// </summary>
@@ -702,7 +819,9 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
     /// </summary>
     private static Tile? DetermineDeadTarget(Map map)
     {
-        return map.HouseCenter ?? map.GetTile(map.Width / 2, map.Height / 2);
+        return map.House?.GetRight()?.GetUp()
+            ?? map.HouseCenter
+            ?? map.GetTile(map.Width / 2, map.Height / 2);
     }
 
     /// <summary>
@@ -723,7 +842,14 @@ internal sealed class BlPacManGhostBehavior : BlingoSpriteBehavior,
             return;
         }
 
-        UpdateSpeedForCurrentMode(context.Tile);
+        var tile = context.Tile;
+        UpdateSpeedForCurrentMode(tile);
+
+        if (_houseExiting && _mode != GhostMode.Dead && tile is not null && !tile.IsHouse() && !tile.IsGhostHouseEntrance())
+        {
+            _houseExiting = false;
+            UpdateHouseExitAllowance();
+        }
     }
 
     /// <summary>

--- a/Demo/LPacMan/Blingo.PacMan.Core/Sprites/ParentScripts/BlPacManCharacter.cs
+++ b/Demo/LPacMan/Blingo.PacMan.Core/Sprites/ParentScripts/BlPacManCharacter.cs
@@ -549,8 +549,12 @@ internal sealed class BlPacManCharacter : BlingoParentScript
                     return true;
                 }
 
-
                 return nextTile is not null && (nextTile.IsHouse() || nextTile.IsGhostHouseEntrance());
+            }
+
+            if (AllowHouseExit && nextTile is not null && (nextTile.IsHouse() || nextTile.IsGhostHouseEntrance()))
+            {
+                return !nextTile.IsWall();
             }
         }
 


### PR DESCRIPTION
## Summary
- mirror the JavaScript house-exit timing and doorway alignment when ghosts leave their home
- replicate the JavaScript dead-mode return path so eyes can re-enter, revive inside the house, and queue up for release again
- allow ghosts to traverse the doorway in either direction when house access is permitted by the behaviour

## Testing
- dotnet test Test/Blingo.PacMan.Tests/Blingo.PacMan.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68dab53e35848332b3b13b9870a76635