### PR TITLE
Refine score member lookup return type

### DIFF
--- a/src/Director/BlingoEngine.Director.Core/Casts/DirCastTab.cs
+++ b/src/Director/BlingoEngine.Director.Core/Casts/DirCastTab.cs
@@ -13,6 +13,7 @@ using BlingoEngine.Core;
 using BlingoEngine.Director.Core.Casts.Commands;
 using BlingoEngine.Director.Core.Icons;
 using BlingoEngine.Director.Core.Scripts.Commands;
+using BlingoEngine.Director.Core.Members.Commands;
 using BlingoEngine.Director.Core.Styles;
 using BlingoEngine.Director.Core.Tools;
 using BlingoEngine.Director.Core.UI;
@@ -42,6 +43,7 @@ namespace BlingoEngine.Director.Core.Casts
         private readonly IDirectorIconManager _iconManager;
         private readonly MemberNavigationBar _navBar;
         private readonly AbstContextMenu _contextMenu;
+        private readonly IDirectorEventMediator _mediator;
         private IDirCastItem? _selected;
         private IDirCastItem? _hoveredItem;
         private DirCastItem? _dragItem;
@@ -71,8 +73,14 @@ namespace BlingoEngine.Director.Core.Casts
             _commandManager = commandManager;
             _factory = factory;
             _iconManager = iconManager;
+            _mediator = mediator;
+            _cast = cast;
             _contextMenu = (contextMenuFactory ?? throw new ArgumentNullException(nameof(contextMenuFactory)))();
-            _contextMenu.AddItemFluent(string.Empty, "Import member", () => _contextSlot > 0, StartImportMembers);
+            _contextMenu
+                .AddItemFluent(string.Empty, "Find cast member", () =>
+                        _contextSlot > 0 && _cast.Member[_contextSlot] != null,
+                        FindCastMember)
+                .AddItemFluent(string.Empty, "Import member", () => _contextSlot > 0, StartImportMembers);
             var tabName = cast.Name ?? $"Cast{cast.Number}";
             _tabItem = factory.CreateTabItem("Cast_" + tabName, tabName);
             _root = factory.CreatePanel(tabName + "_Root");
@@ -91,7 +99,6 @@ namespace BlingoEngine.Director.Core.Casts
             _wrap = factory.CreateWrapPanel(AOrientation.Horizontal, tabName + "_Wrap");
             _listWrap = factory.CreateWrapPanel(AOrientation.Vertical, tabName + "_ListWrap");
             _listWrap.ItemMargin = new APoint(0, 0);
-            _cast = cast;
             _wrap.ItemMargin = new APoint(_itemMargin, _itemMargin);
             _scroll = factory.CreateScrollContainer(tabName + "_Scroll");
             _scroll.ClipContents = true;
@@ -379,6 +386,23 @@ namespace BlingoEngine.Director.Core.Casts
             var slot = _contextSlot;
             _contextSlot = 0;
             _commandManager.Handle(new OpenCastImportDialogCommand(_cast, slot));
+        }
+
+        private void FindCastMember()
+        {
+            if (_contextSlot <= 0)
+                return;
+
+            var slot = _contextSlot;
+            _contextSlot = 0;
+
+            var member = _cast.Member[slot];
+            if (member == null)
+                return;
+
+            _mediator.RaiseFindMember(member);
+            _mediator.RaiseMemberSelected(member);
+            _commandManager.Handle(new FindCastMemberInScoreCommand(member));
         }
 
         private void OpenEditor(IBlingoMember member)

--- a/src/Director/BlingoEngine.Director.Core/DirectorSetup.cs
+++ b/src/Director/BlingoEngine.Director.Core/DirectorSetup.cs
@@ -143,6 +143,7 @@ namespace BlingoEngine.Director.Core
                         .Register<DirectorStageWindow, MoveSpritesCommand>()
                         .Register<DirectorStageWindow, RotateSpritesCommand>()
                         .Register<DirCastManager, CreateFilmLoopCommand>()
+                        .Register<DirectorScoreWindow, FindCastMemberInScoreCommand>()
                         .Register<DirectorScriptsManager, OpenScriptCommand>()
                         .Register<BlingoCodeImporterPopupHandler, OpenBlingoCodeImporterCommand>()
                         .Register<BlingoCSharpConverterPopupHandler, OpenBlingoCSharpConverterCommand>()

