### PR TITLE
Handle actor list command syntax without member access

### DIFF
--- a/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerActorListTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerActorListTests.cs
@@ -29,11 +29,59 @@ public class TestScriptBehavior : BlingoSpriteBehavior
     }
 
     [Fact]
+    public void ActorListAppendCommand_AddsToMovieList()
+    {
+        const string source = """
+on test
+  append the actorList(me)
+end
+""";
+
+        var code = GenerateBehavior(source);
+        const string expected = """
+public class TestScriptBehavior : BlingoSpriteBehavior
+{
+    public TestScriptBehavior(IBlingoMovieEnvironment env) : base(env) { }
+    public void Test()
+    {
+        _Movie.ActorList.Append(this);
+    }
+}
+""";
+
+        LegacyCodeAssert.AreEqual(expected, code);
+    }
+
+    [Fact]
     public void ActorListDeleteOne_RemovesFromMovieList()
     {
         const string source = """
 on test
   the actorList.deleteOne(me)
+end
+""";
+
+        var code = GenerateBehavior(source);
+        const string expected = """
+public class TestScriptBehavior : BlingoSpriteBehavior
+{
+    public TestScriptBehavior(IBlingoMovieEnvironment env) : base(env) { }
+    public void Test()
+    {
+        _Movie.ActorList.DeleteOne(this);
+    }
+}
+""";
+
+        LegacyCodeAssert.AreEqual(expected, code);
+    }
+
+    [Fact]
+    public void ActorListDeleteOneCommand_RemovesFromMovieList()
+    {
+        const string source = """
+on test
+  deleteOne the actorList(me)
 end
 """;
 

--- a/src/BlingoEngine.Legacy.Lingo/Analysis/Blocks/ActorListBlockClassifier.cs
+++ b/src/BlingoEngine.Legacy.Lingo/Analysis/Blocks/ActorListBlockClassifier.cs
@@ -15,6 +15,28 @@ internal sealed class ActorListBlockClassifier : IHandlerBlockClassifier
     public bool TryCreate(IReadOnlyList<BlSyntaxToken> tokens, BlLingoSymbolTable symbols, out BlLingoHandlerCodeBlock block)
     {
         block = null!;
+
+        if (!TryParseMemberInvocation(tokens, out var argumentExpression, out var kind) &&
+            !TryParseCommandInvocation(tokens, out argumentExpression, out kind))
+        {
+            return false;
+        }
+
+        block = new BlLingoHandlerCodeBlock(
+            kind == BlLingoActorListMutationKind.Append ? BlLingoHandlerCodeBlockKind.ActorListAppend : BlLingoHandlerCodeBlockKind.ActorListRemove,
+            tokens,
+            new BlLingoActorListMutationBlockData(argumentExpression, kind));
+        return true;
+    }
+
+    private static bool TryParseMemberInvocation(
+        IReadOnlyList<BlSyntaxToken> tokens,
+        out string argumentExpression,
+        out BlLingoActorListMutationKind kind)
+    {
+        argumentExpression = string.Empty;
+        kind = BlLingoActorListMutationKind.Append;
+
         if (tokens.Count < 6)
         {
             return false;
@@ -28,9 +50,7 @@ internal sealed class ActorListBlockClassifier : IHandlerBlockClassifier
         }
 
         var operationToken = tokens[3];
-        if (!BlLegacyHandlerTokenUtilities.IsIdentifier(operationToken, "append") &&
-            !BlLegacyHandlerTokenUtilities.IsIdentifier(operationToken, "deleteOne") &&
-            !BlLegacyHandlerTokenUtilities.IsIdentifier(operationToken, "delete"))
+        if (!TryGetMutationKind(operationToken, out kind))
         {
             return false;
         }
@@ -47,22 +67,74 @@ internal sealed class ActorListBlockClassifier : IHandlerBlockClassifier
         }
 
         var argumentTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, 5, closeIndex - 5);
-        var argument = BlLegacyExpressionConverter.Convert(argumentTokens);
+        argumentExpression = BlLegacyExpressionConverter.Convert(argumentTokens);
+        return argumentExpression.Length > 0;
+    }
 
-        var kind = BlLingoActorListMutationKind.Append;
+    private static bool TryParseCommandInvocation(
+        IReadOnlyList<BlSyntaxToken> tokens,
+        out string argumentExpression,
+        out BlLingoActorListMutationKind kind)
+    {
+        argumentExpression = string.Empty;
+        kind = BlLingoActorListMutationKind.Append;
+
+        if (tokens.Count < 5)
+        {
+            return false;
+        }
+
+        var operationToken = tokens[0];
+        if (!TryGetMutationKind(operationToken, out kind))
+        {
+            return false;
+        }
+
+        if (!BlLegacyHandlerTokenUtilities.IsKeyword(tokens[1], "the") ||
+            !BlLegacyHandlerTokenUtilities.IsIdentifier(tokens[2], "actorList") ||
+            tokens[3].Kind != BlSyntaxKind.LeftParenthesisToken)
+        {
+            return false;
+        }
+
+        var closeIndex = BlLegacyHandlerTokenUtilities.FindMatchingToken(tokens, 3, BlSyntaxKind.LeftParenthesisToken, BlSyntaxKind.RightParenthesisToken);
+        if (closeIndex < 0)
+        {
+            return false;
+        }
+
+        if (closeIndex + 1 != tokens.Count)
+        {
+            return false;
+        }
+
+        var argumentTokens = BlLegacyHandlerTokenUtilities.SliceTokens(tokens, 4, closeIndex - 4);
+        argumentExpression = BlLegacyExpressionConverter.Convert(argumentTokens);
+        return argumentExpression.Length > 0;
+    }
+
+    private static bool TryGetMutationKind(BlSyntaxToken operationToken, out BlLingoActorListMutationKind kind)
+    {
+        kind = BlLingoActorListMutationKind.Append;
+
+        if (BlLegacyHandlerTokenUtilities.IsIdentifier(operationToken, "append"))
+        {
+            kind = BlLingoActorListMutationKind.Append;
+            return true;
+        }
+
         if (BlLegacyHandlerTokenUtilities.IsIdentifier(operationToken, "deleteOne"))
         {
             kind = BlLingoActorListMutationKind.DeleteOne;
-        }
-        else if (BlLegacyHandlerTokenUtilities.IsIdentifier(operationToken, "delete"))
-        {
-            kind = BlLingoActorListMutationKind.Delete;
+            return true;
         }
 
-        block = new BlLingoHandlerCodeBlock(
-            kind == BlLingoActorListMutationKind.Append ? BlLingoHandlerCodeBlockKind.ActorListAppend : BlLingoHandlerCodeBlockKind.ActorListRemove,
-            tokens,
-            new BlLingoActorListMutationBlockData(argument, kind));
-        return true;
+        if (BlLegacyHandlerTokenUtilities.IsIdentifier(operationToken, "delete"))
+        {
+            kind = BlLingoActorListMutationKind.Delete;
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
- accept command-style actor list mutations like `append the actorList(me)` and `deleteOne the actorList(me)` when classifying legacy handlers
- share mutation-kind detection between member-call and command-call parsing to generate the correct C# calls
- add unit tests that exercise the newly supported command syntax for both append and delete-one conversions

## Testing
- dotnet test Test/BlingoEngine.Legacy.Lingo.Tests/BlingoEngine.Legacy.Lingo.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68dfa0e6f81c8332a67d62384fc786e9