### PR TITLE
Fix boolean operator conversion and add regression test

### DIFF
--- a/Test/BlingoEngine.Legacy.Lingo.Tests/BlLegacyClassGeneratorTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/BlLegacyClassGeneratorTests.cs
@@ -121,6 +121,38 @@ public class MyParentParent : BlingoParentScript
     }
 
     [Fact]
+    public void BooleanOperators_AreTranslatedToCSharpEquivalents()
+    {
+        const string source = """
+on checkFlags flagA, flagB
+  if flagA and flagB then
+    return "both"
+  end if
+
+  if flagA or flagB then
+    return "either"
+  end if
+
+  if flagA <> flagB then
+    return "different"
+  end if
+
+  return "none"
+end
+""";
+
+        var code = _generator.GenerateClass("BooleanLogic", source, BlLingoScriptKind.Behavior);
+
+        Assert.Contains("if (flagA && flagB)", code);
+        Assert.Contains("if (flagA || flagB)", code);
+        Assert.Contains("if (flagA != flagB)", code);
+        Assert.Contains("return \"both\";", code);
+        Assert.Contains("return \"either\";", code);
+        Assert.Contains("return \"different\";", code);
+        Assert.Contains("return \"none\";", code);
+    }
+
+    [Fact]
     public void ReturnKeywordInExpression_TranslatesToEnvironmentNewLine()
     {
         const string source = """

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyExpressionConverter.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyExpressionConverter.cs
@@ -872,6 +872,20 @@ public sealed class BlLegacyExpressionConverter
             return;
         }
 
+        if (string.Equals(text, "or", StringComparison.OrdinalIgnoreCase))
+        {
+            AppendRaw("||");
+            _afterDot = false;
+            return;
+        }
+
+        if (string.Equals(text, "and", StringComparison.OrdinalIgnoreCase))
+        {
+            AppendRaw("&&");
+            _afterDot = false;
+            return;
+        }
+
         if (_afterDot)
         {
             AppendRaw(BlLegacyHandlerTokenUtilities.ToPascalCase(text));


### PR DESCRIPTION
## Summary
- ensure keyword tokens `and`/`or` are converted to `&&`/`||` in the legacy expression converter
- add a regression test verifying boolean operator translation in generated C# code

## Testing
- dotnet test Test/BlingoEngine.Legacy.Lingo.Tests/BlingoEngine.Legacy.Lingo.Tests.csproj -v minimal

------
https://chatgpt.com/codex/tasks/task_e_68dfac04fd408332ae793399b7bdf152