### PR TITLE
Preserve inter-handler comment blocks in generated classes

### DIFF
--- a/Test/BlingoEngine.Legacy.Lingo.Tests/BlLegacyClassGeneratorTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/BlLegacyClassGeneratorTests.cs
@@ -236,4 +236,36 @@ public class MyBehaviorBehavior : BlingoSpriteBehavior, IHasMouseUpEvent
         LegacyCodeAssert.AreEqual(expected, code);
     }
 
+    [Fact]
+    public void LeadingComments_ArePreservedBeforeClassDeclaration()
+    {
+        const string source = "-- Header comment\n-- Second line\non startMovie\nend";
+        var code = _generator.GenerateClass("MyBehavior", source, BlLingoScriptKind.Behavior);
+
+        const string expectedPrefix = """
+// Header comment
+// Second line
+
+public class MyBehaviorBehavior : BlingoSpriteBehavior
+""";
+
+        Assert.StartsWith(expectedPrefix.ReplaceLineEndings(Environment.NewLine), code);
+    }
+
+    [Fact]
+    public void CommentsBetweenHandlers_ArePreserved()
+    {
+        const string source = "-- Header\n" +
+            "on mouseUp\n" +
+            "end\n" +
+            "\n" +
+            "-- Between handlers\n" +
+            "on mouseDown\n" +
+            "end";
+
+        var code = _generator.GenerateClass("MyBehavior", source, BlLingoScriptKind.Behavior);
+
+        var commentSnippet = "    // Between handlers" + Environment.NewLine + Environment.NewLine + "    public void MouseDown";
+        Assert.Contains(commentSnippet.ReplaceLineEndings(Environment.NewLine), code);
+    }
 }

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyClassGenerator.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyClassGenerator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using BlingoEngine.Legacy.Lingo.Analysis;
 using BlingoEngine.Legacy.Lingo.Analysis.Passes;
 using BlingoEngine.Legacy.Lingo.Syntax;
@@ -75,6 +76,29 @@ public sealed class BlLegacyClassGenerator
         var interfaces = CollectInterfaces(classScope);
 
         var writer = new BlCSharpCodeWriter();
+        var commentBlocks = ExtractCommentBlocks(source);
+        var commentsByLine = new Dictionary<int, CommentBlock>();
+        CommentBlock? headerBlock = null;
+
+        foreach (var block in commentBlocks)
+        {
+            if (block.IsFileHeader && headerBlock is null)
+            {
+                headerBlock = block;
+                continue;
+            }
+
+            if (block.TargetLine >= 0 && !commentsByLine.ContainsKey(block.TargetLine))
+            {
+                commentsByLine.Add(block.TargetLine, block);
+            }
+        }
+
+        if (headerBlock is CommentBlock fileHeader && fileHeader.Lines.Count > 0)
+        {
+            WriteCommentBlock(writer, fileHeader.Lines);
+        }
+
         var handlerConverter = new BlLegacyHandlerConverter(source, tokens, _options, analysis);
         var interfaceSuffix = interfaces.Count > 0 ? ", " + string.Join(", ", interfaces) : string.Empty;
 
@@ -99,19 +123,174 @@ public sealed class BlLegacyClassGenerator
                 writer.WriteLine();
             }
 
-            WriteConstructor(writer, className, classScope, needsGlobal, handlerConverter);
+            WriteConstructor(writer, className, classScope, needsGlobal, handlerConverter, commentsByLine);
 
             if (interfaces.Contains("IBlingoPropertyDescriptionList"))
             {
                 WritePropertyDescriptionListStubs(writer);
             }
 
-            WriteHandlers(writer, classScope, handlerConverter, memberInfo.HandlerOrder);
+            WriteHandlers(writer, classScope, handlerConverter, memberInfo.HandlerOrder, commentsByLine);
         }
 
         writer.WriteLine("}");
 
         return writer.ToString();
