### PR TITLE
Fix contains operator translation to use string.Contains

### DIFF
--- a/WillMoveToOwnRepo/Old/OldBlingoEngine.Lingo.Core/CSharpWriter.cs
+++ b/WillMoveToOwnRepo/Old/OldBlingoEngine.Lingo.Core/CSharpWriter.cs
@@ -256,6 +256,24 @@ public partial class CSharpWriter : IBlingoAstVisitor
             return;
         }
 
+        if (node.Opcode == BlingoBinaryOpcode.Contains)
+        {
+            bool needsParensTarget = node.Left is BlingoBinaryOpNode;
+            if (needsParensTarget) Append("(");
+            var startTarget = _sb.Length;
+            node.Left.Accept(this);
+            TrimSemicolon(startTarget);
+            if (needsParensTarget) Append(")");
+
+            Append(".Contains(");
+
+            var startArgument = _sb.Length;
+            node.Right.Accept(this);
+            TrimSemicolon(startArgument);
+            Append(")");
+            return;
+        }
+
         bool needsParensLeft = node.Left is BlingoBinaryOpNode;
         bool needsParensRight = node.Right is BlingoBinaryOpNode;
 

--- a/WillMoveToOwnRepo/Old/OldBlingoEngine.Lingo.Core/Tokenizer/BlingoBinaryOpcode.cs
+++ b/WillMoveToOwnRepo/Old/OldBlingoEngine.Lingo.Core/Tokenizer/BlingoBinaryOpcode.cs
@@ -18,7 +18,8 @@
         GreaterThan,
         GreaterOrEqual,
         LessThan,
-        LessOrEqual
+        LessOrEqual,
+        Contains
         // Add other opcodes as needed
     }
 }


### PR DESCRIPTION
## Summary
- translate the Lingo `contains` binary operator into a C# `Contains` method call
- extend the binary opcode enum with a `Contains` value so it maps cleanly to the new translation

## Testing
- `dotnet test WillMoveToOwnRepo/Old/OldBlingoEngine.Lingo.Core.Tests/OldBlingoEngine.Lingo.Core.Tests.csproj` *(fails: missing OldBlingoEngine references in the legacy test project)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa31ec59c8332a99ef8924307d998