### PR TITLE
Improve Lingo arithmetic type inference

### DIFF
--- a/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerMiscTests.cs
+++ b/Test/BlingoEngine.Legacy.Lingo.Tests/LegacyHandlerMiscTests.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Text.RegularExpressions;
+using BlingoEngine.Legacy.Lingo.Analysis;
+using BlingoEngine.Legacy.Lingo.CodeGen;
 using Xunit;
 
 namespace BlingoEngine.Legacy.Lingo.Tests;
@@ -53,5 +57,26 @@ public class TestScriptBehavior : BlingoSpriteBehavior
 """;
 
         LegacyCodeAssert.AreEqual(expected, code);
+    }
+
+    [Fact]
+    public void ArithmeticAssignment_InfersIntegerTypes()
+    {
+        const string source = """
+property pNum
+on new me,_beginningsprite
+  pNum=_beginningsprite
+end
+on Sadd me
+  pNum=pNum+1
+end
+""";
+
+        var generator = new BlLegacyClassGenerator();
+        var code = generator.GenerateClass("SpriteManager", source, BlLingoScriptKind.Parent);
+
+        Assert.Contains("public int pNum { get; set; }", code);
+        Assert.Matches(new Regex(@"int\s+\w*beginningsprite", RegexOptions.IgnoreCase), code);
+        Assert.DoesNotMatch(new Regex(@"object\s+\w*beginningsprite", RegexOptions.IgnoreCase), code);
     }
 }

--- a/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyReturnTypeHelper.cs
+++ b/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyReturnTypeHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace BlingoEngine.Legacy.Lingo.Analysis;
 
@@ -151,6 +152,11 @@ internal static class BlLegacyReturnTypeHelper
             return "double";
         }
 
+        if (LooksLikeNumericArithmeticExpression(trimmed))
+        {
+            return ContainsFloatingPointLiteral(trimmed) ? "double" : "int";
+        }
+
         return null;
     }
 
@@ -158,6 +164,21 @@ internal static class BlLegacyReturnTypeHelper
     {
         return !string.IsNullOrEmpty(target) &&
             target.Equals("result", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool LooksLikeNumericArithmeticExpression(string expression)
+    {
+        if (!Regex.IsMatch(expression, "[+\\-*/]"))
+        {
+            return false;
+        }
+
+        return Regex.IsMatch(expression, @"\d");
+    }
+
+    private static bool ContainsFloatingPointLiteral(string expression)
+    {
+        return Regex.IsMatch(expression, @"\d\.\d");
     }
 
     public static bool IsReturnWithValue(string? expression)

--- a/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyTypeCollection.cs
+++ b/src/BlingoEngine.Legacy.Lingo/Analysis/BlLegacyTypeCollection.cs
@@ -478,6 +478,7 @@ internal sealed class BlLegacyTypeCollection
     internal sealed class TypeTarget
     {
         private string? _mergedType;
+        private readonly List<TypeTarget> _linkedTargets = new();
 
         public TypeTarget(string name, BlLegacyTypeTargetKind kind, BlCodeSymbol? symbol, bool isSelfParameter)
         {
@@ -508,12 +509,29 @@ internal sealed class BlLegacyTypeCollection
                 : BlLegacyTypeUtilities.MergeTypeNames(_mergedType!, normalized);
         }
 
+        public void LinkTo(TypeTarget? target)
+        {
+            if (target is null || ReferenceEquals(this, target))
+            {
+                return;
+            }
+
+            if (!_linkedTargets.Contains(target))
+            {
+                _linkedTargets.Add(target);
+            }
+        }
+
         public void Apply()
         {
             var normalized = BlLegacyTypeUtilities.NormalizeTypeName(_mergedType);
             if (!string.IsNullOrEmpty(normalized) && Symbol is not null)
             {
                 Symbol.SetResolvedTypeName(normalized);
+                foreach (var linked in _linkedTargets)
+                {
+                    linked.AddHint(normalized);
+                }
             }
         }
     }

--- a/src/BlingoEngine.Legacy.Lingo/Analysis/Passes/BlLegacyTypeAnalysisPass.cs
+++ b/src/BlingoEngine.Legacy.Lingo/Analysis/Passes/BlLegacyTypeAnalysisPass.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using BlingoEngine.Legacy.Lingo.CodeGen;
 using BlingoEngine.Legacy.Lingo.Syntax;
 
@@ -244,6 +245,19 @@ public sealed class BlLegacyTypeAnalysisPass : BlLingoAnalysisPass
         var typeName = BlLegacyTypeUtilities.DetermineExpressionType(expression);
         if (typeName.Length == 0)
         {
+            if (TryExtractSimpleIdentifier(expression, out var identifier) &&
+                scope.TryGetProperty(name, out var propertyTarget))
+            {
+                if (scope.TryGetProperty(identifier, out var sourceProperty))
+                {
+                    propertyTarget.LinkTo(sourceProperty);
+                }
+                else if (handler.TryGetParameter(identifier, out var parameterTarget))
+                {
+                    propertyTarget.LinkTo(parameterTarget);
+                }
+            }
+
             return;
         }
 
@@ -632,6 +646,24 @@ public sealed class BlLegacyTypeAnalysisPass : BlLingoAnalysisPass
                 name = token.ValueText;
                 return true;
             }
+        }
+
+        return false;
+    }
+
+    private static bool TryExtractSimpleIdentifier(string expression, out string identifier)
+    {
+        identifier = string.Empty;
+        if (string.IsNullOrWhiteSpace(expression))
+        {
+            return false;
+        }
+
+        var trimmed = expression.Trim();
+        if (Regex.IsMatch(trimmed, "^[A-Za-z_][A-Za-z0-9_]*$", RegexOptions.CultureInvariant))
+        {
+            identifier = trimmed;
+            return true;
         }
 
         return false;


### PR DESCRIPTION
## Summary
- infer numeric types for arithmetic expressions when analyzing literal values
- link inferred property types to simple identifier assignments so constructor parameters inherit field types
- add a regression test to cover the SpriteManager conversion scenario

## Testing
- dotnet test Test/BlingoEngine.Legacy.Lingo.Tests/BlingoEngine.Legacy.Lingo.Tests.csproj


------
https://chatgpt.com/codex/tasks/task_e_68dfb408f3e883329736e01a82db9796