### PR TITLE
Translate Lingo string function to ToString()

### DIFF
--- a/WillMoveToOwnRepo/Old/OldBlingoEngine.Lingo.Core.Tests/BlingoToCSharpConverterTests.cs
+++ b/WillMoveToOwnRepo/Old/OldBlingoEngine.Lingo.Core.Tests/BlingoToCSharpConverterTests.cs
@@ -98,11 +98,19 @@ public class BlingoToCSharpConverterTests
 on beginsprite me
   num=me.spritenum
   woord=member(""MyTextMember"").line[1] &return& member(""MyTextMember"").line[2] &return& member(""MyTextMember"").line[3]
-  
+
 end";
         var file = new BlingoScriptFile { Name = "MyScript", Source = lingo, Type = BlingoScriptType.Behavior };
         var result = _converter.Convert(file);
         Assert.Contains("woord = (((GetMember<IBlingoMemberTextBase>(\"MyTextMember\").Line[1] + \"\\n\") + GetMember<IBlingoMemberTextBase>(\"MyTextMember\").Line[2]) + \"\\n\") + GetMember<IBlingoMemberTextBase>(\"MyTextMember\").Line[3];", result.Replace("\r", ""));
+    }
+
+    [Fact]
+    public void StringFunctionIsConvertedToToStringCall()
+    {
+        var result = _converter.Convert("member(\"PlayerName\").text = string(WebName)");
+        var normalized = result.Replace("\r", string.Empty);
+        Assert.Contains("Member<IBlingoMemberTextBase>(\"PlayerName\").Text = WebName.ToString();", normalized);
     }
 
     [Fact]

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyExpressionConverter.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyExpressionConverter.cs
@@ -261,6 +261,7 @@ public sealed class BlLegacyExpressionConverter
                 TryHandleListFunction() ||
                 TryHandleVoidPredicate() ||
                 TryHandleScriptInstantiation() ||
+                TryHandleStringFunction() ||
                 TryHandleValueFunction() ||
                 TryHandleAlertCommand() ||
                 TryHandleGoToCurrentFrame() ||
@@ -435,6 +436,61 @@ public sealed class BlLegacyExpressionConverter
         }
 
         AppendRaw(")");
+        _index = closeIndex + 1;
+        _afterDot = false;
+        return true;
+    }
+
+    private bool TryHandleStringFunction()
+    {
+        if (_index >= _tokens.Count ||
+            !string.Equals(_tokens[_index].ValueText, "string", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (_index + 1 >= _tokens.Count || _tokens[_index + 1].Kind != BlSyntaxKind.LeftParenthesisToken)
+        {
+            return false;
+        }
+
+        var closeIndex = BlLegacyHandlerTokenUtilities.FindMatchingToken(
+            _tokens,
+            _index + 1,
+            BlSyntaxKind.LeftParenthesisToken,
+            BlSyntaxKind.RightParenthesisToken);
+
+        if (closeIndex < 0)
+        {
+            return false;
+        }
+
+        var argumentTokens = BlLegacyHandlerTokenUtilities.SliceTokens(
+            _tokens,
+            _index + 2,
+            closeIndex - (_index + 2));
+        var argument = Convert(argumentTokens);
+
+        if (string.IsNullOrEmpty(argument))
+        {
+            AppendRaw("string.Empty");
+        }
+        else
+        {
+            if (RequiresParentheses(argumentTokens))
+            {
+                AppendRaw("(");
+                AppendRaw(argument);
+                AppendRaw(")");
+            }
+            else
+            {
+                AppendRaw(argument);
+            }
+
+            AppendRaw(".ToString()");
+        }
+
         _index = closeIndex + 1;
         _afterDot = false;
         return true;
@@ -658,6 +714,41 @@ public sealed class BlLegacyExpressionConverter
         AppendRaw(mapped);
         _index += lookahead;
         _afterDot = false;
+        return true;
+    }
+
+    private static bool RequiresParentheses(IReadOnlyList<BlSyntaxToken> tokens)
+    {
+        if (tokens.Count == 0)
+        {
+            return false;
+        }
+
+        if (tokens.Count == 1)
+        {
+            return tokens[0].Kind switch
+            {
+                BlSyntaxKind.IdentifierToken => false,
+                BlSyntaxKind.KeywordToken => false,
+                BlSyntaxKind.NumberToken => false,
+                BlSyntaxKind.StringLiteralToken => false,
+                _ => true,
+            };
+        }
+
+        if (tokens[0].Kind == BlSyntaxKind.LeftParenthesisToken)
+        {
+            var closeIndex = BlLegacyHandlerTokenUtilities.FindMatchingToken(
+                tokens,
+                0,
+                BlSyntaxKind.LeftParenthesisToken,
+                BlSyntaxKind.RightParenthesisToken);
+            if (closeIndex == tokens.Count - 1)
+            {
+                return false;
+            }
+        }
+
         return true;
     }
 


### PR DESCRIPTION
## Summary
- map the Lingo `string(...)` built-in to emit `.ToString()` calls in generated C#
- wrap complex arguments in parentheses to preserve evaluation order
- add a regression test covering member text assignments that call `string(...)`

## Testing
- dotnet test Test/BlingoEngine.Legacy.Lingo.Tests/BlingoEngine.Legacy.Lingo.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68dfa760c7f08332b4d8c1754682f39e