### PR TITLE
Add linear list conversion handling

### DIFF
--- a/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyListConversionTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyListConversionTests.cs
@@ -1,0 +1,98 @@
+using System.Text;
+using Xunit;
+
+namespace BlingoEngine.Legacy.Lingo.Tests;
+
+public sealed class LegacyListConversionTests : LegacyHandlerTestBase
+{
+    [Fact]
+    public void ListCommands_AreConverted()
+    {
+        const string source = """
+global items
+
+on test
+  add items,42
+  addAt items,1,99
+  setAt items,2,100
+  deleteAt items,3
+  deleteOne items,99
+  deleteAll items
+  sort items
+end
+""";
+
+        var code = GenerateBehavior(source);
+        var expected = CreateBehavior(
+            "items.Add(42);",
+            "items.AddAt(1, 99);",
+            "items.SetAt(2, 100);",
+            "items.DeleteAt(3);",
+            "items.DeleteOne(99);",
+            "items.DeleteAll();",
+            "items.Sort();");
+
+        LegacyCodeAssert.AreEqual(expected, code);
+    }
+
+    [Fact]
+    public void ListFunctions_AreConverted()
+    {
+        const string source = """
+global items
+
+on test
+  put getAt(items,1) into firstItem
+  put getOne(items) into oneItem
+  put getLast(items) into lastItem
+  put getAValue(items) into randomItem
+  put findPos(items,42) into position
+  put findPosNear(items,42) into nearPosition
+  put getPos(items,24) into pos
+  put count(items) into total
+  put duplicate(items) into copy
+  put ilk(items) into type
+  put listP(items) into isList
+  put max(items) into maxValue
+  put min(items) into minValue
+end
+""";
+
+        var code = GenerateBehavior(source);
+        var expected = CreateBehavior(
+            "firstItem = items.GetAt(1);",
+            "oneItem = items.GetOne();",
+            "lastItem = items.GetLast();",
+            "randomItem = items.GetAValue();",
+            "position = items.FindPos(42);",
+            "nearPosition = items.FindPosNear(42);",
+            "pos = items.GetPos(24);",
+            "total = items.Count;",
+            "copy = items.Duplicate();",
+            "type = items.Ilk();",
+            "isList = items.ListP();",
+            "maxValue = items.Max();",
+            "minValue = items.Min();");
+
+        LegacyCodeAssert.AreEqual(expected, code);
+    }
+
+    private static string CreateBehavior(params string[] statements)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("public class TestScriptBehavior : BlingoSpriteBehavior");
+        builder.AppendLine("{");
+        builder.AppendLine("    public TestScriptBehavior(IBlingoMovieEnvironment env) : base(env) { }");
+        builder.AppendLine("    public void Test()");
+        builder.AppendLine("    {");
+        foreach (var statement in statements)
+        {
+            builder.Append("        ");
+            builder.AppendLine(statement);
+        }
+
+        builder.AppendLine("    }");
+        builder.AppendLine("}");
+        return builder.ToString();
+    }
+}

