### PR TITLE
Handle objectP predicate translation

### DIFF
--- a/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerConditionalTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerConditionalTests.cs
@@ -68,6 +68,36 @@ public class TestScriptBehavior : BlingoSpriteBehavior
     }
 
     [Fact]
+    public void IfObjectPThenPut_TranslatesToObjectTypeCheck()
+    {
+        const string source = """
+on test
+  if objectP(target) then
+    put 1 into value
+  end if
+end
+""";
+
+        var code = GenerateBehavior(source);
+
+        const string expected = """
+public class TestScriptBehavior : BlingoSpriteBehavior
+{
+    public TestScriptBehavior(IBlingoMovieEnvironment env) : base(env) { }
+    public void Test()
+    {
+        if (target is BlingoEngine.Core.IBlingoScriptBase or BlingoEngine.Xtras.IBlingoXtra or BlingoEngine.Core.IBlingoWindow)
+        {
+            value = 1;
+        }
+    }
+}
+""";
+
+        LegacyCodeAssert.AreEqual(expected, code);
+    }
+
+    [Fact]
     public void ElseIf_BecomesElseIf()
     {
         const string source = """

--- a/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyExpressionConverter.cs
+++ b/src/BlingoEngine.Legacy.Lingo/CodeGen/BlLegacyExpressionConverter.cs
@@ -262,6 +262,7 @@ public sealed class BlLegacyExpressionConverter
                 TryHandleListCommand() ||
                 TryHandleListFunction() ||
                 TryHandleVoidPredicate() ||
+                TryHandleObjectPredicate() ||
                 TryHandleScriptInstantiation() ||
                 TryHandleStringFunction() ||
                 TryHandleValueFunction() ||
@@ -344,6 +345,56 @@ public sealed class BlLegacyExpressionConverter
         AppendRaw(expression);
         AppendRaw("==");
         AppendRaw("null");
+        _index = closeIndex + 1;
+        _afterDot = false;
+        return true;
+    }
+
+    private bool TryHandleObjectPredicate()
+    {
+        if (_index >= _tokens.Count ||
+            !string.Equals(_tokens[_index].ValueText, "objectp", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (_index + 1 >= _tokens.Count || _tokens[_index + 1].Kind != BlSyntaxKind.LeftParenthesisToken)
+        {
+            return false;
+        }
+
+        var closeIndex = BlLegacyHandlerTokenUtilities.FindMatchingToken(
+            _tokens,
+            _index + 1,
+            BlSyntaxKind.LeftParenthesisToken,
+            BlSyntaxKind.RightParenthesisToken);
+
+        if (closeIndex < 0)
+        {
+            return false;
+        }
+
+        var innerTokens = BlLegacyHandlerTokenUtilities.SliceTokens(
+            _tokens,
+            _index + 2,
+            closeIndex - (_index + 2));
+        var expression = Convert(innerTokens);
+
+        if (string.IsNullOrEmpty(expression))
+        {
+            AppendRaw("false");
+        }
+        else
+        {
+            AppendRaw(expression);
+            AppendRaw("is");
+            AppendRaw("BlingoEngine.Core.IBlingoScriptBase");
+            AppendRaw("or");
+            AppendRaw("BlingoEngine.Xtras.IBlingoXtra");
+            AppendRaw("or");
+            AppendRaw("BlingoEngine.Core.IBlingoWindow");
+        }
+
         _index = closeIndex + 1;
         _afterDot = false;
         return true;


### PR DESCRIPTION
## Summary
- translate objectP() calls in the legacy Lingo expression converter to C# type checks for script, Xtra, or window instances
- add a regression test covering the generated objectP predicate output

## Testing
- dotnet test Test/BlingoEngine.Legacy.Lingo.Tests/BlingoEngine.Legacy.Lingo.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68dfb2dc1fa88332bab212aa2db2d1c8