### PR TITLE
Enhance legacy member property type inference

### DIFF
--- a/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyMemberPropertyFacts.cs
+++ b/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyMemberPropertyFacts.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+
+namespace BlingoEngine.Legacy.Lingo.Analysis;
+
+internal static class BlLegacyMemberPropertyFacts
+{
+    internal sealed record MemberPropertyInfo(string MemberTypeName, string PropertyName, string? ValueTypeName);
+
+    private static readonly Dictionary<string, MemberPropertyInfo> s_memberProperties = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["text"] = new("IBlingoMemberTextBase", "Text", "string"),
+        ["line"] = new("IBlingoMemberTextBase", "Line", "string"),
+        ["word"] = new("IBlingoMemberTextBase", "Word", "string"),
+        ["char"] = new("IBlingoMemberTextBase", "Char", "string"),
+        ["editable"] = new("IBlingoMemberTextBase", "Editable", "bool"),
+        ["wordwrap"] = new("IBlingoMemberTextBase", "WordWrap", "bool"),
+        ["scrolltop"] = new("IBlingoMemberTextBase", "ScrollTop", "int"),
+        ["textfont"] = new("IBlingoMemberTextBase", "Font", "string"),
+        ["font"] = new("IBlingoMemberTextBase", "Font", "string"),
+        ["textsize"] = new("IBlingoMemberTextBase", "FontSize", "int"),
+        ["fontsize"] = new("IBlingoMemberTextBase", "FontSize", "int"),
+        ["textstyle"] = new("IBlingoMemberTextBase", "FontStyle", null),
+        ["fontstyle"] = new("IBlingoMemberTextBase", "FontStyle", null),
+        ["textcolor"] = new("IBlingoMemberTextBase", "Color", "global::BlingoEngine.Primitives.AColor"),
+        ["color"] = new("IBlingoMemberTextBase", "Color", "global::BlingoEngine.Primitives.AColor"),
+        ["bold"] = new("IBlingoMemberTextBase", "Bold", "bool"),
+        ["italic"] = new("IBlingoMemberTextBase", "Italic", "bool"),
+        ["underline"] = new("IBlingoMemberTextBase", "Underline", "bool"),
+        ["alignment"] = new("IBlingoMemberTextBase", "Alignment", null),
+        ["margin"] = new("IBlingoMemberTextBase", "Margin", "int"),
+
+        ["loop"] = new("BlingoMemberSound", "Loop", "bool"),
+        ["linked"] = new("BlingoMemberSound", "IsLinked", "bool"),
+        ["islinked"] = new("BlingoMemberSound", "IsLinked", "bool"),
+        ["linkedfilepath"] = new("BlingoMemberSound", "LinkedFilePath", "string"),
+        ["isexternal"] = new("BlingoMemberSound", "IsExternal", "bool"),
+        ["length"] = new("BlingoMemberSound", "Length", "double"),
+        ["stereo"] = new("BlingoMemberSound", "Stereo", "bool"),
+
+        ["format"] = new("BlingoMemberBitmap", "Format", "string"),
+        ["imagedata"] = new("BlingoMemberBitmap", "ImageData", "byte[]?"),
+        ["isloaded"] = new("BlingoMemberBitmap", "IsLoaded", "bool"),
+
+        ["vertexlist"] = new("BlingoMemberShape", "VertexList", null),
+        ["shapetype"] = new("BlingoMemberShape", "ShapeType", "global::BlingoEngine.Shapes.BlingoShapeType"),
+        ["shapetypeint"] = new("BlingoMemberShape", "ShapeTypeInt", "int"),
+        ["fillcolor"] = new("BlingoMemberShape", "FillColor", "global::BlingoEngine.Primitives.AColor"),
+        ["endcolor"] = new("BlingoMemberShape", "EndColor", "global::BlingoEngine.Primitives.AColor"),
+        ["strokecolor"] = new("BlingoMemberShape", "StrokeColor", "global::BlingoEngine.Primitives.AColor"),
+        ["strokewidth"] = new("BlingoMemberShape", "StrokeWidth", "int"),
+        ["closed"] = new("BlingoMemberShape", "Closed", "bool"),
+        ["antialias"] = new("BlingoMemberShape", "AntiAlias", "bool"),
+        ["filled"] = new("BlingoMemberShape", "Filled", "bool"),
+
+        ["duration"] = new("BlingoMemberMedia", "Duration", "int"),
+        ["currenttime"] = new("BlingoMemberMedia", "CurrentTime", "int"),
+        ["mediastatus"] = new("BlingoMemberMedia", "MediaStatus", "global::BlingoEngine.Medias.BlingoMediaStatus"),
+
+        ["scripttype"] = new("BlingoMemberScript", "ScriptType", "global::BlingoEngine.Scripts.BlingoScriptType"),
+        ["behaviortypename"] = new("BlingoMemberScript", "BehaviorTypeName", "string"),
+    };
+
+    public static bool TryGet(string? propertyName, out MemberPropertyInfo info)
+    {
+        if (!string.IsNullOrWhiteSpace(propertyName) && s_memberProperties.TryGetValue(propertyName, out var value))
+        {
+            info = value;
+            return true;
+        }
+
+        info = default!;
+        return false;
+    }
+
+    public static bool TryGetValueType(string? propertyName, out string typeName)
+    {
+        if (TryGet(propertyName, out var info) && !string.IsNullOrWhiteSpace(info.ValueTypeName))
+        {
+            typeName = info.ValueTypeName!;
+            return true;
+        }
+
+        typeName = string.Empty;
+        return false;
+    }
+}