--- a/src/Director/BlingoEngine.Director.Core/Members/Commands/FindCastMemberInScoreCommand.cs
+++ b/src/Director/BlingoEngine.Director.Core/Members/Commands/FindCastMemberInScoreCommand.cs
@@ -1,0 +1,15 @@
+using AbstUI.Commands;
+using BlingoEngine.Members;
+
+namespace BlingoEngine.Director.Core.Members.Commands
+{
+    public sealed class FindCastMemberInScoreCommand : IAbstCommand
+    {
+        public FindCastMemberInScoreCommand(IBlingoMember member)
+        {
+            Member = member;
+        }
+
+        public IBlingoMember Member { get; }
+    }
+}

--- a/src/Director/BlingoEngine.Director.Core/Scores/DirScoreManager.cs
+++ b/src/Director/BlingoEngine.Director.Core/Scores/DirScoreManager.cs
@@ -135,6 +135,36 @@ namespace BlingoEngine.Director.Core.Scores
             return null;
         }
 
+        internal (DirScoreChannel Channel, DirScoreSprite Sprite)? TryGetSpriteForMember(IBlingoMember member)
+        {
+            DirScoreSprite? bestSprite = null;
+            DirScoreChannel? bestChannel = null;
+
+            foreach (var ch in _channels.Values)
+            {
+                foreach (var candidate in ch.GetSprites())
+                {
+                    if (candidate.Sprite is not IBlingoSpriteWithMember withMember)
+                        continue;
+
+                    var candidateMember = withMember.GetMember();
+                    if (candidateMember == null || !ReferenceEquals(candidateMember, member))
+                        continue;
+
+                    if (bestSprite == null || candidate.Sprite.BeginFrame < bestSprite.Sprite.BeginFrame)
+                    {
+                        bestSprite = candidate;
+                        bestChannel = ch;
+                    }
+                }
+            }
+
+            if (bestSprite == null || bestChannel == null)
+                return null;
+
+            return (bestChannel, bestSprite);
+        }
+
         public void SelectSprite(BlingoSprite sprite)
         {
             if (sprite.Lock) return;

--- a/src/Director/BlingoEngine.Director.Core/Scores/DirectorScoreWindow.cs
+++ b/src/Director/BlingoEngine.Director.Core/Scores/DirectorScoreWindow.cs
@@ -1,5 +1,6 @@
 ﻿using BlingoEngine.FrameworkCommunication;
 using BlingoEngine.Movies;
+using System;
 using BlingoEngine.Director.Core.Inputs;
 using BlingoEngine.Director.Core.Sprites;
 using BlingoEngine.Core;
@@ -7,6 +8,7 @@ using BlingoEngine.Director.Core.Tools;
 using BlingoEngine.ColorPalettes;
 using AbstUI.Commands;
 using BlingoEngine.Director.Core.UI;
+using BlingoEngine.Director.Core.Members.Commands;
 using BlingoEngine.Sprites;
 using BlingoEngine.Sounds;
 using AbstUI.Primitives;
@@ -16,11 +18,12 @@ using AbstUI.Windowing;
 using AbstUI.Components.Inputs;
 using AbstUI.Components.Containers;
 using BlingoEngine.Transitions.TransitionLibrary;
+using BlingoEngine.Members;
 
 
 namespace BlingoEngine.Director.Core.Scores
 {
-    public class DirectorScoreWindow : DirectorWindow<IDirFrameworkScoreWindow>
+    public class DirectorScoreWindow : DirectorWindow<IDirFrameworkScoreWindow>, IAbstCommandHandler<FindCastMemberInScoreCommand>
     {
         private readonly IDirSpritesManager _spritesManager;
         private readonly DirScoreManager _scoreManager;
@@ -44,6 +47,8 @@ namespace BlingoEngine.Director.Core.Scores
         private float _scollY;
         private float _scollX;
         private float _lastPosV;
+        private float _viewportWidth;
+        private float _viewportHeight;
         private KeyValuePair<string, string>[] _frameLabelsForCombo = [
                    new KeyValuePair<string, string>("Label1","Label1"),
                ];
@@ -308,6 +313,91 @@ namespace BlingoEngine.Director.Core.Scores
                 _LeftChannelContainer.UpdatePosition(new APoint(0, -_lastPosV + 1));
                 //_leftChannelsScollClipper.ScrollVertical = _masterScroller.ScrollVertical;
             }
+        }
+
+        public void UpdateViewportSize(float width, float height)
+        {
+            _viewportWidth = Math.Max(0, width);
+            _viewportHeight = Math.Max(0, height);
+        }
+
+        public bool CanExecute(FindCastMemberInScoreCommand command) => command.Member != null;
+
+        public bool Handle(FindCastMemberInScoreCommand command)
+        {
+            if (command.Member == null)
+                return false;
+
+            return TryFocusMember(command.Member);
+        }
+
+        private bool TryFocusMember(IBlingoMember member)
+        {
+            if (_viewportWidth <= 0 || _viewportHeight <= 0)
+                return false;
+            if (Framework == null)
+                return false;
+            var location = _scoreManager.TryGetSpriteForMember(member);
+            if (location is not { } found)
+                return false;
+            var (channel, sprite) = found;
+
+            var gfx = _scoreManager.GfxValues;
+            float spriteLeft = gfx.LeftMargin + (sprite.Sprite.BeginFrame - 1) * gfx.FrameWidth;
+            float spriteRight = gfx.LeftMargin + sprite.Sprite.EndFrame * gfx.FrameWidth;
+            float spriteTop = channel.Position.Y;
+            float spriteBottom = spriteTop + channel.Size.Y;
+
+            const float margin = 8f;
+
+            float targetScrollX = _scollX;
+            float targetScrollY = _scollY;
+
+            if (spriteLeft < targetScrollX)
+                targetScrollX = spriteLeft - margin;
+            else if (spriteRight > targetScrollX + _viewportWidth)
+                targetScrollX = spriteRight - _viewportWidth + margin;
+
+            if (spriteTop < targetScrollY)
+                targetScrollY = spriteTop - margin;
+            else if (spriteBottom > targetScrollY + _viewportHeight)
+                targetScrollY = spriteBottom - _viewportHeight + margin;
+
+            targetScrollX = Math.Clamp(targetScrollX, 0, ComputeMaxHorizontalScroll());
+            targetScrollY = Math.Clamp(targetScrollY, 0, ComputeMaxVerticalScroll());
+
+            Framework.ScrollTo(targetScrollX, targetScrollY);
+
+            if (sprite.Sprite is BlingoSprite blingoSprite)
+                _spritesManager.SelectSprite(blingoSprite);
+
+            return true;
+        }
+
+        private float ComputeMaxHorizontalScroll()
+        {
+            if (_movie == null)
+                return 0f;
+
+            var gfx = _scoreManager.GfxValues;
+            float totalWidth = gfx.LeftMargin + _movie.FrameCount * gfx.FrameWidth + gfx.ExtraMargin;
+            return Math.Max(0, totalWidth - _viewportWidth);
+        }
+
+        private float ComputeMaxVerticalScroll()
+        {
+            float max = 0f;
+            foreach (var ch in _scoreManager.Channels.Values)
+            {
+                if (!ch.Visible)
+                    continue;
+
+                var bottom = ch.Position.Y + ch.Size.Y;
+                if (bottom > max)
+                    max = bottom;
+            }
+
+            return Math.Max(0, max - _viewportHeight);
         }
 
 

--- a/src/Director/BlingoEngine.Director.Core/Scores/IDirFrameworkScoreWindow.cs
+++ b/src/Director/BlingoEngine.Director.Core/Scores/IDirFrameworkScoreWindow.cs
@@ -1,7 +1,10 @@
-﻿using AbstUI.Windowing;
+using AbstUI.Windowing;
 
 namespace BlingoEngine.Director.Core.Scores
 {
-    public interface IDirFrameworkScoreWindow : IAbstFrameworkWindow { }
+    public interface IDirFrameworkScoreWindow : IAbstFrameworkWindow
+    {
+        void ScrollTo(float horizontal, float vertical);
+    }
 }
 

--- a/src/Director/BlingoEngine.Director.LGodot/Bitmaps/DirGodotPictureMemberEditorWindow.cs
+++ b/src/Director/BlingoEngine.Director.LGodot/Bitmaps/DirGodotPictureMemberEditorWindow.cs
@@ -1,4 +1,4 @@
-﻿using AbstEngine.Director.LGodot;
+using AbstEngine.Director.LGodot;
 using AbstUI.Commands;
 using AbstUI.FrameworkCommunication;
 using AbstUI.Inputs;

--- a/src/Director/BlingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
+++ b/src/Director/BlingoEngine.Director.LGodot/Scores/DirGodotScoreWindow.cs
@@ -62,6 +62,7 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
         _masterScroller.HorizontalScrollMode = ScrollContainer.ScrollMode.ShowAlways;
         _masterScroller.VerticalScrollMode= ScrollContainer.ScrollMode.ShowAlways;
         _masterScroller.Size = new Vector2(Size.X - _gfxValues.ChannelInfoWidth, Size.Y - _gfxValues.TopStripHeight- _footerMargin);
+        _directorScoreWindow.UpdateViewportSize(_masterScroller.Size.X, _masterScroller.Size.Y);
         _masterScroller.AddChild(_scrollContent);
         _marginContainer.AddChild(_masterScroller);
 
@@ -184,8 +185,15 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
         }
         if (changed)
             _topStripContent.Position = new Vector2(-_masterScroller.ScrollHorizontal, _topStripContent.Position.Y);
