### PR TITLE
Fix leading underscores in generated class names

### DIFF
--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlCSharpName.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlCSharpName.cs
@@ -28,6 +28,8 @@ internal static class BlCSharpName
         ArgumentNullException.ThrowIfNull(options);
 
         var baseName = NormalizeScriptName(name);
+        baseName = RemoveLeadingUnderscores(baseName);
+
         var suffix = kind switch
         {
             BlLingoScriptKind.Movie => options.MovieScriptSuffix,
@@ -73,5 +75,26 @@ internal static class BlCSharpName
         }
 
         return builder.ToString();
+    }
+
+    private static string RemoveLeadingUnderscores(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return "Script";
+        }
+
+        var trimmed = value.TrimStart('_');
+        if (trimmed.Length == 0)
+        {
+            return "Script";
+        }
+
+        if (char.IsDigit(trimmed[0]))
+        {
+            trimmed = "S" + trimmed;
+        }
+
+        return trimmed;
     }
 }


### PR DESCRIPTION
## Summary
- remove leading underscores from normalized script names when composing C# class names
- ensure resulting names still default to Script or add an S prefix when needed after trimming underscores

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfa13b5d908332a8620b97e4e5c49b