--- a/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyTypeUtilities.cs
+++ b/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyTypeUtilities.cs
@@ -57,6 +57,11 @@ internal static class BlLegacyTypeUtilities
             return typeName;
         }
 
+        if (TryDetermineMemberPropertyType(expression, out var memberPropertyType))
+        {
+            return memberPropertyType;
+        }
+
         if (IsMemberConstructor(expression))
         {
             return "IBlingoMember";
@@ -65,11 +70,6 @@ internal static class BlLegacyTypeUtilities
         if (TryDetermineArrayType(expression, out var arrayType))
         {
             return arrayType;
-        }
-
-        if (IsStringMemberAccess(expression))
-        {
-            return "string";
         }
 
         return string.Empty;
@@ -201,29 +201,87 @@ internal static class BlLegacyTypeUtilities
         return false;
     }
 
-    private static bool IsStringMemberAccess(string? expression)
+    private static bool TryDetermineMemberPropertyType(string? expression, out string typeName)
     {
+        typeName = string.Empty;
         if (string.IsNullOrWhiteSpace(expression))
         {
             return false;
         }
 
         var trimmed = expression.Trim();
-        if (!trimmed.StartsWith("Member<", StringComparison.Ordinal) &&
-            !trimmed.StartsWith("Member(", StringComparison.Ordinal))
+        if (!trimmed.StartsWith("Member", StringComparison.OrdinalIgnoreCase))
         {
             return false;
         }
 
-        return ContainsSegment(trimmed, ".Line") ||
-            ContainsSegment(trimmed, ".Word") ||
-            ContainsSegment(trimmed, ".Text") ||
-            ContainsSegment(trimmed, ".Char");
+        var openIndex = trimmed.IndexOf('(');
+        if (openIndex < 0)
+        {
+            return false;
+        }
+
+        var closeIndex = FindClosingParenthesisIndex(trimmed, openIndex);
+        if (closeIndex < 0)
+        {
+            return false;
+        }
+
+        var propertyName = ExtractLastMemberPropertyName(trimmed, closeIndex + 1);
+        if (propertyName.Length == 0)
+        {
+            return false;
+        }
+
+        if (!BlLegacyMemberPropertyFacts.TryGetValueType(propertyName, out var candidate))
+        {
+            return false;
+        }
+
+        typeName = NormalizeTypeName(candidate);
+        return true;
     }
 