-        
-        
+
+
+    }
+
+    public void ScrollTo(float horizontal, float vertical)
+    {
+        _masterScroller.ScrollHorizontal = (int)horizontal;
+        _masterScroller.ScrollVertical = (int)vertical;
+        UpdatePositioScollPositionChanged();
     }
 
     private void RefreshGrid()
@@ -210,7 +218,8 @@ public partial class DirGodotScoreWindow : BaseGodotWindow, IDirFrameworkScoreWi
         _leftChannelsScollClipper.Size = new Vector2(_gfxValues.ChannelInfoWidth, Size.Y - topHeight - 20 - _footerMargin);
         _topHClipper.Size = new Vector2(Size.X - _gfxValues.ChannelInfoWidth, topHeight + 20);
         _masterScroller.Size = new Vector2(Size.X - _gfxValues.ChannelInfoWidth, Size.Y - topHeight - 20 - _footerMargin);
-        
+        _directorScoreWindow.UpdateViewportSize(_masterScroller.Size.X, _masterScroller.Size.Y);
+
     }
 
 

--- a/src/Director/BlingoEngine.Director.LGodot/Texts/TextableMemberWindow.cs
+++ b/src/Director/BlingoEngine.Director.LGodot/Texts/TextableMemberWindow.cs
@@ -1,4 +1,4 @@
-﻿using AbstEngine.Director.LGodot;
+using AbstEngine.Director.LGodot;
 using AbstUI.FrameworkCommunication;
 using AbstUI.LGodot.Components;
 using AbstUI.LGodot.Primitives;