--- a/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyPropertyListConversionTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyPropertyListConversionTests.cs
@@ -1,0 +1,90 @@
+using System.Text;
+using Xunit;
+
+namespace BlingoEngine.Legacy.Lingo.Tests;
+
+public sealed class LegacyPropertyListConversionTests : LegacyHandlerTestBase
+{
+    [Fact]
+    public void PropertyListCommands_AreConverted()
+    {
+        const string source = """
+global plist
+
+on test
+  addProp plist,#foo,42
+  setProp plist,#bar,24
+  deleteProp plist,#zap
+  setaProp plist,#foo,99
+  addAt plist,2,#newProp,77
+  deleteAt plist,3
+  setAt plist,4,88
+end
+""";
+
+        var code = GenerateBehavior(source);
+        var expected = CreateBehavior(
+            "plist.Add(Symbol(\"foo\"), 42);",
+            "plist.SetProp(Symbol(\"bar\"), 24);",
+            "plist.DeleteProp(Symbol(\"zap\"));",
+            "plist.SetaProp(Symbol(\"foo\"), 99);",
+            "plist.AddAt(2, Symbol(\"newProp\"), 77);",
+            "plist.DeleteAt(3);",
+            "plist.SetAt(4, 88);");
+
+        LegacyCodeAssert.AreEqual(expected, code);
+    }
+
+    [Fact]
+    public void PropertyListFunctions_AreConverted()
+    {
+        const string source = """
+global plist
+
+on test
+  put getProp(plist,#foo) into x
+  put getaProp(plist,#foo) into y
+  put getPropAt(plist,2) into keyName
+  put findPos(plist,#foo) into pos
+  put findPosNear(plist,#foo) into nearPos
+  put getPos(plist,42) into valuePos
+  put getAt(plist,1) into firstValue
+  put count(plist) into total
+  put duplicate(plist) into copy
+end
+""";
+
+        var code = GenerateBehavior(source);
+        var expected = CreateBehavior(
+            "x = plist.GetProp(Symbol(\"foo\"));",
+            "y = plist.GetaProp(Symbol(\"foo\"));",
+            "keyName = plist.GetPropAt(2);",
+            "pos = plist.FindPos(Symbol(\"foo\"));",
+            "nearPos = plist.FindPosNear(Symbol(\"foo\"));",
+            "valuePos = plist.GetPos(42);",
+            "firstValue = plist.GetAt(1);",
+            "total = plist.Count;",
+            "copy = plist.Duplicate();");
+
+        LegacyCodeAssert.AreEqual(expected, code);
+    }
+
+    private static string CreateBehavior(params string[] statements)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("public class TestScriptBehavior : BlingoSpriteBehavior");
+        builder.AppendLine("{");
+        builder.AppendLine("    public TestScriptBehavior(IBlingoMovieEnvironment env) : base(env) { }");
+        builder.AppendLine("    public void Test()");
+        builder.AppendLine("    {");
+        foreach (var statement in statements)
+        {
+            builder.Append("        ");
+            builder.AppendLine(statement);
+        }
+
+        builder.AppendLine("    }");
+        builder.AppendLine("}");
+        return builder.ToString();
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyExpressionConverter.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyExpressionConverter.cs
@@ -122,6 +122,120 @@ public sealed class BlLegacyExpressionConverter
         ["stage"] = "_Player.Stage",
     };
 