-    private static bool ContainsSegment(string expression, string segment)
+    private static string ExtractLastMemberPropertyName(string expression, int startIndex)
     {
-        return expression.IndexOf(segment, StringComparison.OrdinalIgnoreCase) >= 0;
+        var last = string.Empty;
+        for (var index = startIndex; index < expression.Length; index++)
+        {
+            if (expression[index] != '.')
+            {
+                continue;
+            }
+
+            index++;
+            if (index >= expression.Length)
+            {
+                break;
+            }
+
+            var begin = index;
+            var startChar = expression[begin];
+            if (!char.IsLetter(startChar) && startChar != '_')
+            {
+                continue;
+            }
+
+            index++;
+            while (index < expression.Length)
+            {
+                var ch = expression[index];
+                if (char.IsLetterOrDigit(ch) || ch == '_')
+                {
+                    index++;
+                    continue;
+                }
+
+                break;
+            }
+
+            last = expression[begin..index];
+        }
+
+        return last;
     }
 
     private static int GetFirstSpan(BlCodeSymbol symbol)

--- a/src/BlingoEngine.Legacy.Lingo/BlingoToCSharpConverter.cs
+++ b/src/BlingoEngine.Legacy.Lingo/BlingoToCSharpConverter.cs
@@ -19,7 +19,7 @@ public sealed class BlingoToCSharpConverter
     {
         _errors.Clear();
         var script = new BlingoScriptFile("ConvertedScript", lingoSource ?? string.Empty, BlingoScriptType.Behavior);
-        return ConvertScript(script, respectDeclaredKind: false);
+        return TryConvertScript(script, respectDeclaredKind: false, out var code, out _) ? code : string.Empty;
     }
 
     public BlingoBatchResult Convert(IEnumerable<BlingoScriptFile> scripts)
@@ -38,12 +38,12 @@ public sealed class BlingoToCSharpConverter
                 continue;
             }
 
-            var code = ConvertScript(script, respectDeclaredKind: true);
-            if (!string.IsNullOrEmpty(code))
+            if (!TryConvertScript(script, respectDeclaredKind: true, out var code, out var scriptName))
             {
-                var key = string.IsNullOrWhiteSpace(script.Name) ? "ConvertedScript" : script.Name;
-                result.ConvertedScripts[key] = code;
+                continue;
             }
+
+            result.ConvertedScripts[scriptName] = code;
         }
 
         return result;
@@ -61,28 +61,24 @@ public sealed class BlingoToCSharpConverter
         return message;
     }
 
-    private string ConvertScript(BlingoScriptFile script, bool respectDeclaredKind)
+    private bool TryConvertScript(BlingoScriptFile script, bool respectDeclaredKind, out string code, out string scriptName)
     {
-        var scriptName = string.IsNullOrWhiteSpace(script.Name) ? "ConvertedScript" : script.Name;
+        scriptName = ResolveScriptName(script);
         var source = script.Source ?? string.Empty;
         var kind = respectDeclaredKind ? MapScriptType(script.Type) : BlLingoScriptKind.Unknown;
 
         try
         {
             var generator = new BlLegacyClassGenerator();
-            var code = generator.GenerateClass(scriptName, source, kind);
+            code = generator.GenerateClass(scriptName, source, kind);
             script.CSharp = code;
-            return code;
+            return true;
         }
         catch (Exception ex)
         {
-            var message = $"{scriptName}: {ex.Message}";
-            _errors.Add(message);
-            script.CSharp = string.Empty;
-            script.Errors = string.IsNullOrEmpty(script.Errors)
-                ? message
-                : string.Concat(script.Errors, Environment.NewLine, message);
-            return string.Empty;
+            code = string.Empty;
+            RecordConversionFailure(script, scriptName, ex);
+            return false;
         }
     }
 
