### PR TITLE
Handle property description addProp conversions

### DIFF
--- a/Test/BlingoEngine.Legacy.Lingo.Tests/BlLegacyClassGeneratorTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/BlLegacyClassGeneratorTests.cs
@@ -169,20 +169,41 @@ public class MyBehaviorBehavior : BlingoSpriteBehavior, IBlingoPropertyDescripti
 {
     public MyBehaviorBehavior(IBlingoMovieEnvironment env) : base(env) { }
 
-    public BehaviorPropertyDescriptionList? GetPropertyDescriptionList()
-    {
-        return null;
-    }
-
     public string? GetBehaviorDescription() => null;
 
     public string? GetBehaviorTooltip() => null;
 
     public bool IsOKToAttach(BlingoSymbol spriteType, int spriteNum) => true;
+    public BehaviorPropertyDescriptionList? GetPropertyDescriptionList()
+    {
+        return new BehaviorPropertyDescriptionList();
+    }
 }
 """;
 
         LegacyCodeAssert.AreEqual(expected, code);
+    }
+
+    [Fact]
+    public void PropertyDescriptionList_TranslatesAddPropStatements()
+    {
+        const string source = """
+property myFunction
+property mySpriteNum
+on getPropertyDescriptionList
+  addProp description,#myFunction,[#comment:"Function:", #default:"0"]
+  addProp description,#mySpriteNum,[#comment:"Sprite Num:", #default:4]
+end
+""";
+
+        var code = _generator.GenerateClass("Execute", source, BlLingoScriptKind.Behavior);
+
+        Assert.Contains(
+            ".Add(this, x => x.myFunction, \"Function:\", \"0\")",
+            code);
+        Assert.Contains(
+            ".Add(this, x => x.mySpriteNum, \"Sprite Num:\", 4)",
+            code);
     }
 
     [Fact]

--- a/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyHandlerFilters.cs
+++ b/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyHandlerFilters.cs
@@ -16,7 +16,8 @@ internal static class BlLegacyHandlerFilters
             return true;
         }
 
-        if (IsPropertyDescriptionHandler(handler.OriginalName) || IsPropertyDescriptionHandler(handler.Symbol.Name))
+        if (IsPropertyDescriptionUtilityHandler(handler.OriginalName) ||
+            IsPropertyDescriptionUtilityHandler(handler.Symbol.Name))
         {
             return true;
         }
@@ -24,15 +25,14 @@ internal static class BlLegacyHandlerFilters
         return false;
     }
 
-    private static bool IsPropertyDescriptionHandler(string? name)
+    private static bool IsPropertyDescriptionUtilityHandler(string? name)
     {
         if (string.IsNullOrEmpty(name))
         {
             return false;
         }
 
-        return name.Equals("getPropertyDescriptionList", StringComparison.OrdinalIgnoreCase)
-            || name.Equals("getBehaviorDescription", StringComparison.OrdinalIgnoreCase)
+        return name.Equals("getBehaviorDescription", StringComparison.OrdinalIgnoreCase)
             || name.Equals("getBehaviorTooltip", StringComparison.OrdinalIgnoreCase)
             || name.Equals("isOKToAttach", StringComparison.OrdinalIgnoreCase);
     }

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyClassGenerator.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyClassGenerator.cs
@@ -127,7 +127,8 @@ public sealed class BlLegacyClassGenerator
 
             if (interfaces.Contains("IBlingoPropertyDescriptionList"))
             {
-                WritePropertyDescriptionListStubs(writer);
+                var hasPropertyListHandler = classScope.Handlers.ContainsKey("getPropertyDescriptionList");
+                WritePropertyDescriptionListMembers(writer, hasPropertyListHandler);
             }
 
             WriteHandlers(writer, classScope, handlerConverter, memberInfo.HandlerOrder, commentsByLine);
@@ -452,18 +453,21 @@ public sealed class BlLegacyClassGenerator
         }
     }
 
-    private static void WritePropertyDescriptionListStubs(BlCSharpCodeWriter writer)
+    private static void WritePropertyDescriptionListMembers(BlCSharpCodeWriter writer, bool hasListHandler)
     {
         writer.WriteLine();
-        writer.WriteLine("public BehaviorPropertyDescriptionList? GetPropertyDescriptionList()");
-        writer.WriteLine("{");
-        using (writer.IndentScope())
+        if (!hasListHandler)
         {
-            writer.WriteLine("return null;");
-        }
+            writer.WriteLine("public BehaviorPropertyDescriptionList? GetPropertyDescriptionList()");
+            writer.WriteLine("{");
+            using (writer.IndentScope())
+            {
+                writer.WriteLine("return null;");
+            }
 
-        writer.WriteLine("}");
-        writer.WriteLine();
+            writer.WriteLine("}");
+            writer.WriteLine();
+        }
         writer.WriteLine("public string? GetBehaviorDescription() => null;");
         writer.WriteLine();
         writer.WriteLine("public string? GetBehaviorTooltip() => null;");
@@ -594,6 +598,12 @@ public sealed class BlLegacyClassGenerator
         if (string.IsNullOrEmpty(handlerName))
         {
             handlerName = handler?.OriginalName;
+        }
+
+        if (!string.IsNullOrEmpty(handlerName) &&
+            handlerName.Equals("GetPropertyDescriptionList", StringComparison.OrdinalIgnoreCase))
+        {
+            return "BehaviorPropertyDescriptionList?";
         }
 
         var scriptName = classScope?.Symbol?.Name;

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyHandlerBodyEmitter.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyHandlerBodyEmitter.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using BlingoEngine.Legacy.Lingo.Analysis;
+using BlingoEngine.Legacy.Lingo.Syntax;
 
 namespace BlingoEngine.Legacy.Lingo.CodeGen;
 
@@ -11,22 +13,36 @@ public sealed class BlLegacyHandlerBodyEmitter : IBlLegacyHandlerBlockDataVisito
     private readonly BlLegacyClassGeneratorOptions _options;
     private readonly BlLingoAnalysisResult _analysis;
     private readonly HandlerBlockManager _blockManager;
+    private readonly BlLingoHandlerSymbolTable _handler;
+    private readonly bool _isPropertyDescriptionHandler;
 
     public BlLegacyHandlerBodyEmitter(
         BlCSharpCodeWriter writer,
+        BlLingoHandlerSymbolTable handler,
         IReadOnlyList<BlLingoHandlerCodeBlock> blocks,
         BlLegacyClassGeneratorOptions options,
         BlLingoAnalysisResult analysis)
     {
         _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+        _handler = handler ?? throw new ArgumentNullException(nameof(handler));
         _blocks = blocks ?? Array.Empty<BlLingoHandlerCodeBlock>();
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _analysis = analysis ?? throw new ArgumentNullException(nameof(analysis));
         _blockManager = new HandlerBlockManager(_writer);
+        _isPropertyDescriptionHandler = string.Equals(
+            handler.Symbol.Name,
+            "GetPropertyDescriptionList",
+            StringComparison.Ordinal);
     }
 
     public void Emit()
     {
+        if (_isPropertyDescriptionHandler)
+        {
+            EmitPropertyDescriptionHandler();
+            return;
+        }
+
         if (_blocks.Count == 0)
         {
             return;
@@ -39,6 +55,474 @@ public sealed class BlLegacyHandlerBodyEmitter : IBlLegacyHandlerBlockDataVisito
 
         _blockManager.CloseAll();
     }
+
+    private void EmitPropertyDescriptionHandler()
+    {
+        var entries = new List<PropertyDescription>();
+        var positions = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var block in _blocks)
+        {
+            if (block.Kind != BlLingoHandlerCodeBlockKind.Expression)
+            {
+                continue;
+            }
+
+            if (!TryParseAddProp(block.Tokens, out var description))
+            {
+                continue;
+            }
+
+            if (positions.TryGetValue(description.PropertyName, out var existingIndex))
+            {
+                entries[existingIndex] = description;
+            }
+            else
+            {
+                positions[description.PropertyName] = entries.Count;
+                entries.Add(description);
+            }
+        }
+
+        if (entries.Count == 0)
+        {
+            _writer.WriteLine("return new BehaviorPropertyDescriptionList();");
+            return;
+        }
+
+        _writer.WriteLine("return new BehaviorPropertyDescriptionList()");
+        using (_writer.IndentScope())
+        {
+            for (var index = 0; index < entries.Count; index++)
+            {
+                var entry = entries[index];
+                var suffix = index == entries.Count - 1 ? ";" : string.Empty;
+                _writer.WriteLine($".Add(this, x => x.{entry.PropertyName}, {entry.Comment}, {entry.DefaultValue}){suffix}");
+            }
+        }
+    }
+
+    private bool TryParseAddProp(IReadOnlyList<BlSyntaxToken> tokens, out PropertyDescription description)
+    {
+        description = default!;
+
+        if (tokens is null || tokens.Count == 0)
+        {
+            return false;
+        }
+
+        var index = 0;
+        if (!TryMatchIdentifier(tokens, ref index, "addProp"))
+        {
+            return false;
+        }
+
+        // Skip the description variable name.
+        if (index >= tokens.Count || tokens[index].Kind != BlSyntaxKind.IdentifierToken)
+        {
+            return false;
+        }
+
+        index++;
+
+        if (!TryConsume(tokens, ref index, BlSyntaxKind.CommaToken))
+        {
+            return false;
+        }
+
+        if (!TryConsumeSymbol(tokens, ref index, out var propertyName))
+        {
+            return false;
+        }
+
+        if (!TryConsume(tokens, ref index, BlSyntaxKind.CommaToken))
+        {
+            return false;
+        }
+
+        if (!TryConsume(tokens, ref index, BlSyntaxKind.LeftBracketToken))
+        {
+            return false;
+        }
+
+        string? comment = null;
+        string? format = null;
+        IReadOnlyList<BlSyntaxToken>? defaultTokens = null;
+
+        while (index < tokens.Count)
+        {
+            if (tokens[index].Kind == BlSyntaxKind.RightBracketToken)
+            {
+                index++;
+                break;
+            }
+
+            if (!TryConsumeSymbol(tokens, ref index, out var key))
+            {
+                return false;
+            }
+
+            if (!TryConsume(tokens, ref index, BlSyntaxKind.ColonToken))
+            {
+                return false;
+            }
+
+            var valueTokens = ReadValueTokens(tokens, ref index);
+
+            if (string.Equals(key, "comment", StringComparison.OrdinalIgnoreCase))
+            {
+                comment ??= ExtractComment(valueTokens);
+            }
+            else if (string.Equals(key, "default", StringComparison.OrdinalIgnoreCase))
+            {
+                defaultTokens = valueTokens;
+            }
+            else if (string.Equals(key, "format", StringComparison.OrdinalIgnoreCase))
+            {
+                format = ExtractFormat(valueTokens);
+            }
+
+            if (index < tokens.Count && tokens[index].Kind == BlSyntaxKind.CommaToken)
+            {
+                index++;
+            }
+            else if (index < tokens.Count && tokens[index].Kind == BlSyntaxKind.RightBracketToken)
+            {
+                index++;
+                break;
+            }
+        }
+
+        if (string.IsNullOrEmpty(propertyName) || comment is null || defaultTokens is null)
+        {
+            return false;
+        }
+
+        var defaultValue = FormatDefault(defaultTokens, format);
+        if (defaultValue is null)
+        {
+            return false;
+        }
+
+        description = new PropertyDescription(propertyName, ToCSharpStringLiteral(comment), defaultValue);
+        return true;
+    }
+
+    private static bool TryMatchIdentifier(IReadOnlyList<BlSyntaxToken> tokens, ref int index, string expected)
+    {
+        if (index >= tokens.Count)
+        {
+            return false;
+        }
+
+        var token = tokens[index];
+        if (token.Kind != BlSyntaxKind.IdentifierToken ||
+            !token.ValueText.Equals(expected, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        index++;
+        return true;
+    }
+
+    private static bool TryConsume(IReadOnlyList<BlSyntaxToken> tokens, ref int index, BlSyntaxKind kind)
+    {
+        if (index >= tokens.Count || tokens[index].Kind != kind)
+        {
+            return false;
+        }
+
+        index++;
+        return true;
+    }
+
+    private static bool TryConsumeSymbol(IReadOnlyList<BlSyntaxToken> tokens, ref int index, out string value)
+    {
+        value = string.Empty;
+        if (index >= tokens.Count)
+        {
+            return false;
+        }
+
+        var token = tokens[index];
+        if (token.Kind != BlSyntaxKind.SymbolToken)
+        {
+            return false;
+        }
+
+        value = token.ValueText;
+        index++;
+        return true;
+    }
+
+    private static IReadOnlyList<BlSyntaxToken> ReadValueTokens(IReadOnlyList<BlSyntaxToken> tokens, ref int index)
+    {
+        var result = new List<BlSyntaxToken>();
+        var depth = 0;
+
+        while (index < tokens.Count)
+        {
+            var token = tokens[index];
+
+            if (token.Kind == BlSyntaxKind.LeftBracketToken || token.Kind == BlSyntaxKind.LeftParenthesisToken)
+            {
+                depth++;
+            }
+            else if (token.Kind == BlSyntaxKind.RightBracketToken || token.Kind == BlSyntaxKind.RightParenthesisToken)
+            {
+                if (depth == 0)
+                {
+                    break;
+                }
+
+                depth--;
+            }
+
+            if (depth == 0 && (token.Kind == BlSyntaxKind.CommaToken || token.Kind == BlSyntaxKind.RightBracketToken))
+            {
+                break;
+            }
+
+            result.Add(token);
+            index++;
+        }
+
+        return result;
+    }
+
+    private static string? ExtractComment(IReadOnlyList<BlSyntaxToken> tokens)
+    {
+        if (tokens.Count == 0)
+        {
+            return null;
+        }
+
+        if (tokens.Count == 1 && tokens[0].Kind == BlSyntaxKind.StringLiteralToken)
+        {
+            return tokens[0].ValueText;
+        }
+
+        var builder = new StringBuilder();
+        foreach (var token in tokens)
+        {
+            if (token.Kind == BlSyntaxKind.StringLiteralToken)
+            {
+                builder.Append(token.ValueText);
+            }
+            else
+            {
+                builder.Append(token.ValueText.Length > 0 ? token.ValueText : token.Text);
+            }
+        }
+
+        return builder.ToString();
+    }
+
+    private static string? ExtractFormat(IReadOnlyList<BlSyntaxToken> tokens)
+    {
+        if (tokens.Count == 0)
+        {
+            return null;
+        }
+
+        var token = tokens[0];
+        if (token.Kind == BlSyntaxKind.SymbolToken || token.Kind == BlSyntaxKind.IdentifierToken)
+        {
+            return token.ValueText;
+        }
+
+        if (token.Kind == BlSyntaxKind.StringLiteralToken)
+        {
+            return token.ValueText;
+        }
+
+        return null;
+    }
+
+    private static string? FormatDefault(IReadOnlyList<BlSyntaxToken> tokens, string? format)
+    {
+        if (tokens.Count == 0)
+        {
+            return null;
+        }
+
+        var treatAsString = string.Equals(format, "string", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(format, "symbol", StringComparison.OrdinalIgnoreCase);
+
+        if (treatAsString)
+        {
+            var text = ExtractComment(tokens) ?? string.Empty;
+            return ToCSharpStringLiteral(text);
+        }
+
+        if (tokens.Count == 1)
+        {
+            var token = tokens[0];
+            switch (token.Kind)
+            {
+                case BlSyntaxKind.StringLiteralToken:
+                    return ToCSharpStringLiteral(token.ValueText);
+                case BlSyntaxKind.NumberToken:
+                    return token.ValueText;
+                case BlSyntaxKind.IdentifierToken:
+                    if (IsBooleanLiteral(token.ValueText))
+                    {
+                        return token.ValueText.ToLowerInvariant();
+                    }
+
+                    return ToCSharpStringLiteral(token.ValueText);
+                case BlSyntaxKind.SymbolToken:
+                    if (IsBooleanLiteral(token.ValueText))
+                    {
+                        return token.ValueText.ToLowerInvariant();
+                    }
+
+                    return ToCSharpStringLiteral(token.ValueText);
+            }
+        }
+
+        if (tokens.Count == 2 &&
+            tokens[0].Kind == BlSyntaxKind.OperatorToken &&
+            tokens[0].Text == "-" &&
+            tokens[1].Kind == BlSyntaxKind.NumberToken)
+        {
+            return "-" + tokens[1].ValueText;
+        }
+
+        if (tokens.Count > 0 &&
+            tokens[0].Kind == BlSyntaxKind.IdentifierToken &&
+            string.Equals(tokens[0].ValueText, "rgb", StringComparison.OrdinalIgnoreCase))
+        {
+            return FormatRgb(tokens);
+        }
+
+        var builder = new StringBuilder();
+        foreach (var token in tokens)
+        {
+            builder.Append(token.Text);
+        }
+
+        var combined = builder.ToString();
+        if (treatAsString)
+        {
+            return ToCSharpStringLiteral(combined);
+        }
+
+        return combined.Length > 0 ? combined : null;
+    }
+
+    private static string? FormatRgb(IReadOnlyList<BlSyntaxToken> tokens)
+    {
+        if (tokens.Count < 4 || tokens[1].Kind != BlSyntaxKind.LeftParenthesisToken)
+        {
+            return null;
+        }
+
+        var components = new List<string>(3);
+        var index = 2;
+        var current = new List<BlSyntaxToken>();
+        var depth = 0;
+
+        while (index < tokens.Count)
+        {
+            var token = tokens[index];
+
+            if (token.Kind == BlSyntaxKind.RightParenthesisToken && depth == 0)
+            {
+                if (current.Count > 0)
+                {
+                    var value = FormatDefault(current, null);
+                    if (value is null)
+                    {
+                        return null;
+                    }
+
+                    components.Add(value);
+                }
+
+                break;
+            }
+
+            if (token.Kind == BlSyntaxKind.CommaToken && depth == 0)
+            {
+                var value = FormatDefault(current, null);
+                if (value is null)
+                {
+                    return null;
+                }
+
+                components.Add(value);
+                current.Clear();
+                index++;
+                continue;
+            }
+
+            if (token.Kind == BlSyntaxKind.LeftParenthesisToken || token.Kind == BlSyntaxKind.LeftBracketToken)
+            {
+                depth++;
+            }
+            else if (token.Kind == BlSyntaxKind.RightParenthesisToken || token.Kind == BlSyntaxKind.RightBracketToken)
+            {
+                if (depth > 0)
+                {
+                    depth--;
+                }
+            }
+
+            current.Add(token);
+            index++;
+        }
+
+        if (components.Count == 2 && current.Count > 0)
+        {
+            var value = FormatDefault(current, null);
+            if (value is null)
+            {
+                return null;
+            }
+
+            components.Add(value);
+        }
+
+        if (components.Count != 3)
+        {
+            return null;
+        }
+
+        return $"AColor.FromCode({string.Join(',', components)})";
+    }
+
+    private static bool IsBooleanLiteral(string? value)
+    {
+        return value is not null &&
+            (value.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+             value.Equals("false", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string ToCSharpStringLiteral(string value)
+    {
+        var builder = new StringBuilder(value.Length + 2);
+        builder.Append('"');
+
+        foreach (var ch in value)
+        {
+            builder.Append(ch switch
+            {
+                '\\' => "\\\\",
+                '"' => "\\\"",
+                '\r' => "\\r",
+                '\n' => "\\n",
+                '\t' => "\\t",
+                _ => ch.ToString(),
+            });
+        }
+
+        builder.Append('"');
+        return builder.ToString();
+    }
+
+    private sealed record PropertyDescription(string PropertyName, string Comment, string DefaultValue);
 
     private void EmitBlock(BlLingoHandlerCodeBlock block)
     {

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyHandlerConverter.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyHandlerConverter.cs
@@ -58,7 +58,7 @@ public sealed class BlLegacyHandlerConverter
 
         if (_handlerBlocks.TryGetValue(handler, out var blocks))
         {
-            var emitter = new BlLegacyHandlerBodyEmitter(writer, blocks, _options, _analysis);
+            var emitter = new BlLegacyHandlerBodyEmitter(writer, handler, blocks, _options, _analysis);
             emitter.Emit();
             return;
         }
@@ -70,7 +70,7 @@ public sealed class BlLegacyHandlerConverter
         }
 
         var fallbackBlocks = BlLingoHandlerFallbackBuilder.Build(body.Tokens, body.EndLeadingTrivia, _analysis.Symbols);
-        var fallbackEmitter = new BlLegacyHandlerBodyEmitter(writer, fallbackBlocks, _options, _analysis);
+        var fallbackEmitter = new BlLegacyHandlerBodyEmitter(writer, handler, fallbackBlocks, _options, _analysis);
         fallbackEmitter.Emit();
     }
 


### PR DESCRIPTION
## Summary
- translate `getPropertyDescriptionList` handlers by parsing `addProp` calls into fluent property descriptions
- avoid stubbing the property description method when a handler exists and ensure the return type is `BehaviorPropertyDescriptionList?`
- add a regression test covering `addProp` conversion output

## Testing
- dotnet test Test/BlingoEngine.Legacy.Lingo.Tests/BlingoEngine.Legacy.Lingo.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68dfaabb41788332b9ec6832687ca993