+    private sealed record PropertyListCommandInfo
+    {
+        public PropertyListCommandInfo(string methodName, int requiredArgumentCount, int[]? symbolArgumentIndices = null)
+        {
+            MethodName = methodName ?? throw new ArgumentNullException(nameof(methodName));
+            RequiredArgumentCount = requiredArgumentCount;
+            SymbolArgumentIndices = symbolArgumentIndices ?? Array.Empty<int>();
+        }
+
+        public string MethodName { get; }
+
+        public int RequiredArgumentCount { get; }
+
+        public int[] SymbolArgumentIndices { get; }
+    }
+
+    private sealed record PropertyListFunctionInfo
+    {
+        public PropertyListFunctionInfo(
+            string methodName,
+            int requiredArgumentCount,
+            int[]? symbolArgumentIndices = null,
+            bool isPropertyAccess = false)
+        {
+            MethodName = methodName ?? throw new ArgumentNullException(nameof(methodName));
+            RequiredArgumentCount = requiredArgumentCount;
+            SymbolArgumentIndices = symbolArgumentIndices ?? Array.Empty<int>();
+            IsPropertyAccess = isPropertyAccess;
+        }
+
+        public string MethodName { get; }
+
+        public int RequiredArgumentCount { get; }
+
+        public int[] SymbolArgumentIndices { get; }
+
+        public bool IsPropertyAccess { get; }
+    }
+
+    private sealed record ListCommandInfo
+    {
+        public ListCommandInfo(string methodName, int requiredArgumentCount)
+        {
+            MethodName = methodName ?? throw new ArgumentNullException(nameof(methodName));
+            RequiredArgumentCount = requiredArgumentCount;
+        }
+
+        public string MethodName { get; }
+
+        public int RequiredArgumentCount { get; }
+    }
+
+    private sealed record ListFunctionInfo
+    {
+        public ListFunctionInfo(string methodName, int requiredArgumentCount, bool isPropertyAccess = false)
+        {
+            MethodName = methodName ?? throw new ArgumentNullException(nameof(methodName));
+            RequiredArgumentCount = requiredArgumentCount;
+            IsPropertyAccess = isPropertyAccess;
+        }
+
+        public string MethodName { get; }
+
+        public int RequiredArgumentCount { get; }
+
+        public bool IsPropertyAccess { get; }
+    }
+
+    private static readonly Dictionary<string, PropertyListCommandInfo> s_propertyListCommands = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["addprop"] = new PropertyListCommandInfo("Add", 3, new[] { 0 }),
+        ["setprop"] = new PropertyListCommandInfo("SetProp", 3, new[] { 0 }),
+        ["deleteprop"] = new PropertyListCommandInfo("DeleteProp", 2, new[] { 0 }),
+        ["setaprop"] = new PropertyListCommandInfo("SetaProp", 3, new[] { 0 }),
+        ["addat"] = new PropertyListCommandInfo("AddAt", 4, new[] { 1 }),
+        ["deleteat"] = new PropertyListCommandInfo("DeleteAt", 2),
+        ["setat"] = new PropertyListCommandInfo("SetAt", 3),
+    };
+
+    private static readonly Dictionary<string, PropertyListFunctionInfo> s_propertyListFunctions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["getprop"] = new PropertyListFunctionInfo("GetProp", 2, new[] { 0 }),
+        ["getaprop"] = new PropertyListFunctionInfo("GetaProp", 2, new[] { 0 }),
+        ["getpropat"] = new PropertyListFunctionInfo("GetPropAt", 2),
+        ["findpos"] = new PropertyListFunctionInfo("FindPos", 2, new[] { 0 }),
+        ["findposnear"] = new PropertyListFunctionInfo("FindPosNear", 2, new[] { 0 }),
+        ["getpos"] = new PropertyListFunctionInfo("GetPos", 2),
+        ["getat"] = new PropertyListFunctionInfo("GetAt", 2),
+        ["count"] = new PropertyListFunctionInfo("Count", 1, isPropertyAccess: true),
+        ["duplicate"] = new PropertyListFunctionInfo("Duplicate", 1),
+    };
+
+    private static readonly Dictionary<string, ListCommandInfo> s_listCommands = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["add"] = new ListCommandInfo("Add", 2),
+        ["addat"] = new ListCommandInfo("AddAt", 3),
+        ["deleteat"] = new ListCommandInfo("DeleteAt", 2),
+        ["setat"] = new ListCommandInfo("SetAt", 3),
+        ["deleteone"] = new ListCommandInfo("DeleteOne", 2),
+        ["deleteall"] = new ListCommandInfo("DeleteAll", 1),
+        ["sort"] = new ListCommandInfo("Sort", 1),
+    };
+
+    private static readonly Dictionary<string, ListFunctionInfo> s_listFunctions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["getone"] = new ListFunctionInfo("GetOne", 1),
+        ["getlast"] = new ListFunctionInfo("GetLast", 1),
+        ["getavalue"] = new ListFunctionInfo("GetAValue", 1),
+        ["ilk"] = new ListFunctionInfo("Ilk", 1),
+        ["listp"] = new ListFunctionInfo("ListP", 1),
+        ["max"] = new ListFunctionInfo("Max", 1),
+        ["min"] = new ListFunctionInfo("Min", 1),
+    };
+
     public BlLegacyExpressionConverter(IReadOnlyList<BlSyntaxToken> tokens)
     {
         _tokens = tokens ?? Array.Empty<BlSyntaxToken>();
@@ -141,7 +255,11 @@ public sealed class BlLegacyExpressionConverter
     {
         while (_index < _tokens.Count)
         {
-            if (TryHandleVoidPredicate() ||
+            if (TryHandlePropertyListCommand() ||
+                TryHandlePropertyListFunction() ||
+                TryHandleListCommand() ||
+                TryHandleListFunction() ||
+                TryHandleVoidPredicate() ||
                 TryHandleScriptInstantiation() ||
                 TryHandleValueFunction() ||
                 TryHandleAlertCommand() ||
@@ -760,6 +878,370 @@ public sealed class BlLegacyExpressionConverter
         }
 
         return false;
+    }
+
+    private bool TryHandleListCommand()
+    {
+        if (_index >= _tokens.Count)
+        {
+            return false;
+        }
+
+        var token = _tokens[_index];
+        if (token.Kind is not (BlSyntaxKind.IdentifierToken or BlSyntaxKind.KeywordToken))
+        {
+            return false;
+        }
+
+        if (!s_listCommands.TryGetValue(token.ValueText, out var info))
+        {
+            return false;
+        }
+
+        if (_index + 1 >= _tokens.Count)
+        {
+            return false;
+        }
+
+        var argumentTokens = BlLegacyHandlerTokenUtilities.SliceTokens(_tokens, _index + 1, _tokens.Count - (_index + 1));
+        var segments = BlLegacyHandlerTokenUtilities.SplitByComma(argumentTokens);
+        if (segments.Count < info.RequiredArgumentCount)
+        {
+            return false;
+        }
+
+        var listExpression = Convert(segments[0]);
+        if (string.IsNullOrEmpty(listExpression))
+        {
+            return false;
+        }
+
+        var arguments = new List<string>(segments.Count - 1);
+        for (var i = 1; i < segments.Count; i++)
+        {
+            arguments.Add(Convert(segments[i]));
+        }
+
+        AppendRaw(listExpression);
+        AppendRaw(".");
+        AppendRaw(info.MethodName);
+        AppendRaw("(");
+        for (var i = 0; i < arguments.Count; i++)
+        {
+            AppendRaw(arguments[i]);
+            if (i < arguments.Count - 1)
+            {
+                AppendRaw(", ");
+            }
+        }
+
+        AppendRaw(")");
+        _index = _tokens.Count;
+        _afterDot = false;
+        return true;
+    }
+
+    private bool TryHandleListFunction()
+    {
+        if (_index >= _tokens.Count)
+        {
+            return false;
+        }
+
+        var token = _tokens[_index];
+        if (token.Kind is not (BlSyntaxKind.IdentifierToken or BlSyntaxKind.KeywordToken))
+        {
+            return false;
+        }
+
+        if (!s_listFunctions.TryGetValue(token.ValueText, out var info))
+        {
+            return false;
+        }
+
+        if (_index + 1 >= _tokens.Count || _tokens[_index + 1].Kind != BlSyntaxKind.LeftParenthesisToken)
+        {
+            return false;
+        }
+
+        var closeIndex = BlLegacyHandlerTokenUtilities.FindMatchingToken(
+            _tokens,
+            _index + 1,
+            BlSyntaxKind.LeftParenthesisToken,
+            BlSyntaxKind.RightParenthesisToken);
+
+        if (closeIndex < 0)
+        {
+            return false;
+        }
+
+        var argumentTokens = BlLegacyHandlerTokenUtilities.SliceTokens(
+            _tokens,
+            _index + 2,
+            closeIndex - (_index + 2));
+        var segments = BlLegacyHandlerTokenUtilities.SplitByComma(argumentTokens);
+        if (segments.Count < info.RequiredArgumentCount)
+        {
+            return false;
+        }
+
+        if (info.IsPropertyAccess && segments.Count > info.RequiredArgumentCount)
+        {
+            return false;
+        }
+
+        var listExpression = Convert(segments[0]);
+        if (string.IsNullOrEmpty(listExpression))
+        {
+            return false;
+        }
+
+        var arguments = new List<string>(segments.Count - 1);
+        for (var i = 1; i < segments.Count; i++)
+        {
+            arguments.Add(Convert(segments[i]));
+        }
+
+        AppendRaw(listExpression);
+        AppendRaw(".");
+        AppendRaw(info.MethodName);
+        if (!info.IsPropertyAccess)
+        {
+            AppendRaw("(");
+            for (var i = 0; i < arguments.Count; i++)
+            {
+                AppendRaw(arguments[i]);
+                if (i < arguments.Count - 1)
+                {
+                    AppendRaw(", ");
+                }
+            }
+
+            AppendRaw(")");
+        }
+
+        _index = closeIndex + 1;
+        _afterDot = false;
+        return true;
+    }
+
+    private bool TryHandlePropertyListCommand()
+    {
+        if (_index >= _tokens.Count)
+        {
+            return false;
+        }
+
+        var token = _tokens[_index];
+        if (token.Kind is not (BlSyntaxKind.IdentifierToken or BlSyntaxKind.KeywordToken))
+        {
+            return false;
+        }
+
+        if (!s_propertyListCommands.TryGetValue(token.ValueText, out var info))
+        {
+            return false;
+        }
+
+        if (_index + 1 >= _tokens.Count)
+        {
+            return false;
+        }
+
+        var argumentTokens = BlLegacyHandlerTokenUtilities.SliceTokens(_tokens, _index + 1, _tokens.Count - (_index + 1));
+        var segments = BlLegacyHandlerTokenUtilities.SplitByComma(argumentTokens);
+        if (segments.Count < info.RequiredArgumentCount)
+        {
+            return false;
+        }
+
+        var listExpression = Convert(segments[0]);
+        if (string.IsNullOrEmpty(listExpression))
+        {
+            return false;
+        }
+
+        var arguments = new List<string>(segments.Count - 1);
+        for (var i = 1; i < segments.Count; i++)
+        {
+            var segmentTokens = segments[i];
+            var expression = Convert(segmentTokens);
+            if (ContainsSymbolArgument(info.SymbolArgumentIndices, i - 1))
+            {
+                expression = EnsureSymbol(segmentTokens, expression);
+            }
+
+            arguments.Add(expression);
+        }
+
+        AppendRaw(listExpression);
+        AppendRaw(".");
+        AppendRaw(info.MethodName);
+        AppendRaw("(");
+        for (var i = 0; i < arguments.Count; i++)
+        {
+            AppendRaw(arguments[i]);
+            if (i < arguments.Count - 1)
+            {
+                AppendRaw(", ");
+            }
+        }
+
+        AppendRaw(")");
+        _index = _tokens.Count;
+        _afterDot = false;
+        return true;
+    }
+
+    private bool TryHandlePropertyListFunction()
+    {
+        if (_index >= _tokens.Count)
+        {
+            return false;
+        }
+
+        var token = _tokens[_index];
+        if (token.Kind is not (BlSyntaxKind.IdentifierToken or BlSyntaxKind.KeywordToken))
+        {
+            return false;
+        }
+
+        if (!s_propertyListFunctions.TryGetValue(token.ValueText, out var info))
+        {
+            return false;
+        }
+
+        if (_index + 1 >= _tokens.Count || _tokens[_index + 1].Kind != BlSyntaxKind.LeftParenthesisToken)
+        {
+            return false;
+        }
+
+        var closeIndex = BlLegacyHandlerTokenUtilities.FindMatchingToken(
+            _tokens,
+            _index + 1,
+            BlSyntaxKind.LeftParenthesisToken,
+            BlSyntaxKind.RightParenthesisToken);
+
+        if (closeIndex < 0)
+        {
+            return false;
+        }
+
+        var argumentTokens = BlLegacyHandlerTokenUtilities.SliceTokens(
+            _tokens,
+            _index + 2,
+            closeIndex - (_index + 2));
+        var segments = BlLegacyHandlerTokenUtilities.SplitByComma(argumentTokens);
+        if (segments.Count < info.RequiredArgumentCount)
+        {
+            return false;
+        }
+
+        if (info.IsPropertyAccess && segments.Count > info.RequiredArgumentCount)
+        {
+            return false;
+        }
+
+        var listExpression = Convert(segments[0]);
+        if (string.IsNullOrEmpty(listExpression))
+        {
+            return false;
+        }
+
+        var arguments = new List<string>(segments.Count - 1);
+        for (var i = 1; i < segments.Count; i++)
+        {
+            var segmentTokens = segments[i];
+            var expression = Convert(segmentTokens);
+            if (ContainsSymbolArgument(info.SymbolArgumentIndices, i - 1))
+            {
+                expression = EnsureSymbol(segmentTokens, expression);
+            }
+
+            arguments.Add(expression);
+        }
+
+        AppendRaw(listExpression);
+        AppendRaw(".");
+        AppendRaw(info.MethodName);
+        if (!info.IsPropertyAccess)
+        {
+            AppendRaw("(");
+            for (var i = 0; i < arguments.Count; i++)
+            {
+                AppendRaw(arguments[i]);
+                if (i < arguments.Count - 1)
+                {
+                    AppendRaw(", ");
+                }
+            }
+
+            AppendRaw(")");
+        }
+
+        _index = closeIndex + 1;
+        _afterDot = false;
+        return true;
+    }
+
+    private static bool ContainsSymbolArgument(int[] indices, int index)
+    {
+        if (indices is null || indices.Length == 0)
+        {
+            return false;
+        }
+
+        return Array.IndexOf(indices, index) >= 0;
+    }
+
+    private static string EnsureSymbol(IReadOnlyList<BlSyntaxToken> tokens, string expression)
+    {
+        if (string.IsNullOrEmpty(expression))
+        {
+            return expression;
+        }
+
+        if (expression.StartsWith("Symbol(", StringComparison.Ordinal))
+        {
+            return expression;
+        }
+
+        if (tokens.Count > 0 && tokens[0].Kind == BlSyntaxKind.SymbolToken)
+        {
+            return $"Symbol({ToStringLiteral(tokens[0].ValueText)})";
+        }
+
+        if (expression[0] == '#')
+        {
+            return $"Symbol({ToStringLiteral(expression[1..])})";
+        }
+
+        return expression;
+    }
+
+    private static string ToStringLiteral(string value)
+    {
+        var builder = new StringBuilder();
+        builder.Append('"');
+        if (!string.IsNullOrEmpty(value))
+        {
+            for (var index = 0; index < value.Length; index++)
+            {
+                var ch = value[index];
+                builder.Append(ch switch
+                {
+                    '\\' => "\\\\",
+                    '"' => "\\\"",
+                    '\n' => "\\n",
+                    '\r' => "\\r",
+                    '\t' => "\\t",
+                    _ => ch.ToString(),
+                });
+            }
+        }
+
+        builder.Append('"');
+        return builder.ToString();
     }
 
     private static string ResolveClassName(IReadOnlyList<BlSyntaxToken> tokens)


### PR DESCRIPTION
## Summary
- extend the legacy expression converter with mappings for Lingo list commands and functions so BlingoList usages keep 1-based indices
- add LegacyListConversionTests covering command- and function-style list conversions to ensure generated C# uses the BlingoList API

## Testing
- dotnet test Test/BlingoEngine.Legacy.Lingo.Tests/BlingoEngine.Legacy.Lingo.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68df8dbfb0048332b9996a396a3be252