@@ -95,6 +91,21 @@ public sealed class BlingoToCSharpConverter
             BlingoScriptType.Behavior => BlLingoScriptKind.Behavior,
             _ => BlLingoScriptKind.Unknown,
         };
+    }
+
+    private static string ResolveScriptName(BlingoScriptFile script)
+    {
+        return string.IsNullOrWhiteSpace(script.Name) ? "ConvertedScript" : script.Name;
+    }
+
+    private void RecordConversionFailure(BlingoScriptFile script, string scriptName, Exception ex)
+    {
+        var message = $"{scriptName}: {ex.Message}";
+        _errors.Add(message);
+        script.CSharp = string.Empty;
+        script.Errors = string.IsNullOrEmpty(script.Errors)
+            ? message
+            : string.Concat(script.Errors, Environment.NewLine, message);
     }
 }
 

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyExpressionConverter.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyExpressionConverter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using BlingoEngine.Legacy.Lingo.Analysis;
 using BlingoEngine.Legacy.Lingo.Syntax;
 
 namespace BlingoEngine.Legacy.Lingo.CodeGen;
@@ -14,67 +15,6 @@ public sealed class BlLegacyExpressionConverter
     private int _index;
     private bool _afterDot;
 
-    private readonly struct MemberPropertyMapping
-    {
-        public MemberPropertyMapping(string genericType, string propertyName)
-        {
-            GenericType = genericType;
-            PropertyName = propertyName;
-        }
-
-        public string GenericType { get; }
-
-        public string PropertyName { get; }
-    }
-
-    private static readonly Dictionary<string, MemberPropertyMapping> s_memberPropertyMap = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["text"] = new MemberPropertyMapping("IBlingoMemberTextBase", "Text"),
-        ["line"] = new MemberPropertyMapping("IBlingoMemberTextBase", "Line"),
-        ["word"] = new MemberPropertyMapping("IBlingoMemberTextBase", "Word"),
-        ["char"] = new MemberPropertyMapping("IBlingoMemberTextBase", "Char"),
-        ["editable"] = new MemberPropertyMapping("IBlingoMemberTextBase", "Editable"),
-        ["wordwrap"] = new MemberPropertyMapping("IBlingoMemberTextBase", "WordWrap"),
-        ["scrolltop"] = new MemberPropertyMapping("IBlingoMemberTextBase", "ScrollTop"),
-        ["textfont"] = new MemberPropertyMapping("IBlingoMemberTextBase", "Font"),
-        ["font"] = new MemberPropertyMapping("IBlingoMemberTextBase", "Font"),
-        ["textsize"] = new MemberPropertyMapping("IBlingoMemberTextBase", "FontSize"),
-        ["fontsize"] = new MemberPropertyMapping("IBlingoMemberTextBase", "FontSize"),
-        ["textstyle"] = new MemberPropertyMapping("IBlingoMemberTextBase", "FontStyle"),
-        ["fontstyle"] = new MemberPropertyMapping("IBlingoMemberTextBase", "FontStyle"),
-        ["textcolor"] = new MemberPropertyMapping("IBlingoMemberTextBase", "Color"),
-        ["color"] = new MemberPropertyMapping("IBlingoMemberTextBase", "Color"),
-        ["bold"] = new MemberPropertyMapping("IBlingoMemberTextBase", "Bold"),
-        ["italic"] = new MemberPropertyMapping("IBlingoMemberTextBase", "Italic"),
-        ["underline"] = new MemberPropertyMapping("IBlingoMemberTextBase", "Underline"),
-        ["alignment"] = new MemberPropertyMapping("IBlingoMemberTextBase", "Alignment"),
-        ["margin"] = new MemberPropertyMapping("IBlingoMemberTextBase", "Margin"),
-        ["loop"] = new MemberPropertyMapping("BlingoMemberSound", "Loop"),
-        ["stereo"] = new MemberPropertyMapping("BlingoMemberSound", "Stereo"),
-        ["length"] = new MemberPropertyMapping("BlingoMemberSound", "Length"),
-        ["linked"] = new MemberPropertyMapping("BlingoMemberSound", "IsLinked"),
-        ["islinked"] = new MemberPropertyMapping("BlingoMemberSound", "IsLinked"),
-        ["linkedfilepath"] = new MemberPropertyMapping("BlingoMemberSound", "LinkedFilePath"),
-        ["isexternal"] = new MemberPropertyMapping("BlingoMemberSound", "IsExternal"),
-        ["imagedata"] = new MemberPropertyMapping("BlingoMemberBitmap", "ImageData"),
-        ["isloaded"] = new MemberPropertyMapping("BlingoMemberBitmap", "IsLoaded"),
-        ["format"] = new MemberPropertyMapping("BlingoMemberBitmap", "Format"),
-        ["vertexlist"] = new MemberPropertyMapping("BlingoMemberShape", "VertexList"),
-        ["shapetype"] = new MemberPropertyMapping("BlingoMemberShape", "ShapeType"),
-        ["shapetypeint"] = new MemberPropertyMapping("BlingoMemberShape", "ShapeTypeInt"),
-        ["fillcolor"] = new MemberPropertyMapping("BlingoMemberShape", "FillColor"),
-        ["endcolor"] = new MemberPropertyMapping("BlingoMemberShape", "EndColor"),
-        ["strokecolor"] = new MemberPropertyMapping("BlingoMemberShape", "StrokeColor"),
-        ["strokewidth"] = new MemberPropertyMapping("BlingoMemberShape", "StrokeWidth"),
-        ["closed"] = new MemberPropertyMapping("BlingoMemberShape", "Closed"),
-        ["antialias"] = new MemberPropertyMapping("BlingoMemberShape", "AntiAlias"),
-        ["filled"] = new MemberPropertyMapping("BlingoMemberShape", "Filled"),
-        ["duration"] = new MemberPropertyMapping("BlingoMemberMedia", "Duration"),
-        ["currenttime"] = new MemberPropertyMapping("BlingoMemberMedia", "CurrentTime"),
-        ["mediastatus"] = new MemberPropertyMapping("BlingoMemberMedia", "MediaStatus"),
-        ["scripttype"] = new MemberPropertyMapping("BlingoMemberScript", "ScriptType"),
-        ["behaviortypename"] = new MemberPropertyMapping("BlingoMemberScript", "BehaviorTypeName"),
-    };
 
     private static readonly Dictionary<string, string> s_thePropertyMap = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -658,7 +598,7 @@ public sealed class BlLegacyExpressionConverter
             return false;
         }
 
-        if (!s_memberPropertyMap.TryGetValue(propertyToken.ValueText, out var mapping))
+        if (!BlLegacyMemberPropertyFacts.TryGet(propertyToken.ValueText, out var mapping))
         {
             return false;
         }
@@ -666,7 +606,7 @@ public sealed class BlLegacyExpressionConverter
         var argsTokens = BlLegacyHandlerTokenUtilities.SliceTokens(_tokens, _index + 2, argsClose - (_index + 2));
         var arguments = ConvertArguments(argsTokens);
 
-        AppendRaw($"Member<{mapping.GenericType}>");
+        AppendRaw($"Member<{mapping.MemberTypeName}>");
         AppendRaw("(");
         if (!string.IsNullOrEmpty(arguments))
         {


### PR DESCRIPTION
## Summary
- introduce `BlLegacyMemberPropertyFacts` to centralize member property metadata and expose inferred value types
- update the expression converter to use the shared facts instead of a local map when emitting `Member<T>` property accessors
- expand the type utilities to infer property types from the shared metadata, improving property/member inference results

## Testing
- dotnet test Test/BlingoEngine.Legacy.Lingo.Tests/BlingoEngine.Legacy.Lingo.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68dfb05241148332a54c8337b3910231