+    }
+
+    private static IReadOnlyList<CommentBlock> ExtractCommentBlocks(string source)
+    {
+        if (string.IsNullOrEmpty(source))
+        {
+            return Array.Empty<CommentBlock>();
+        }
+
+        var blocks = new List<CommentBlock>();
+        using var reader = new StringReader(source);
+
+        string? line;
+        var lineIndex = 0;
+        var hasComment = false;
+        var seenNonCommentLine = false;
+        var commentLines = new List<CommentLine>();
+        var blockIsFileHeader = false;
+
+        while ((line = reader.ReadLine()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                if (hasComment)
+                {
+                    commentLines.Add(new CommentLine(null, isBlankLine: true));
+                }
+
+                lineIndex++;
+                continue;
+            }
+
+            var trimmed = line.TrimStart();
+            if (trimmed.StartsWith("--", StringComparison.Ordinal))
+            {
+                if (!hasComment)
+                {
+                    hasComment = true;
+                    blockIsFileHeader = !seenNonCommentLine;
+                }
+
+                var commentText = trimmed.Length > 2 ? trimmed[2..] : string.Empty;
+                commentLines.Add(new CommentLine(commentText.Trim(), isBlankLine: false));
+                lineIndex++;
+                continue;
+            }
+
+            if (hasComment)
+            {
+                blocks.Add(new CommentBlock(lineIndex, commentLines.ToArray(), blockIsFileHeader));
+                commentLines.Clear();
+                hasComment = false;
+                blockIsFileHeader = false;
+            }
+
+            seenNonCommentLine = true;
+            lineIndex++;
+        }
+
+        return blocks;
+    }
+
+    private static void TryWriteLeadingComments(
+        BlCSharpCodeWriter writer,
+        Dictionary<int, CommentBlock> commentsByLine,
+        BlLingoHandlerSymbolTable? handler)
+    {
+        if (commentsByLine is null || handler is null)
+        {
+            return;
+        }
+
+        var declarationLine = GetHandlerDeclarationLine(handler);
+        if (declarationLine < 0)
+        {
+            return;
+        }
+
+        if (!commentsByLine.TryGetValue(declarationLine, out var block))
+        {
+            return;
+        }
+
+        commentsByLine.Remove(declarationLine);
+        WriteCommentBlock(writer, block.Lines);
+    }
+
+    private static int GetHandlerDeclarationLine(BlLingoHandlerSymbolTable handler)
+    {
+        if (handler?.Symbol?.Declarations is null || handler.Symbol.Declarations.Count == 0)
+        {
+            return -1;
+        }
+
+        return handler.Symbol.Declarations[0].LineSpan.Start.Line;
+    }
+
+    private static void WriteCommentBlock(BlCSharpCodeWriter writer, IReadOnlyList<CommentLine> lines)
+    {
+        if (lines.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var line in lines)
+        {
+            if (line.IsBlankLine)
+            {
+                writer.WriteLine();
+                continue;
+            }
+
+            if (string.IsNullOrEmpty(line.Text))
+            {
+                writer.WriteLine("//");
+            }
+            else
+            {
+                writer.WriteLine("// " + line.Text);
+            }
+        }
+
+        if (!lines[^1].IsBlankLine)
+        {
+            writer.WriteLine();
+        }
+    }
+
+    private readonly struct CommentLine
+    {
+        public CommentLine(string? text, bool isBlankLine)
+        {
+            Text = text;
+            IsBlankLine = isBlankLine;
+        }
+
+        public string? Text { get; }
+
+        public bool IsBlankLine { get; }
+    }
+
+    private readonly struct CommentBlock
+    {
+        public CommentBlock(int targetLine, IReadOnlyList<CommentLine> lines, bool isFileHeader)
+        {
+            TargetLine = targetLine;
+            Lines = lines;
+            IsFileHeader = isFileHeader;
+        }
+
+        public int TargetLine { get; }
+
+        public IReadOnlyList<CommentLine> Lines { get; }
+
+        public bool IsFileHeader { get; }
     }
 
     private static BlLingoClassSymbolTable ResolveClassScope(string scriptName, BlLingoAnalysisResult analysis)
@@ -203,13 +382,16 @@ public sealed class BlLegacyClassGenerator
         string className,
         BlLingoClassSymbolTable classScope,
         bool needsGlobal,
-        BlLegacyHandlerConverter handlerConverter)
+        BlLegacyHandlerConverter handlerConverter,
+        Dictionary<int, CommentBlock> commentsByLine)
     {
+        var constructorHandler = GetConstructorHandler(classScope);
+        TryWriteLeadingComments(writer, commentsByLine, constructorHandler);
+
         writer.Write($"public {className}(IBlingoMovieEnvironment env");
         var reservedNames = needsGlobal
             ? new[] { "env", "global" }
             : new[] { "env" };
-        var constructorHandler = GetConstructorHandler(classScope);
         var constructorParameters = constructorHandler is not null
             ? ComposeHandlerParameterDefinitions(constructorHandler, reservedNames)
             : new List<ParameterDefinition>();
@@ -293,7 +475,8 @@ public sealed class BlLegacyClassGenerator
         BlCSharpCodeWriter writer,
         BlLingoClassSymbolTable classScope,
         BlLegacyHandlerConverter handlerConverter,
-        IReadOnlyList<BlLingoHandlerSymbolTable> orderedHandlers)
+        IReadOnlyList<BlLingoHandlerSymbolTable> orderedHandlers,
+        Dictionary<int, CommentBlock> commentsByLine)
     {
         if (classScope is null || classScope.Handlers.Count == 0)
         {
@@ -359,7 +542,7 @@ public sealed class BlLegacyClassGenerator
 
             first = false;
             var returnType = resolvedReturnTypes.TryGetValue(handler, out var resolved) ? resolved : "void";
-            WriteHandler(writer, classScope, handler, handlerConverter, returnType);
+            WriteHandler(writer, classScope, handler, handlerConverter, returnType, commentsByLine);
         }
     }
 
@@ -368,8 +551,11 @@ public sealed class BlLegacyClassGenerator
         BlLingoClassSymbolTable classScope,
         BlLingoHandlerSymbolTable handler,
         BlLegacyHandlerConverter handlerConverter,
-        string returnType)
+        string returnType,
+        Dictionary<int, CommentBlock> commentsByLine)
     {
+        TryWriteLeadingComments(writer, commentsByLine, handler);
+
         var methodName = BlCSharpName.SanitizeIdentifier(handler.Symbol.Name);
         if (string.IsNullOrEmpty(methodName))
         {


### PR DESCRIPTION
## Summary
- generalize Lingo comment extraction so header and handler comment blocks are reused when generating C#
- emit constructor and handler comments before the generated members to preserve inter-handler annotations
- add regression coverage proving comments between handlers remain in the converted output

## Testing
- dotnet test Test/BlingoEngine.Legacy.Lingo.Tests/BlingoEngine.Legacy.Lingo.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68dfa1bce0748332863f38eccf3d8fcc