--- a/src/Director/BlingoEngine.Director.SDL2/Scores/DirSdlScoreWindow.cs
+++ b/src/Director/BlingoEngine.Director.SDL2/Scores/DirSdlScoreWindow.cs
@@ -142,6 +142,7 @@ internal class DirSdlScoreWindow : AbstSdlWindow, IDirFrameworkScoreWindow, IDis
         _masterScroller.Y = topHeight;
         _masterScroller.Width = Width - _gfxValues.ChannelInfoWidth;
         _masterScroller.Height = Height - topHeight - FooterMargin;
+        _directorScoreWindow.UpdateViewportSize(_masterScroller.Width, _masterScroller.Height);
 
         _leftChannelsScroller.X = 0;
         _leftChannelsScroller.Y = topHeight;
@@ -185,6 +186,13 @@ internal class DirSdlScoreWindow : AbstSdlWindow, IDirFrameworkScoreWindow, IDis
             _topContainer.ScrollX = _lastScrollH;
             _leftChannelsScroller.ScrollVertical = _lastScrollV;
         }
+    }
+
+    public void ScrollTo(float horizontal, float vertical)
+    {
+        _masterScroller.ScrollHorizontal = horizontal;
+        _masterScroller.ScrollVertical = vertical;
+        UpdateScroll();
     }
 
     public new void Dispose()


### PR DESCRIPTION
## Summary
- return a tuple from `DirScoreManager.TryGetSpriteForMember` rather than using out parameters
- update `DirectorScoreWindow` to consume the new tuple result when focusing members in the score

## Testing
- dotnet build src/Director/BlingoEngine.Director.Core/BlingoEngine.Director.Core.csproj

------
https://chatgpt.com/codex/tasks/task_e_68db3b95072c8332b3187e0f7b4c2ca4